### PR TITLE
fix: add missing verify-ca ssl mode for postgres destination

### DIFF
--- a/docs/resources/destination_postgres.md
+++ b/docs/resources/destination_postgres.md
@@ -95,7 +95,7 @@ Required:
 - `namespace` (String) Enter the schema name where RudderStack will create all the tables. Defaults to the source name.
 - `password` (String, Sensitive) Enter the password you set for the above user.
 - `port` (String) Enter the port number associated with your PostgreSQL instance.
-- `ssl_mode` (String) Choose the SSL mode through which RudderStack will connect to your PostgreSQL instance. RudderStack provides three options - disable, require, and verify-ca.
+- `ssl_mode` (String) Choose the SSL mode through which RudderStack will connect to your PostgreSQL instance. RudderStack provides three options - `disable`, `require`, and `verify-ca`.
 - `user` (String) Enter the name of the PostgreSQL user with the required permissions to the PostgreSQL database.
 
 Optional:

--- a/rudderstack/integrations/destinations/destination_postgres.go
+++ b/rudderstack/integrations/destinations/destination_postgres.go
@@ -88,8 +88,8 @@ func init() {
 			"ssl_mode": {
 				Type:             schema.TypeString,
 				Required:         true,
-				Description:      "Choose the SSL mode through which RudderStack will connect to your PostgreSQL instance. RudderStack provides three options - disable, require, and verify-ca.",
-				ValidateDiagFunc: c.StringMatchesRegexp("^(disable|require)$"),
+				Description:      "Choose the SSL mode through which RudderStack will connect to your PostgreSQL instance. RudderStack provides three options - `disable`, `require`, and `verify-ca`.",
+				ValidateDiagFunc: c.StringMatchesRegexp("^(disable|require|verify-ca)$"),
 			},
 			"use_rudder_storage": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Notion link: https://www.notion.so/rudderstacks/Terraform-Postgres-Not-able-to-set-SSL-mode-to-Verify_ca-from-terraform-aef114f7e50643acb66e718670f03265

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
