### PR TITLE
fix: remove string validation in google analytic destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ examples/.terraform.lock.hcl
 .env
 dist
 __debug_bin
+
+terraform-provider-rudderstack

--- a/rudderstack/integrations/destinations/destination_google_analytics.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics.go
@@ -222,8 +222,8 @@ func init() {
 							Type:     schema.TypeList,
 							Required: true,
 							Elem: &schema.Schema{
-								Type:             schema.TypeString,
-								ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)")},
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},

--- a/rudderstack/integrations/destinations/destination_google_analytics_test.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics_test.go
@@ -80,6 +80,10 @@ func TestDestinationResourceGoogleAnalytics(t *testing.T) {
 			      web = ["one", "two", "three"]
 			    }
 
+				reset_custom_dimensions_on_page {
+				   web = ["one", "two", "three"]
+				}				
+
 				content_groupings = [{
 				  from = "from"
 				  to   = "to"
@@ -118,6 +122,13 @@ func TestDestinationResourceGoogleAnalytics(t *testing.T) {
 				"optimize": { "web": "..." },
 				"useGoogleAmpClientId": { "web": true },
 				"namedTracker": { "web": true },
+				"resetCustomDimensionsOnPage": {
+					"web": [
+						{ "resetCustomDimensionsOnPage": "one" },
+						{ "resetCustomDimensionsOnPage": "two" },
+						{ "resetCustomDimensionsOnPage": "three" }
+					]
+				},
 				"oneTrustCookieCategories": {
 				  "web": [
 					{ "oneTrustCookieCategory": "one" },


### PR DESCRIPTION
Notion link: https://www.notion.so/rudderstacks/Terraform-Getting-the-error-terraform-provider-rudderstack-plugin-crashing-on-applying-the-cha-cad1a8d9b910484692d53f2263821c12

There is a bug in terraform sdk reported here: https://issuehint.com/issue/hashicorp/terraform-plugin-sdk/734
This prevents the library from being able to run Diag validators on list elements.
I removed the validation on `reset_custom_dimensions_on_page` until we find a better solution. The field will still be validated by the API.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
