### PR TITLE
feat!: make onetrust consent manager fields source type specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=rudderstack.com
 NAMESPACE=rudderlabs
 NAME=rudderstack
 BINARY=terraform-provider-${NAME}
-VERSION=0.7.2
+VERSION=1.0.0
 OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 
 default: install

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -72,11 +72,13 @@ func TestGeneratorTerraform(t *testing.T) {
 				"categoryToContent": [{ "from": "from", "to": "to" }],
 				"legacyConversionPixelId": { "from": "from", "to": "to" },
 				"useNativeSDK": { "web": true },
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				],
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				},
 				"blacklistedEvents": [
 				  { "eventName": "one" },
 				  { "eventName": "two" },
@@ -144,11 +146,13 @@ resource "rudderstack_destination_facebook_pixel" "dst_id-facebook-pixel" {
       from = "from"
       to   = "to"
     }
-    onetrust_cookie_categories = ["one", "two", "three"]
-    pixel_id                   = "facebook pixel id"
-    standard_page_call         = true
-    test_destination           = true
-    test_event_code            = "..."
+    onetrust_cookie_categories {
+      web = ["one", "two", "three"]
+    }
+    pixel_id           = "facebook pixel id"
+    standard_page_call = true
+    test_destination   = true
+    test_event_code    = "..."
     use_native_sdk {
       web = true
     }

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -72,13 +72,11 @@ func TestGeneratorTerraform(t *testing.T) {
 				"categoryToContent": [{ "from": "from", "to": "to" }],
 				"legacyConversionPixelId": { "from": "from", "to": "to" },
 				"useNativeSDK": { "web": true },
-				"oneTrustCookieCategories": {
-				  "web": [
+				"oneTrustCookieCategories": [
 					{ "oneTrustCookieCategory": "one" },
 					{ "oneTrustCookieCategory": "two" },
 					{ "oneTrustCookieCategory": "three" }
-				  ]
-				},
+				],
 				"blacklistedEvents": [
 				  { "eventName": "one" },
 				  { "eventName": "two" },
@@ -146,13 +144,11 @@ resource "rudderstack_destination_facebook_pixel" "dst_id-facebook-pixel" {
       from = "from"
       to   = "to"
     }
-    onetrust_cookie_categories {
-      web = ["one", "two", "three"]
-    }
-    pixel_id           = "facebook pixel id"
-    standard_page_call = true
-    test_destination   = true
-    test_event_code    = "..."
+    onetrust_cookie_categories = ["one", "two", "three"]
+    pixel_id                   = "facebook pixel id"
+    standard_page_call         = true
+    test_destination           = true
+    test_event_code            = "..."
     use_native_sdk {
       web = true
     }

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -46,7 +46,7 @@ terraform {
   required_providers {
     rudderstack = {
       source  = "rudderlabs/rudderstack"
-      version = "~> 0.7.2"
+      version = "~> 1.0.0"
     }
   }
   required_version = "~> 1.1.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     rudderstack = {
       source  = "rudderlabs/rudderstack"
-      version = "~> 0.7.2"
+      version = "~> 1.0.0"
     }
   }
   required_version = "~> 1.1.0"

--- a/docs/resources/destination_active_campaign.md
+++ b/docs/resources/destination_active_campaign.md
@@ -22,7 +22,19 @@ resource "rudderstack_destination_active_campaign" "example" {
 
     # actid     = "..."
     # event_key = "..."
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_adobe_analytics.md
+++ b/docs/resources/destination_adobe_analytics.md
@@ -104,7 +104,19 @@ resource "rudderstack_destination_adobe_analytics" "example" {
     #   android      = false
     #   react_native = true
     #  }
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_amplitude.md
+++ b/docs/resources/destination_amplitude.md
@@ -121,7 +121,19 @@ resource "rudderstack_destination_amplitude" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     # residency_server = "EU"
   }

--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -24,7 +24,19 @@ resource "rudderstack_destination_bigquery" "example" {
     # location  = "us-east1"
     # prefix    = ""
     # namespace = ""
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     sync {
       frequency = "30"

--- a/docs/resources/destination_customerio.md
+++ b/docs/resources/destination_customerio.md
@@ -32,7 +32,19 @@ resource "rudderstack_destination_customerio" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_facebook_pixel.md
+++ b/docs/resources/destination_facebook_pixel.md
@@ -67,7 +67,19 @@ resource "rudderstack_destination_facebook_pixel" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_google_ads.md
+++ b/docs/resources/destination_google_ads.md
@@ -52,7 +52,9 @@ resource "rudderstack_destination_google_ads" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #	  web = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_google_analytics.md
+++ b/docs/resources/destination_google_analytics.md
@@ -81,7 +81,19 @@ resource "rudderstack_destination_google_analytics" "example" {
     #   web = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     # content_groupings = [{
     #   from = "from"

--- a/docs/resources/destination_google_analytics4.md
+++ b/docs/resources/destination_google_analytics4.md
@@ -38,7 +38,19 @@ resource "rudderstack_destination_google_analytics4" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_google_tag_manager.md
+++ b/docs/resources/destination_google_tag_manager.md
@@ -30,7 +30,9 @@ resource "rudderstack_destination_google_tag_manager" "example" {
       blacklist = ["one", "two", "three"]
     }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_iterable.md
+++ b/docs/resources/destination_iterable.md
@@ -86,7 +86,19 @@ resource "rudderstack_destination_iterable" "example" {
       # close_button_position { 
       #   web = "" 
       # }
-      # onetrust_cookie_categories = ["one", "two", "three"]
+      # onetrust_cookie_categories {
+      #   web = ["one", "two", "three"]
+      #   android = ["one", "two", "three"]
+      #   ios = ["one", "two", "three"]
+      #   unity = ["one", "two", "three"]
+      #   reactnative = ["one", "two", "three"]
+      #   flutter = ["one", "two", "three"]
+      #   cordova = ["one", "two", "three"]
+      #   amp = ["one", "two", "three"]
+      #   cloud = ["one", "two", "three"]
+      #   warehouse = ["one", "two", "three"]
+      #   shopify = ["one", "two", "three"]
+      # }
 
     }
   

--- a/docs/resources/destination_mixpanel.md
+++ b/docs/resources/destination_mixpanel.md
@@ -44,7 +44,19 @@ resource "rudderstack_destination_mixpanel" example{
     #   blacklist = ["one","two","three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
     # use_new_mapping = true
   }
 }

--- a/docs/resources/destination_redis.md
+++ b/docs/resources/destination_redis.md
@@ -26,7 +26,19 @@ resource "rudderstack_destination_redis" "example" {
     # database      = "..."
     # ca_certificate = "..."
     # skip_verify   = false
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_redshift.md
+++ b/docs/resources/destination_redshift.md
@@ -34,7 +34,19 @@ resource "rudderstack_destination_redshift" "example" {
     #   access_key    = ""
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     sync {
       frequency = "30"

--- a/docs/resources/destination_s3.md
+++ b/docs/resources/destination_s3.md
@@ -24,7 +24,19 @@ resource "rudderstack_destination_s3" "example" {
     # access_key    = "..."
 
     # enable_sse    = true
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_s3_datalake.md
+++ b/docs/resources/destination_s3_datalake.md
@@ -26,7 +26,19 @@ resource "rudderstack_destination_s3_datalake" "example" {
 
     # enable_sse    = true
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     use_glue = true
     region   = "us-east-2"

--- a/docs/resources/destination_sentry.md
+++ b/docs/resources/destination_sentry.md
@@ -40,7 +40,9 @@ resource "rudderstack_destination_sentry" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_slack.md
+++ b/docs/resources/destination_slack.md
@@ -39,7 +39,19 @@ resource "rudderstack_destination_slack" "example" {
 
     # whitelisted_trait_settings = ["one", "two", "three"]
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_snowflake.md
+++ b/docs/resources/destination_snowflake.md
@@ -50,7 +50,19 @@ resource "rudderstack_destination_snowflake" example{
     #   account_key = "..."
     #   storage_integration = "..."
     # }
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_vwo.md
+++ b/docs/resources/destination_vwo.md
@@ -37,7 +37,9 @@ resource "rudderstack_destination_vwo" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_webhook.md
+++ b/docs/resources/destination_webhook.md
@@ -31,7 +31,19 @@ resource "rudderstack_destination_webhook" "example" {
       }
     ]
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/docs/resources/destination_zendesk.md
+++ b/docs/resources/destination_zendesk.md
@@ -25,7 +25,19 @@ resource "rudderstack_destination_zendesk" "example" {
     send_group_calls_without_user_id = false
     remove_users_from_organization   = false
     search_by_external_id = false
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }
 ```

--- a/examples/destination_active_campaign.tf
+++ b/examples/destination_active_campaign.tf
@@ -7,6 +7,18 @@ resource "rudderstack_destination_active_campaign" "example" {
 
     # actid     = "..."
     # event_key = "..."
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_adobe_analytics.tf
+++ b/examples/destination_adobe_analytics.tf
@@ -89,6 +89,18 @@ resource "rudderstack_destination_adobe_analytics" "example" {
     #   android      = false
     #   react_native = true
     #  }
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_amplitude.tf
+++ b/examples/destination_amplitude.tf
@@ -106,7 +106,19 @@ resource "rudderstack_destination_amplitude" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     # residency_server = "EU"
   }

--- a/examples/destination_bigquery.tf
+++ b/examples/destination_bigquery.tf
@@ -9,7 +9,19 @@ resource "rudderstack_destination_bigquery" "example" {
     # location  = "us-east1"
     # prefix    = ""
     # namespace = ""
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     sync {
       frequency = "30"

--- a/examples/destination_customerio.tf
+++ b/examples/destination_customerio.tf
@@ -18,6 +18,18 @@ resource "rudderstack_destination_customerio" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_facebook_pixel.tf
+++ b/examples/destination_facebook_pixel.tf
@@ -52,6 +52,18 @@ resource "rudderstack_destination_facebook_pixel" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_gcs.tf
+++ b/examples/destination_gcs.tf
@@ -6,6 +6,18 @@ resource "rudderstack_destination_gcs" "example" {
 
     # prefix        = "prefix"
     # credentials   = "..."
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_google_ads.tf
+++ b/examples/destination_google_ads.tf
@@ -37,6 +37,8 @@ resource "rudderstack_destination_google_ads" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_google_analytics.tf
+++ b/examples/destination_google_analytics.tf
@@ -66,7 +66,19 @@ resource "rudderstack_destination_google_analytics" "example" {
     #   web = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     # content_groupings = [{
     #   from = "from"

--- a/examples/destination_google_analytics4.tf
+++ b/examples/destination_google_analytics4.tf
@@ -23,6 +23,18 @@ resource "rudderstack_destination_google_analytics4" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_google_tag_manager.tf
+++ b/examples/destination_google_tag_manager.tf
@@ -15,6 +15,8 @@ resource "rudderstack_destination_google_tag_manager" "example" {
       blacklist = ["one", "two", "three"]
     }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_iterable.tf
+++ b/examples/destination_iterable.tf
@@ -71,7 +71,19 @@ resource "rudderstack_destination_iterable" "example" {
       # close_button_position { 
       #   web = "" 
       # }
-      # onetrust_cookie_categories = ["one", "two", "three"]
+      # onetrust_cookie_categories {
+      #   web = ["one", "two", "three"]
+      #   android = ["one", "two", "three"]
+      #   ios = ["one", "two", "three"]
+      #   unity = ["one", "two", "three"]
+      #   reactnative = ["one", "two", "three"]
+      #   flutter = ["one", "two", "three"]
+      #   cordova = ["one", "two", "three"]
+      #   amp = ["one", "two", "three"]
+      #   cloud = ["one", "two", "three"]
+      #   warehouse = ["one", "two", "three"]
+      #   shopify = ["one", "two", "three"]
+      # }
 
     }
   

--- a/examples/destination_mixpanel.tf
+++ b/examples/destination_mixpanel.tf
@@ -29,7 +29,19 @@ resource "rudderstack_destination_mixpanel" example{
     #   blacklist = ["one","two","three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
     # use_new_mapping = true
   }
 }

--- a/examples/destination_redis.tf
+++ b/examples/destination_redis.tf
@@ -11,6 +11,18 @@ resource "rudderstack_destination_redis" "example" {
     # database      = "..."
     # ca_certificate = "..."
     # skip_verify   = false
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_redshift.tf
+++ b/examples/destination_redshift.tf
@@ -19,7 +19,19 @@ resource "rudderstack_destination_redshift" "example" {
     #   access_key    = ""
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     sync {
       frequency = "30"

--- a/examples/destination_s3.tf
+++ b/examples/destination_s3.tf
@@ -9,6 +9,18 @@ resource "rudderstack_destination_s3" "example" {
     # access_key    = "..."
 
     # enable_sse    = true
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_s3_datalake.tf
+++ b/examples/destination_s3_datalake.tf
@@ -11,7 +11,19 @@ resource "rudderstack_destination_s3_datalake" "example" {
 
     # enable_sse    = true
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
 
     use_glue = true
     region   = "us-east-2"

--- a/examples/destination_sentry.tf
+++ b/examples/destination_sentry.tf
@@ -25,6 +25,8 @@ resource "rudderstack_destination_sentry" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_slack.tf
+++ b/examples/destination_slack.tf
@@ -24,6 +24,18 @@ resource "rudderstack_destination_slack" "example" {
 
     # whitelisted_trait_settings = ["one", "two", "three"]
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_snowflake.tf
+++ b/examples/destination_snowflake.tf
@@ -36,6 +36,18 @@ resource "rudderstack_destination_snowflake" example{
     #   account_key = "..."
     #   storage_integration = "..."
     # }
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_vwo.tf
+++ b/examples/destination_vwo.tf
@@ -22,6 +22,8 @@ resource "rudderstack_destination_vwo" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_webhook.tf
+++ b/examples/destination_webhook.tf
@@ -16,6 +16,18 @@ resource "rudderstack_destination_webhook" "example" {
       }
     ]
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/destination_zendesk.tf
+++ b/examples/destination_zendesk.tf
@@ -10,6 +10,18 @@ resource "rudderstack_destination_zendesk" "example" {
     send_group_calls_without_user_id = false
     remove_users_from_organization   = false
     search_by_external_id = false
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # onetrust_cookie_categories {
+    #   web = ["one", "two", "three"]
+    #   android = ["one", "two", "three"]
+    #   ios = ["one", "two", "three"]
+    #   unity = ["one", "two", "three"]
+    #   reactnative = ["one", "two", "three"]
+    #   flutter = ["one", "two", "three"]
+    #   cordova = ["one", "two", "three"]
+    #   amp = ["one", "two", "three"]
+    #   cloud = ["one", "two", "three"]
+    #   warehouse = ["one", "two", "three"]
+    #   shopify = ["one", "two", "three"]
+    # }
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rudderstack = {
       source  = "rudderlabs/rudderstack"
-      version = "~> 0.7.2"
+      version = "~> 1.0.0"
     }
   }
   required_version = "~> 1.1.0"

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -10,11 +10,12 @@ import (
 func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
 	onetrust_terraform_key := "onetrust_cookie_categories"
 
-	oneTrustConsentFieldProperties := []c.ConfigProperty{}
+	oneTrustConsentsProperties := []c.ConfigProperty{}
 	onetrust_elements_schema := make(map[string]*schema.Schema)
 
+	// Create property and schema for each source type
 	for _, sourceType := range supportedSourceTypes {
-		oneTrustConsentFieldProperties = append(oneTrustConsentFieldProperties, c.ArrayWithStrings(fmt.Sprintf("oneTrustCookieCategories.%s", sourceType), "oneTrustCookieCategory", fmt.Sprintf("%s.0.%s", onetrust_terraform_key, sourceType)))
+		oneTrustConsentsProperties = append(oneTrustConsentsProperties, c.ArrayWithStrings(fmt.Sprintf("oneTrustCookieCategories.%s", sourceType), "oneTrustCookieCategory", fmt.Sprintf("%s.0.%s", onetrust_terraform_key, sourceType)))
 
 		onetrust_elements_schema[sourceType] = &schema.Schema{
 			Type:        schema.TypeList,
@@ -25,7 +26,7 @@ func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.Config
 		}
 	}
 
-	oneTrustConsentFieldSchema := map[string]*schema.Schema{
+	oneTrustConsentsSchema := map[string]*schema.Schema{
 		onetrust_terraform_key: {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -37,7 +38,7 @@ func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.Config
 		},
 	}
 
-	return oneTrustConsentFieldProperties, oneTrustConsentFieldSchema
+	return oneTrustConsentsProperties, oneTrustConsentsSchema
 }
 
 func GetCommonConfigMeta(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -8,26 +8,27 @@ import (
 )
 
 func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
-	onetrust_terraform_key := "onetrust_cookie_categories"
-
 	oneTrustConsentsProperties := []c.ConfigProperty{}
-	onetrust_elements_schema := make(map[string]*schema.Schema)
+	oneTrustConsentsSchema := map[string]*schema.Schema{}
 
-	// Create property and schema for each source type
-	for _, sourceType := range supportedSourceTypes {
-		oneTrustConsentsProperties = append(oneTrustConsentsProperties, c.ArrayWithStrings(fmt.Sprintf("oneTrustCookieCategories.%s", sourceType), "oneTrustCookieCategory", fmt.Sprintf("%s.0.%s", onetrust_terraform_key, sourceType)))
+	if len(supportedSourceTypes) != 0 && supportedSourceTypes != nil {
+		onetrust_terraform_key := "onetrust_cookie_categories"
+		onetrust_elements_schema := make(map[string]*schema.Schema)
 
-		onetrust_elements_schema[sourceType] = &schema.Schema{
-			Type:        schema.TypeList,
-			Optional:    true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
+		// Create property and schema for each source type
+		for _, sourceType := range supportedSourceTypes {
+			oneTrustConsentsProperties = append(oneTrustConsentsProperties, c.ArrayWithStrings(fmt.Sprintf("oneTrustCookieCategories.%s", sourceType), "oneTrustCookieCategory", fmt.Sprintf("%s.0.%s", onetrust_terraform_key, sourceType)))
+
+			onetrust_elements_schema[sourceType] = &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			}
 		}
-	}
 
-	oneTrustConsentsSchema := map[string]*schema.Schema{
-		onetrust_terraform_key: {
+		oneTrustConsentsSchema[onetrust_terraform_key] = &schema.Schema{
 			Type:        schema.TypeList,
 			Optional:    true,
 			MaxItems:    1,
@@ -35,7 +36,7 @@ func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.Config
 			Elem: &schema.Resource{
 				Schema: onetrust_elements_schema,
 			},
-		},
+		};
 	}
 
 	return oneTrustConsentsProperties, oneTrustConsentsSchema

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -1,0 +1,56 @@
+package destinations
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+)
+
+func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
+	onetrust_terraform_key := "onetrust_cookie_categories"
+
+	oneTrustConsentFieldProperties := []c.ConfigProperty{}
+	onetrust_elements_schema := make(map[string]*schema.Schema)
+
+	for _, sourceType := range supportedSourceTypes {
+		oneTrustConsentFieldProperties = append(oneTrustConsentFieldProperties, c.ArrayWithStrings(fmt.Sprintf("oneTrustCookieCategories.%s", sourceType), "oneTrustCookieCategory", fmt.Sprintf("%s.0.%s", onetrust_terraform_key, sourceType)))
+
+		onetrust_elements_schema[sourceType] = &schema.Schema{
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		}
+	}
+
+	oneTrustConsentFieldSchema := map[string]*schema.Schema{
+		onetrust_terraform_key: {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Specify OneTrust category IDs.",
+			Elem: &schema.Resource{
+				Schema: onetrust_elements_schema,
+			},
+		},
+	}
+
+	return oneTrustConsentFieldProperties, oneTrustConsentFieldSchema
+}
+
+func GetCommonConfigMeta(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
+	commonProperties := []c.ConfigProperty{}
+	commonSchema := map[string]*schema.Schema{}
+
+	oneTrustConsentFieldProperties, oneTrustConsentFieldSchema := GetConfigMetaForOneTrustConsents(supportedSourceTypes)
+
+	commonProperties = append(commonProperties, oneTrustConsentFieldProperties...)
+
+	for key, value := range oneTrustConsentFieldSchema {
+		commonSchema[key] = value
+	}
+
+	return commonProperties, commonSchema
+}

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -1,0 +1,199 @@
+// write unit tests for the common_config_meta.go file
+
+package destinations
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCommonConfigMeta(t *testing.T) {
+	testCases := []struct {
+		description          string
+		supportedSourceTypes []string
+		expectedProperties   []c.ConfigProperty
+		expectedSchema       map[string]*schema.Schema
+	}{
+		{
+			description:          "Valid list of supported source types",
+			supportedSourceTypes: []string{"web", "android", "ios"},
+			expectedProperties: []c.ConfigProperty{
+				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+				c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
+				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
+			},
+			expectedSchema: map[string]*schema.Schema{
+				"onetrust_cookie_categories": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify OneTrust category IDs.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+							"android": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+							"ios": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:          "Empty list of supported source types",
+			supportedSourceTypes: []string{},
+			expectedProperties:   []c.ConfigProperty{},
+			expectedSchema:       map[string]*schema.Schema{
+				"onetrust_cookie_categories": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify OneTrust category IDs.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{},
+					},
+				},
+			},
+		},
+		{
+			description:          "A single supported source type",
+			supportedSourceTypes: []string{"web"},
+			expectedProperties: []c.ConfigProperty{
+				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+			},
+			expectedSchema: map[string]*schema.Schema{
+				"onetrust_cookie_categories": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify OneTrust category IDs.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actualProperties, actualSchema := GetCommonConfigMeta(tc.supportedSourceTypes)
+			require.EqualValues(t, tc.expectedSchema, actualSchema)
+			require.True(t, len(actualProperties) == len(tc.expectedProperties))
+		})
+	}
+}
+
+func TestGetConfigMetaForOneTrustConsents(t *testing.T) {
+	testCases := []struct {
+		description          string
+		supportedSourceTypes []string
+		expectedProperties   []c.ConfigProperty
+		expectedSchema       map[string]*schema.Schema
+	}{
+		{
+			description:          "Valid list of supported source types",
+			supportedSourceTypes: []string{"web", "android", "ios"},
+			expectedProperties: []c.ConfigProperty{
+				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+				c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
+				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
+			},
+			expectedSchema: map[string]*schema.Schema{
+				"onetrust_cookie_categories": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify OneTrust category IDs.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+							"android": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+							"ios": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:          "Empty list of supported source types",
+			supportedSourceTypes: []string{},
+			expectedProperties:   []c.ConfigProperty{},
+			expectedSchema:       map[string]*schema.Schema{
+				"onetrust_cookie_categories": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify OneTrust category IDs.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{},
+					},
+				},
+			},
+		},
+		{
+			description:          "A single supported source type",
+			supportedSourceTypes: []string{"web"},
+			expectedProperties: []c.ConfigProperty{
+				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+			},
+			expectedSchema: map[string]*schema.Schema{
+				"onetrust_cookie_categories": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify OneTrust category IDs.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actualProperties, actualSchema := GetConfigMetaForOneTrustConsents(tc.supportedSourceTypes)
+			require.EqualValues(t, tc.expectedSchema, actualSchema)
+			require.True(t, len(actualProperties) == len(tc.expectedProperties))
+		})
+	}
+}

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -57,17 +57,13 @@ func TestGetCommonConfigMeta(t *testing.T) {
 			description:          "Empty list of supported source types",
 			supportedSourceTypes: []string{},
 			expectedProperties:   []c.ConfigProperty{},
-			expectedSchema:       map[string]*schema.Schema{
-				"onetrust_cookie_categories": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					MaxItems:    1,
-					Description: "Specify OneTrust category IDs.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{},
-					},
-				},
-			},
+			expectedSchema:       map[string]*schema.Schema{},
+		},
+		{
+			description:          "Nil supported source types",
+			supportedSourceTypes: nil,
+			expectedProperties:   []c.ConfigProperty{},
+			expectedSchema:       map[string]*schema.Schema{},
 		},
 		{
 			description:          "A single supported source type",
@@ -98,100 +94,6 @@ func TestGetCommonConfigMeta(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			actualProperties, actualSchema := GetCommonConfigMeta(tc.supportedSourceTypes)
-			require.EqualValues(t, tc.expectedSchema, actualSchema)
-			require.True(t, len(actualProperties) == len(tc.expectedProperties))
-		})
-	}
-}
-
-func TestGetConfigMetaForOneTrustConsents(t *testing.T) {
-	testCases := []struct {
-		description          string
-		supportedSourceTypes []string
-		expectedProperties   []c.ConfigProperty
-		expectedSchema       map[string]*schema.Schema
-	}{
-		{
-			description:          "Valid list of supported source types",
-			supportedSourceTypes: []string{"web", "android", "ios"},
-			expectedProperties: []c.ConfigProperty{
-				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
-				c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
-				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
-			},
-			expectedSchema: map[string]*schema.Schema{
-				"onetrust_cookie_categories": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					MaxItems:    1,
-					Description: "Specify OneTrust category IDs.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"web": {
-								Type:        schema.TypeList,
-								Optional:    true,
-								Elem:        &schema.Schema{Type: schema.TypeString},
-							},
-							"android": {
-								Type:        schema.TypeList,
-								Optional:    true,
-								Elem:        &schema.Schema{Type: schema.TypeString},
-							},
-							"ios": {
-								Type:        schema.TypeList,
-								Optional:    true,
-								Elem:        &schema.Schema{Type: schema.TypeString},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			description:          "Empty list of supported source types",
-			supportedSourceTypes: []string{},
-			expectedProperties:   []c.ConfigProperty{},
-			expectedSchema:       map[string]*schema.Schema{
-				"onetrust_cookie_categories": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					MaxItems:    1,
-					Description: "Specify OneTrust category IDs.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{},
-					},
-				},
-			},
-		},
-		{
-			description:          "A single supported source type",
-			supportedSourceTypes: []string{"web"},
-			expectedProperties: []c.ConfigProperty{
-				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
-			},
-			expectedSchema: map[string]*schema.Schema{
-				"onetrust_cookie_categories": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					MaxItems:    1,
-					Description: "Specify OneTrust category IDs.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"web": {
-								Type:        schema.TypeList,
-								Optional:    true,
-								Elem:        &schema.Schema{Type: schema.TypeString},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			actualProperties, actualSchema := GetConfigMetaForOneTrustConsents(tc.supportedSourceTypes)
 			require.EqualValues(t, tc.expectedSchema, actualSchema)
 			require.True(t, len(actualProperties) == len(tc.expectedProperties))
 		})

--- a/rudderstack/integrations/destinations/destination_active_campaign.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign.go
@@ -13,7 +13,17 @@ func init() {
 			c.Simple("apiKey", "api_key", c.SkipZeroValue),
 			c.Simple("actid", "actid", c.SkipZeroValue),
 			c.Simple("eventKey", "event_key", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
+			c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+			c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
+			c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
+			c.ArrayWithStrings("oneTrustCookieCategories.unity", "oneTrustCookieCategory", "onetrust_cookie_categories.0.unity"),
+			c.ArrayWithStrings("oneTrustCookieCategories.reactnative", "oneTrustCookieCategory", "onetrust_cookie_categories.0.reactnative"),
+			c.ArrayWithStrings("oneTrustCookieCategories.flutter", "oneTrustCookieCategory", "onetrust_cookie_categories.0.flutter"),
+			c.ArrayWithStrings("oneTrustCookieCategories.cordova", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cordova"),
+			c.ArrayWithStrings("oneTrustCookieCategories.amp", "oneTrustCookieCategory", "onetrust_cookie_categories.0.amp"),
+			c.ArrayWithStrings("oneTrustCookieCategories.cloud", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cloud"),
+			c.ArrayWithStrings("oneTrustCookieCategories.warehouse", "oneTrustCookieCategory", "onetrust_cookie_categories.0.warehouse"),
+			c.ArrayWithStrings("oneTrustCookieCategories.shopify", "oneTrustCookieCategory", "onetrust_cookie_categories.0.shopify"),
 		},
 		ConfigSchema: map[string]*schema.Schema{
 			"api_url": {
@@ -44,9 +54,88 @@ func init() {
 			"onetrust_cookie_categories": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				MaxItems:    1,
+				Description: "Specify OneTrust category IDs.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"web": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"android": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"ios": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"unity": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"reactnative": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"flutter": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"cordova": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"amp": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"cloud": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"warehouse": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"shopify": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
 				},
 			},
 		},

--- a/rudderstack/integrations/destinations/destination_active_campaign.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign.go
@@ -6,138 +6,53 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("apiUrl", "api_url"),
+		c.Simple("apiKey", "api_key", c.SkipZeroValue),
+		c.Simple("actid", "actid", c.SkipZeroValue),
+		c.Simple("eventKey", "event_key", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"api_url": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter your ActiveCampaign API URL. You can find it in your account in the Settings page under the Developer tab.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"api_key": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Enter your ActiveCampaign API key.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"actid": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Enter your ActID here. To obtain the ActID unique to your ActiveCampaign account, go to Settings > Tracking > Event Tracking API.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"event_key": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Enter the event key unique to your ActiveCampaign account. To obtain the event key, go to your ActiveCampaign account > Settings > Tracking > Event Tracking.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("active_campaign", c.ConfigMeta{
 		APIType: "ACTIVE_CAMPAIGN",
-		Properties: []c.ConfigProperty{
-			c.Simple("apiUrl", "api_url"),
-			c.Simple("apiKey", "api_key", c.SkipZeroValue),
-			c.Simple("actid", "actid", c.SkipZeroValue),
-			c.Simple("eventKey", "event_key", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
-			c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
-			c.ArrayWithStrings("oneTrustCookieCategories.unity", "oneTrustCookieCategory", "onetrust_cookie_categories.0.unity"),
-			c.ArrayWithStrings("oneTrustCookieCategories.reactnative", "oneTrustCookieCategory", "onetrust_cookie_categories.0.reactnative"),
-			c.ArrayWithStrings("oneTrustCookieCategories.flutter", "oneTrustCookieCategory", "onetrust_cookie_categories.0.flutter"),
-			c.ArrayWithStrings("oneTrustCookieCategories.cordova", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cordova"),
-			c.ArrayWithStrings("oneTrustCookieCategories.amp", "oneTrustCookieCategory", "onetrust_cookie_categories.0.amp"),
-			c.ArrayWithStrings("oneTrustCookieCategories.cloud", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cloud"),
-			c.ArrayWithStrings("oneTrustCookieCategories.warehouse", "oneTrustCookieCategory", "onetrust_cookie_categories.0.warehouse"),
-			c.ArrayWithStrings("oneTrustCookieCategories.shopify", "oneTrustCookieCategory", "onetrust_cookie_categories.0.shopify"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"api_url": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter your ActiveCampaign API URL. You can find it in your account in the Settings page under the Developer tab.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"api_key": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Sensitive:   true,
-				Description: "Enter your ActiveCampaign API key.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"actid": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter your ActID here. To obtain the ActID unique to your ActiveCampaign account, go to Settings > Tracking > Event Tracking API.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"event_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter the event key unique to your ActiveCampaign account. To obtain the event key, go to your ActiveCampaign account > Settings > Tracking > Event Tracking.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				MaxItems:    1,
-				Description: "Specify OneTrust category IDs.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"android": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"ios": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"unity": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"reactnative": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"flutter": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"cordova": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"amp": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"cloud": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"warehouse": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"shopify": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -16,8 +16,7 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 			`,
 			APICreate: `{
 				"apiUrl": "https://some-url",
-				"apiKey": "api-key",
-				}
+				"apiKey": "api-key"
 			}`,
 			TerraformUpdate: `
 				api_url   = "https://some-url"

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -13,79 +13,10 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 			TerraformCreate: `
 				api_url = "https://some-url"
 				api_key = "api-key"
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
-				}
 			`,
 			APICreate: `{
 				"apiUrl": "https://some-url",
 				"apiKey": "api-key",
-				"oneTrustCookieCategories": {
-					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					]
 				}
 			}`,
 			TerraformUpdate: `

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -13,28 +13,162 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 			TerraformCreate: `
 				api_url = "https://some-url"
 				api_key = "api-key"
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APICreate: `{
 				"apiUrl": "https://some-url",
-				"apiKey": "api-key"
+				"apiKey": "api-key",
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 			TerraformUpdate: `
 				api_url   = "https://some-url"
 				api_key   = "api-key"
 				actid     = "actid"
 				event_key = "event-key"
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"apiUrl": "https://some-url",
 				"apiKey": "api-key",
 				"actid": "actid",
 				"eventKey": "event-key",
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_adobe_analytics.go
+++ b/rudderstack/integrations/destinations/destination_adobe_analytics.go
@@ -6,588 +6,592 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("trackingServerUrl", "tracking_server_url", c.SkipZeroValue),
+		c.Simple("trackingServerSecureUrl", "tracking_server_secure_url", c.SkipZeroValue),
+		c.Simple("reportSuiteIds", "report_suite_ids"),
+		c.Simple("sslHeartbeat", "ssl_heartbeat"),
+		c.Simple("heartbeatTrackingServerUrl", "heartbeat_tracking_server_url", c.SkipZeroValue),
+		c.Simple("useUtf8Charset", "use_utf8_charset"),
+		c.Simple("useSecureServerSide", "use_secure_server_side"),
+		c.Simple("proxyNormalUrl", "proxy_normal_url", c.SkipZeroValue),
+		c.Simple("proxyHeartbeatUrl", "proxy_heartbeat_url", c.SkipZeroValue),
+		c.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.Simple("marketingCloudOrgId", "marketing_cloud_org_id", c.SkipZeroValue),
+		c.Simple("dropVisitorId", "drop_visitor_id"),
+		c.Simple("timestampOption", "timestamp_option", c.SkipZeroValue),
+		c.Simple("timestampOptionalReporting", "timestamp_optional_reporting"),
+		c.Simple("noFallbackVisitorId", "no_fallback_visitor_id"),
+		c.Simple("preferVisitorId", "prefer_visitor_id"),
+		c.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.Simple("trackPageName", "track_page_name"),
+		c.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.Simple("contextDataPrefix", "context_data_prefix", c.SkipZeroValue),
+		c.Simple("useLegacyLinkName", "use_legacy_link_name"),
+		c.Simple("pageNameFallbackTostring", "page_name_fallback_tostring"),
+		c.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.Simple("sendFalseValues", "send_false_values"),
+		c.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithObjects("hierMapping", "hier_mapping", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithObjects("listMapping", "list_mapping", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+
+		c.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithStrings("eventMerchProperties", "eventMerchProperties", "event_merch_properties"),
+
+		c.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithStrings("productMerchProperties", "productMerchProperties", "product_merch_properties"),
+
+		c.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]string{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.Simple("productIdentifier", "product_identifier", c.SkipZeroValue),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.Simple("useNativeSDK.ios", "use_native_sdk.0.ios"),
+		c.Simple("useNativeSDK.android", "use_native_sdk.0.android"),
+		c.Simple("useNativeSDK.reactnative", "use_native_sdk.0.react_native"),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"tracking_server_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Tracking Server URL",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"tracking_server_secure_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Tracking Server Secure URL",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"report_suite_ids": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Report Suite ID(s). You can add multiple report suite ID's separated by commas.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,300})$"),
+		},
+		"ssl_heartbeat": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Check for Heartbeat calls to be made over https",
+		},
+		"heartbeat_tracking_server_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Heartbeat Tracking Server URL",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"use_utf8_charset": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Use UTF-8 charset",
+		},
+		"use_secure_server_side": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Use Secure URL for Server-side",
+		},
+		"proxy_normal_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Adobe Analytics Javascript SDK URL",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"proxy_heartbeat_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Adobe Analytics Hearbeat SDK URL",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+
+		"events_to_types": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map your Rudder video events with types of Video Events",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Provide the Video Event Name.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Type of Video Event",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(initHeartbeat|heartbeatPlaybackStarted|heartbeatPlaybackPaused|heartbeatPlaybackResumed|heartbeatPlaybackCompleted|heartbeatPlaybackInterrupted|heartbeatContentStarted|heartbeatContentComplete|heartbeatAdBreakStarted|heartbeatAdBreakCompleted|heartbeatAdStarted|heartbeatAdCompleted|heartbeatAdSkipped|heartbeatSeekStarted|heartbeatSeekCompleted|heartbeatBufferStarted|heartbeatBufferCompleted|heartbeatQualityUpdated|heartbeatUpdatePlayhead)$"),
+					},
+				},
+			},
+		},
+		"marketing_cloud_org_id": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Marketing Cloud Organization Id.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"drop_visitor_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Check to Drop Visitor Id.",
+		},
+		"timestamp_option": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Timestamp Option.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(disabled|hybrid|optional|enabled)$"),
+		},
+		"timestamp_optional_reporting": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Check to send both Timestamp and VisitorID for Timestamp Optional Reporting Suites",
+		},
+		"no_fallback_visitor_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Check to enable no fallbacks for Visitor ID",
+		},
+		"prefer_visitor_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Check to prefer Visitor Id",
+		},
+		"rudder_events_to_adobe_events": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder Events to Adobe Custom Events.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Event Name",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Adobe Custom Event",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"track_page_name": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Check to enable pageName for Track Events",
+		},
+		"context_data_mapping": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder Context data to Adobe Context Data",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Context Data path.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Adobe Context Data property name",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"context_data_prefix": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your prefix to add before all contextData property.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"use_legacy_link_name": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Check to use Legacy LinkName",
+		},
+		"page_name_fallback_tostring": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Check to allow Page Name Fallback to Screen",
+		},
+		"mobile_event_mapping": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder mobile events.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Context Data path.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Adobe Context Data property name",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"send_false_values": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Check to allow sending false value from properties",
+		},
+		"e_var_mapping": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder properties to Adobe eVars",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Property",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the eVar Index",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"hier_mapping": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder properties to Adobe hierarchy properties",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Property",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the eVar Index",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"list_mapping": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder properties to Adobe list properties",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Property as an array/string seperated by commas",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the eVar Index",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"list_delimiter": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map your Rudder Property with delimiters for list properties",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Property.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the List Delimiter.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^$|(^env[.].+)|^(\\||:|,|;|\\/)$"),
+					},
+				},
+			},
+		},
+		"custom_props_mapping": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder properties to Adobe Custom properties",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Property.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the prop Index.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"props_delimiter": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map your Rudder property with delimiters for Adobe custom properties",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Property.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the List Delimiter.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^$|(^env[.].+)|^(\\||:|,|;|\\/)$"),
+					},
+				},
+			},
+		},
+		"event_merch_event_to_adobe_event": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder events to Adobe merchandise events.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Event.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Adobe Event.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"event_merch_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Currency/Incremental properties to add to merchandise events at event level",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"product_merch_event_to_adobe_event": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder events to Adobe merchandise events",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Event.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Adobe Event.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"product_merch_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Currency/Incremental properties to add to merchandise events at product level",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"product_merch_evars_map": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can map Rudder properties to eVars at product level",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the Rudder Event.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the eVar Index.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"product_identifier": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your Product Identifier",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(name|id|sku)$"),
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send events to Adobe Analytics via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"ios": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"android": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "This option allows you to filter the events you want to send to Adobe Analytics.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for k, v := range commonSchema {
+		schema[k] = v
+	}
+
 	c.Destinations.Register("adobe_analytics", c.ConfigMeta{
 		APIType: "ADOBE_ANALYTICS",
-		Properties: []c.ConfigProperty{
-			c.Simple("trackingServerUrl", "tracking_server_url", c.SkipZeroValue),
-			c.Simple("trackingServerSecureUrl", "tracking_server_secure_url", c.SkipZeroValue),
-			c.Simple("reportSuiteIds", "report_suite_ids"),
-			c.Simple("sslHeartbeat", "ssl_heartbeat"),
-			c.Simple("heartbeatTrackingServerUrl", "heartbeat_tracking_server_url", c.SkipZeroValue),
-			c.Simple("useUtf8Charset", "use_utf8_charset"),
-			c.Simple("useSecureServerSide", "use_secure_server_side"),
-			c.Simple("proxyNormalUrl", "proxy_normal_url", c.SkipZeroValue),
-			c.Simple("proxyHeartbeatUrl", "proxy_heartbeat_url", c.SkipZeroValue),
-			c.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.Simple("marketingCloudOrgId", "marketing_cloud_org_id", c.SkipZeroValue),
-			c.Simple("dropVisitorId", "drop_visitor_id"),
-			c.Simple("timestampOption", "timestamp_option", c.SkipZeroValue),
-			c.Simple("timestampOptionalReporting", "timestamp_optional_reporting"),
-			c.Simple("noFallbackVisitorId", "no_fallback_visitor_id"),
-			c.Simple("preferVisitorId", "prefer_visitor_id"),
-			c.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.Simple("trackPageName", "track_page_name"),
-			c.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.Simple("contextDataPrefix", "context_data_prefix", c.SkipZeroValue),
-			c.Simple("useLegacyLinkName", "use_legacy_link_name"),
-			c.Simple("pageNameFallbackTostring", "page_name_fallback_tostring"),
-			c.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.Simple("sendFalseValues", "send_false_values"),
-			c.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithObjects("hierMapping", "hier_mapping", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithObjects("listMapping", "list_mapping", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-
-			c.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithStrings("eventMerchProperties", "eventMerchProperties", "event_merch_properties"),
-
-			c.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithStrings("productMerchProperties", "productMerchProperties", "product_merch_properties"),
-
-			c.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]string{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.Simple("productIdentifier", "product_identifier", c.SkipZeroValue),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.Simple("useNativeSDK.ios", "use_native_sdk.0.ios"),
-			c.Simple("useNativeSDK.android", "use_native_sdk.0.android"),
-			c.Simple("useNativeSDK.reactnative", "use_native_sdk.0.react_native"),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"tracking_server_url": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Tracking Server URL",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"tracking_server_secure_url": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Tracking Server Secure URL",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"report_suite_ids": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Report Suite ID(s). You can add multiple report suite ID's separated by commas.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,300})$"),
-			},
-			"ssl_heartbeat": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Check for Heartbeat calls to be made over https",
-			},
-			"heartbeat_tracking_server_url": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Heartbeat Tracking Server URL",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"use_utf8_charset": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Use UTF-8 charset",
-			},
-			"use_secure_server_side": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Use Secure URL for Server-side",
-			},
-			"proxy_normal_url": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Adobe Analytics Javascript SDK URL",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"proxy_heartbeat_url": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Adobe Analytics Hearbeat SDK URL",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-
-			"events_to_types": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map your Rudder video events with types of Video Events",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Provide the Video Event Name.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Type of Video Event",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(initHeartbeat|heartbeatPlaybackStarted|heartbeatPlaybackPaused|heartbeatPlaybackResumed|heartbeatPlaybackCompleted|heartbeatPlaybackInterrupted|heartbeatContentStarted|heartbeatContentComplete|heartbeatAdBreakStarted|heartbeatAdBreakCompleted|heartbeatAdStarted|heartbeatAdCompleted|heartbeatAdSkipped|heartbeatSeekStarted|heartbeatSeekCompleted|heartbeatBufferStarted|heartbeatBufferCompleted|heartbeatQualityUpdated|heartbeatUpdatePlayhead)$"),
-						},
-					},
-				},
-			},
-			"marketing_cloud_org_id": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Marketing Cloud Organization Id.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"drop_visitor_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Check to Drop Visitor Id.",
-			},
-			"timestamp_option": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Timestamp Option.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(disabled|hybrid|optional|enabled)$"),
-			},
-			"timestamp_optional_reporting": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Check to send both Timestamp and VisitorID for Timestamp Optional Reporting Suites",
-			},
-			"no_fallback_visitor_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Check to enable no fallbacks for Visitor ID",
-			},
-			"prefer_visitor_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Check to prefer Visitor Id",
-			},
-			"rudder_events_to_adobe_events": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder Events to Adobe Custom Events.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Event Name",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Adobe Custom Event",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"track_page_name": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Check to enable pageName for Track Events",
-			},
-			"context_data_mapping": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder Context data to Adobe Context Data",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Context Data path.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Adobe Context Data property name",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"context_data_prefix": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your prefix to add before all contextData property.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"use_legacy_link_name": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Check to use Legacy LinkName",
-			},
-			"page_name_fallback_tostring": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Check to allow Page Name Fallback to Screen",
-			},
-			"mobile_event_mapping": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder mobile events.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Context Data path.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Adobe Context Data property name",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"send_false_values": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Check to allow sending false value from properties",
-			},
-			"e_var_mapping": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder properties to Adobe eVars",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Property",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the eVar Index",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"hier_mapping": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder properties to Adobe hierarchy properties",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Property",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the eVar Index",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"list_mapping": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder properties to Adobe list properties",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Property as an array/string seperated by commas",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the eVar Index",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"list_delimiter": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map your Rudder Property with delimiters for list properties",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Property.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the List Delimiter.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^$|(^env[.].+)|^(\\||:|,|;|\\/)$"),
-						},
-					},
-				},
-			},
-			"custom_props_mapping": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder properties to Adobe Custom properties",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Property.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the prop Index.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"props_delimiter": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map your Rudder property with delimiters for Adobe custom properties",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Property.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the List Delimiter.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^$|(^env[.].+)|^(\\||:|,|;|\\/)$"),
-						},
-					},
-				},
-			},
-			"event_merch_event_to_adobe_event": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder events to Adobe merchandise events.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Event.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Adobe Event.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"event_merch_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Currency/Incremental properties to add to merchandise events at event level",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"product_merch_event_to_adobe_event": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder events to Adobe merchandise events",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Event.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Adobe Event.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"product_merch_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Currency/Incremental properties to add to merchandise events at product level",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"product_merch_evars_map": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can map Rudder properties to eVars at product level",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the Rudder Event.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the eVar Index.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"product_identifier": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your Product Identifier",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(name|id|sku)$"),
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send events to Adobe Analytics via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"ios": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"android": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "This option allows you to filter the events you want to send to Adobe Analytics.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_adobe_analytics_test.go
+++ b/rudderstack/integrations/destinations/destination_adobe_analytics_test.go
@@ -12,7 +12,7 @@ func TestDestinationResourceAdobeAnalytics(t *testing.T) {
 		{
 			TerraformCreate: `
 				report_suite_ids = "id001, id002"
-			`,
+							`,
 			APICreate: `{
 				"reportSuiteIds": "id001, id002",
   				"sslHeartbeat": true,
@@ -90,7 +90,19 @@ func TestDestinationResourceAdobeAnalytics(t *testing.T) {
 					from = "phone"
 					to = "1"
 					}]
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			  `,
 			APIUpdate: `{
 				"reportSuiteIds": "id003, id004",
@@ -204,11 +216,63 @@ func TestDestinationResourceAdobeAnalytics(t *testing.T) {
 					"eventName": "three"
 				  }
 				],
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				],
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				},
 				"eventFilteringOption": "blacklistedEvents"
 			  }`,
 		},

--- a/rudderstack/integrations/destinations/destination_amplitude.go
+++ b/rudderstack/integrations/destinations/destination_amplitude.go
@@ -6,478 +6,482 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("apiKey", "api_key"),
+		c.Simple("apiSecret", "api_secret"),
+		c.Simple("groupTypeTrait", "group_type_trait", c.SkipZeroValue),
+		c.Simple("groupValueTrait", "group_value_trait", c.SkipZeroValue),
+		c.Simple("trackAllPages", "track_all_pages", c.SkipZeroValue),
+		c.Simple("trackCategorizedPages", "track_categorized_pages", c.SkipZeroValue),
+		c.Simple("trackNamedPages", "track_named_pages", c.SkipZeroValue),
+		c.Simple("trackProductsOnce", "track_products_once", c.SkipZeroValue),
+		c.Simple("trackRevenuePerProduct", "track_revenue_per_product", c.SkipZeroValue),
+		c.Simple("versionName", "version_name", c.SkipZeroValue),
+		c.ArrayWithStrings("traitsToIncrement", "traits", "traits_to_increment"),
+		c.ArrayWithStrings("traitsToSetOnce", "traits", "traits_to_set_once"),
+		c.ArrayWithStrings("traitsToAppend", "traits", "traits_to_append"),
+		c.ArrayWithStrings("traitsToPrepend", "traits", "traits_to_prepend"),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.Simple("useNativeSDK.ios", "use_native_sdk.0.ios"),
+		c.Simple("useNativeSDK.android", "use_native_sdk.0.android"),
+		c.Simple("useNativeSDK.reactnative", "use_native_sdk.0.react_native"),
+		c.Simple("preferAnonymousIdForDeviceId.web", "prefer_anonymous_id_for_device_id.0.web"),
+		c.Simple("deviceIdFromUrlParam.web", "device_id_from_url_param.0.web"),
+		c.Simple("forceHttps.web", "force_https.0.web"),
+		c.Simple("trackGclid.web", "track_gclid.0.web"),
+		c.Simple("trackReferrer.web", "track_referrer.0.web"),
+		c.Simple("saveParamsReferrerOncePerSession.web", "save_params_referrer_once_per_session.0.web"),
+		c.Simple("trackUtmProperties.web", "track_utm_properties.0.web"),
+		c.Simple("unsetParamsReferrerOnNewSession.web", "unset_params_referrer_on_new_session.0.web"),
+		c.Simple("batchEvents.web", "batch_events.0.web"),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.Simple("eventUploadPeriodMillis.web", "event_upload_period_millis.0.web"),
+		c.Simple("eventUploadPeriodMillis.android", "event_upload_period_millis.0.android"),
+		c.Simple("eventUploadPeriodMillis.ios", "event_upload_period_millis.0.ios"),
+		c.Simple("eventUploadPeriodMillis.reactnative", "event_upload_period_millis.0.react_native"),
+		c.Simple("eventUploadThreshold.web", "event_upload_threshold.0.web"),
+		c.Simple("eventUploadThreshold.android", "event_upload_threshold.0.android"),
+		c.Simple("eventUploadThreshold.ios", "event_upload_threshold.0.ios"),
+		c.Simple("eventUploadThreshold.reactnative", "event_upload_threshold.0.react_native"),
+		c.Simple("mapDeviceBrand", "map_device_brand", c.SkipZeroValue),
+		c.Simple("enableLocationListening.android", "enable_location_listening.0.android"),
+		c.Simple("enableLocationListening.reactnative", "enable_location_listening.0.react_native"),
+		c.Simple("trackSessionEvents.android", "track_session_events.0.android"),
+		c.Simple("trackSessionEvents.ios", "track_session_events.0.ios"),
+		c.Simple("trackSessionEvents.reactnative", "track_session_events.0.react_native"),
+		c.Simple("useAdvertisingIdForDeviceId.android", "use_advertising_id_for_device_id.0.android"),
+		c.Simple("useAdvertisingIdForDeviceId.reactnative", "use_advertising_id_for_device_id.0.react_native"),
+		c.Simple("useIdfaAsDeviceId.ios", "use_idfa_as_device_id.0.ios"),
+		c.Simple("useIdfaAsDeviceId.reactnative", "use_idfa_as_device_id.0.react_native"),
+		c.Simple("residencyServer", "residency_server", c.SkipZeroValue),
+	};
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"api_key": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Amplitude API key.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"api_secret": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Sensitive:        true,
+			Description:      "Enter the Amplitude API Secret key required for user deletion.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"group_type_trait": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "RudderStack will use this value as `groupType` in the `group` calls.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"group_value_trait": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "RudderStack will use this value as `groupValue` in the `group` calls.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"residency_server": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].*)|^(standard|EU)$"),
+		},
+		"track_all_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If this setting is enabled, RudderStack sends an event named `Loaded a page` / `Loaded a Screen` to Amplitude.",
+		},
+		"track_categorized_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If this setting is enabled and if `category` is present in a `page` / `screen` call, then an event named `Viewed {category} page` / `Viewed {category} Screen` will be sent to Amplitude.",
+		},
+		"track_named_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If this setting is enabled and `name` is present in a `page` call, then an event named `Viewed {name} page` will be sent to Amplitude.",
+		},
+		"track_products_once": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If this setting is enabled and if the event payload contains an array of products, then the event is tracked with the original event name and all the products as its property. Otherwise, each product is tracked with event as `Product purchased`.",
+		},
+		"track_revenue_per_product": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If this setting is enabled and if the event payload contains multiple products, each product's revenue is tracked individually.",
+		},
+		"version_name": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "The value of this field is set as the `versionName` of the Amplitude SDK.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"traits_to_increment": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "If this setting is enabled, the value of the corresponding trait will be incremented at Amplitude, with the value provided against the trait in an `identify` call.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"traits_to_set_once": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "If this setting is enabled, the value of the corresponding trait will be set once at Amplitude with the value provided against the trait in an `identify` call.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"traits_to_append": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "If this setting is enabled, the value of the corresponding trait will be appended to the corresponding trait array at Amplitude.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"traits_to_prepend": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "If this setting is enabled, the value of the corresponding trait will be prepended to the corresponding trait array at Amplitude.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send events to Amplitude via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"ios": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"android": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"prefer_anonymous_id_for_device_id": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the device ID will be set as the `anonymousId` generated by RudderStack SDK or by the `anonymousId` set via RudderStack's `setAnonymousId()` method.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"device_id_from_url_param": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the Amplitude SDK will parse the URL parameter and set the device ID from `amp_device_id`.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"force_https": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the events will always be uploaded by the Amplitude SDK to the HTTPS endpoint, otherwise it will use the embedding site's protocol.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"track_gclid": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the Amplitude SDK will capture the `gclid` URL parameters along with the user's `initial_gclid` parameters.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"track_referrer": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the Amplitude SDK will capture the `referrer` and `referring_domain` for each session along with the user's `initial_referrer` and `initial_referring_domain`.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"save_params_referrer_once_per_session": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the corresponding tracking of `gclid`, referrer, UTM parameters will be done once per session.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"track_utm_properties": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the Amplitude SDK parses the UTM parameters in the query string or `_utmz` cookie and includes them as user properties in all uploaded events.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"unset_params_referrer_on_new_session": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is disabled, the existing `referrer` and `utm_parameter` values will be passed to each new session. If enabled, `referrer` and `utm_parameter` properties will be set to `null` upon instantiating a new session.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"batch_events": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If this setting is enabled, the events are batched together and uploaded by the Amplitude SDK.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "This option allows you filter the events you want to send to Amplitude.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"event_upload_period_millis": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If the batch events settings is enabled, this is the amount of time that the SDK waits to upload the events.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"ios": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"android": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_upload_threshold": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "If the batch events settings is enabled, this is the minimum number of events to batch together by the Amplitude SDK.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"ios": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"android": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"map_device_brand": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting for RudderStack to send the device brand information (`context.device.brand`) to Amplitude.",
+		},
+		"enable_location_listening": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to activate location listening.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"android": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"track_session_events": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to track the session events.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"ios": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"android": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"use_advertising_id_for_device_id": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to set the advertising ID as the device ID.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"android": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"use_idfa_as_device_id": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to set the IDFA as the device ID.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"ios": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"react_native": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+	};
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("amplitude", c.ConfigMeta{
 		APIType: "AM",
-		Properties: []c.ConfigProperty{
-			c.Simple("apiKey", "api_key"),
-			c.Simple("apiSecret", "api_secret"),
-			c.Simple("groupTypeTrait", "group_type_trait", c.SkipZeroValue),
-			c.Simple("groupValueTrait", "group_value_trait", c.SkipZeroValue),
-			c.Simple("trackAllPages", "track_all_pages", c.SkipZeroValue),
-			c.Simple("trackCategorizedPages", "track_categorized_pages", c.SkipZeroValue),
-			c.Simple("trackNamedPages", "track_named_pages", c.SkipZeroValue),
-			c.Simple("trackProductsOnce", "track_products_once", c.SkipZeroValue),
-			c.Simple("trackRevenuePerProduct", "track_revenue_per_product", c.SkipZeroValue),
-			c.Simple("versionName", "version_name", c.SkipZeroValue),
-			c.ArrayWithStrings("traitsToIncrement", "traits", "traits_to_increment"),
-			c.ArrayWithStrings("traitsToSetOnce", "traits", "traits_to_set_once"),
-			c.ArrayWithStrings("traitsToAppend", "traits", "traits_to_append"),
-			c.ArrayWithStrings("traitsToPrepend", "traits", "traits_to_prepend"),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.Simple("useNativeSDK.ios", "use_native_sdk.0.ios"),
-			c.Simple("useNativeSDK.android", "use_native_sdk.0.android"),
-			c.Simple("useNativeSDK.reactnative", "use_native_sdk.0.react_native"),
-			c.Simple("preferAnonymousIdForDeviceId.web", "prefer_anonymous_id_for_device_id.0.web"),
-			c.Simple("deviceIdFromUrlParam.web", "device_id_from_url_param.0.web"),
-			c.Simple("forceHttps.web", "force_https.0.web"),
-			c.Simple("trackGclid.web", "track_gclid.0.web"),
-			c.Simple("trackReferrer.web", "track_referrer.0.web"),
-			c.Simple("saveParamsReferrerOncePerSession.web", "save_params_referrer_once_per_session.0.web"),
-			c.Simple("trackUtmProperties.web", "track_utm_properties.0.web"),
-			c.Simple("unsetParamsReferrerOnNewSession.web", "unset_params_referrer_on_new_session.0.web"),
-			c.Simple("batchEvents.web", "batch_events.0.web"),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.Simple("eventUploadPeriodMillis.web", "event_upload_period_millis.0.web"),
-			c.Simple("eventUploadPeriodMillis.android", "event_upload_period_millis.0.android"),
-			c.Simple("eventUploadPeriodMillis.ios", "event_upload_period_millis.0.ios"),
-			c.Simple("eventUploadPeriodMillis.reactnative", "event_upload_period_millis.0.react_native"),
-			c.Simple("eventUploadThreshold.web", "event_upload_threshold.0.web"),
-			c.Simple("eventUploadThreshold.android", "event_upload_threshold.0.android"),
-			c.Simple("eventUploadThreshold.ios", "event_upload_threshold.0.ios"),
-			c.Simple("eventUploadThreshold.reactnative", "event_upload_threshold.0.react_native"),
-			c.Simple("mapDeviceBrand", "map_device_brand", c.SkipZeroValue),
-			c.Simple("enableLocationListening.android", "enable_location_listening.0.android"),
-			c.Simple("enableLocationListening.reactnative", "enable_location_listening.0.react_native"),
-			c.Simple("trackSessionEvents.android", "track_session_events.0.android"),
-			c.Simple("trackSessionEvents.ios", "track_session_events.0.ios"),
-			c.Simple("trackSessionEvents.reactnative", "track_session_events.0.react_native"),
-			c.Simple("useAdvertisingIdForDeviceId.android", "use_advertising_id_for_device_id.0.android"),
-			c.Simple("useAdvertisingIdForDeviceId.reactnative", "use_advertising_id_for_device_id.0.react_native"),
-			c.Simple("useIdfaAsDeviceId.ios", "use_idfa_as_device_id.0.ios"),
-			c.Simple("useIdfaAsDeviceId.reactnative", "use_idfa_as_device_id.0.react_native"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-			c.Simple("residencyServer", "residency_server", c.SkipZeroValue),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"api_key": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Amplitude API key.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"api_secret": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Sensitive:        true,
-				Description:      "Enter the Amplitude API Secret key required for user deletion.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"group_type_trait": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "RudderStack will use this value as `groupType` in the `group` calls.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"group_value_trait": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "RudderStack will use this value as `groupValue` in the `group` calls.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"residency_server": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].*)|^(standard|EU)$"),
-			},
-			"track_all_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If this setting is enabled, RudderStack sends an event named `Loaded a page` / `Loaded a Screen` to Amplitude.",
-			},
-			"track_categorized_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If this setting is enabled and if `category` is present in a `page` / `screen` call, then an event named `Viewed {category} page` / `Viewed {category} Screen` will be sent to Amplitude.",
-			},
-			"track_named_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If this setting is enabled and `name` is present in a `page` call, then an event named `Viewed {name} page` will be sent to Amplitude.",
-			},
-			"track_products_once": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If this setting is enabled and if the event payload contains an array of products, then the event is tracked with the original event name and all the products as its property. Otherwise, each product is tracked with event as `Product purchased`.",
-			},
-			"track_revenue_per_product": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If this setting is enabled and if the event payload contains multiple products, each product's revenue is tracked individually.",
-			},
-			"version_name": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "The value of this field is set as the `versionName` of the Amplitude SDK.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"traits_to_increment": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "If this setting is enabled, the value of the corresponding trait will be incremented at Amplitude, with the value provided against the trait in an `identify` call.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"traits_to_set_once": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "If this setting is enabled, the value of the corresponding trait will be set once at Amplitude with the value provided against the trait in an `identify` call.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"traits_to_append": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "If this setting is enabled, the value of the corresponding trait will be appended to the corresponding trait array at Amplitude.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"traits_to_prepend": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "If this setting is enabled, the value of the corresponding trait will be prepended to the corresponding trait array at Amplitude.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send events to Amplitude via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"ios": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"android": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"prefer_anonymous_id_for_device_id": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the device ID will be set as the `anonymousId` generated by RudderStack SDK or by the `anonymousId` set via RudderStack's `setAnonymousId()` method.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"device_id_from_url_param": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the Amplitude SDK will parse the URL parameter and set the device ID from `amp_device_id`.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"force_https": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the events will always be uploaded by the Amplitude SDK to the HTTPS endpoint, otherwise it will use the embedding site's protocol.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"track_gclid": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the Amplitude SDK will capture the `gclid` URL parameters along with the user's `initial_gclid` parameters.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"track_referrer": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the Amplitude SDK will capture the `referrer` and `referring_domain` for each session along with the user's `initial_referrer` and `initial_referring_domain`.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"save_params_referrer_once_per_session": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the corresponding tracking of `gclid`, referrer, UTM parameters will be done once per session.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"track_utm_properties": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the Amplitude SDK parses the UTM parameters in the query string or `_utmz` cookie and includes them as user properties in all uploaded events.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"unset_params_referrer_on_new_session": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is disabled, the existing `referrer` and `utm_parameter` values will be passed to each new session. If enabled, `referrer` and `utm_parameter` properties will be set to `null` upon instantiating a new session.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"batch_events": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If this setting is enabled, the events are batched together and uploaded by the Amplitude SDK.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "This option allows you filter the events you want to send to Amplitude.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"event_upload_period_millis": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If the batch events settings is enabled, this is the amount of time that the SDK waits to upload the events.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"ios": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"android": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_upload_threshold": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "If the batch events settings is enabled, this is the minimum number of events to batch together by the Amplitude SDK.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"ios": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"android": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"map_device_brand": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting for RudderStack to send the device brand information (`context.device.brand`) to Amplitude.",
-			},
-			"enable_location_listening": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to activate location listening.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"android": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"track_session_events": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to track the session events.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"ios": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"android": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"use_advertising_id_for_device_id": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to set the advertising ID as the device ID.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"android": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"use_idfa_as_device_id": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to set the IDFA as the device ID.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"ios": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"react_native": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_amplitude_test.go
+++ b/rudderstack/integrations/destinations/destination_amplitude_test.go
@@ -122,7 +122,19 @@ func TestDestinationResourceAmplitude(t *testing.T) {
 				  blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 
 				residency_server = "EU"
 			`,
@@ -195,11 +207,63 @@ func TestDestinationResourceAmplitude(t *testing.T) {
 				"trackSessionEvents": { "android": true, "ios": true, "reactnative": true },
 				"useAdvertisingIdForDeviceId": { "android": true, "reactnative": true },
 				"useIdfaAsDeviceId": { "ios": true, "reactnative": true },
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				],
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				},
 				"residencyServer": "EU"
 			}`,
 		},

--- a/rudderstack/integrations/destinations/destination_bigquery.go
+++ b/rudderstack/integrations/destinations/destination_bigquery.go
@@ -6,104 +6,108 @@ import (
 )
 
 func init() {
-	c.Destinations.Register("bigquery", c.ConfigMeta{
-		APIType: "BQ",
-		Properties: []c.ConfigProperty{
-			c.Simple("project", "project"),
-			c.Simple("location", "location", c.SkipZeroValue),
-			c.Simple("bucketName", "bucket_name"),
-			c.Simple("prefix", "prefix", c.SkipZeroValue),
-			c.Simple("namespace", "namespace", c.SkipZeroValue),
-			c.Simple("credentials", "credentials"),
-			c.Simple("syncFrequency", "sync.0.frequency"),
-			c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
-			c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
-			c.Simple("excludeWindow.excludeWindowEndTime", "sync.0.exclude_window_end_time", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("project", "project"),
+		c.Simple("location", "location", c.SkipZeroValue),
+		c.Simple("bucketName", "bucket_name"),
+		c.Simple("prefix", "prefix", c.SkipZeroValue),
+		c.Simple("namespace", "namespace", c.SkipZeroValue),
+		c.Simple("credentials", "credentials"),
+		c.Simple("syncFrequency", "sync.0.frequency"),
+		c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
+		c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
+		c.Simple("excludeWindow.excludeWindowEndTime", "sync.0.exclude_window_end_time", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"project": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your GCP project ID where the BigQuery database is located.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
 		},
-		ConfigSchema: map[string]*schema.Schema{
-			"project": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your GCP project ID where the BigQuery database is located.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"location": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter the GCP region of your project dataset.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"bucket_name": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter the name of your staging storage bucket.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"prefix": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "If specified, RudderStack creates a folder in the bucket with this prefix and loads all the data in it.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"namespace": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter the schema name where RudderStack will create all the tables. If not specified, RudderStack will set this to the source name by default.",
-				ValidateDiagFunc: c.ValidateAll(
-					c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
-					c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
-				),
-			},
-			"credentials": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Sensitive:        true,
-				Description:      "Enter your GCP service account credentials JSON.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
-			},
-			"sync": {
-				Type:     schema.TypeList,
-				MinItems: 1, MaxItems: 1,
-				Required:    true,
-				Description: "Enter the sync settings for the following fields:",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"frequency": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify how often RudderStack should sync the data to your BigQuery dataset.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
-						},
-						"start_at": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to BigQuery.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-						"exclude_window_start_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Set a time window when RudderStack will not sync the data to your database.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-						"exclude_window_end_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Specify the end time for the exclusion window.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
+		"location": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter the GCP region of your project dataset.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"bucket_name": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter the name of your staging storage bucket.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"prefix": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "If specified, RudderStack creates a folder in the bucket with this prefix and loads all the data in it.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"namespace": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Enter the schema name where RudderStack will create all the tables. If not specified, RudderStack will set this to the source name by default.",
+			ValidateDiagFunc: c.ValidateAll(
+				c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
+				c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
+			),
+		},
+		"credentials": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Sensitive:        true,
+			Description:      "Enter your GCP service account credentials JSON.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
+		},
+		"sync": {
+			Type:     schema.TypeList,
+			MinItems: 1, MaxItems: 1,
+			Required:    true,
+			Description: "Enter the sync settings for the following fields:",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"frequency": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify how often RudderStack should sync the data to your BigQuery dataset.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
+					},
+					"start_at": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to BigQuery.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+					"exclude_window_start_time": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Set a time window when RudderStack will not sync the data to your database.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+					"exclude_window_end_time": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Specify the end time for the exclusion window.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
 					},
 				},
 			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
+	c.Destinations.Register("bigquery", c.ConfigMeta{
+		APIType: "BQ",
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_bigquery_test.go
+++ b/rudderstack/integrations/destinations/destination_bigquery_test.go
@@ -40,7 +40,19 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 					exclude_window_start_time = "11:00"
 					exclude_window_end_time   = "12:00"
 				}
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"project": "project",
@@ -55,11 +67,63 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 					"excludeWindowStartTime": "11:00",
 					"excludeWindowEndTime": "12:00"
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_customerio.go
+++ b/rudderstack/integrations/destinations/destination_customerio.go
@@ -6,97 +6,101 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("siteID", "site_id"),
+		c.Simple("apiKey", "api_key"),
+		c.Simple("deviceTokenEventName", "device_token_event_name", c.SkipZeroValue),
+		c.Simple("datacenterEU", "datacenter_eu", c.SkipZeroValue),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"site_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Customer.io site ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"api_key": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Sensitive:        true,
+			Description:      "Enter your Customer.io API key.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"device_token_event_name": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter the name of the event that is fired immediately after setting the device token.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"datacenter_eu": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this option in case your account is based in the EU region.",
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events through Customer.io's native JavaScript SDK.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "RudderStack lets you determine which events should be allowed to flow through or blocked.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("customerio", c.ConfigMeta{
 		APIType: "CUSTOMERIO",
-		Properties: []c.ConfigProperty{
-			c.Simple("siteID", "site_id"),
-			c.Simple("apiKey", "api_key"),
-			c.Simple("deviceTokenEventName", "device_token_event_name", c.SkipZeroValue),
-			c.Simple("datacenterEU", "datacenter_eu", c.SkipZeroValue),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"site_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Customer.io site ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"api_key": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Sensitive:        true,
-				Description:      "Enter your Customer.io API key.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"device_token_event_name": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter the name of the event that is fired immediately after setting the device token.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"datacenter_eu": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this option in case your account is based in the EU region.",
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events through Customer.io's native JavaScript SDK.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "RudderStack lets you determine which events should be allowed to flow through or blocked.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_customerio_test.go
+++ b/rudderstack/integrations/destinations/destination_customerio_test.go
@@ -20,7 +20,19 @@ func TestDestinationResourceCustomerIO(t *testing.T) {
 				}
 
 				
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APICreate: `{
 				"siteID": "cd820c1b31d8f2696f3b",
@@ -29,11 +41,63 @@ func TestDestinationResourceCustomerIO(t *testing.T) {
 				"useNativeSDK": {
 					"web": true
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 			TerraformUpdate: `
 				site_id = "cd820c1b31d8f2696f3b"

--- a/rudderstack/integrations/destinations/destination_facebook_pixel.go
+++ b/rudderstack/integrations/destinations/destination_facebook_pixel.go
@@ -6,229 +6,233 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("pixelId", "pixel_id"),
+		c.Simple("accessToken", "access_token", c.SkipZeroValue),
+		c.Simple("standardPageCall", "standard_page_call", c.SkipZeroValue),
+		c.Simple("valueFieldIdentifier", "value_field_identifier", c.SkipZeroValue),
+		c.Simple("advancedMapping", "advanced_mapping", c.SkipZeroValue),
+		c.Simple("testDestination", "test_destination", c.SkipZeroValue),
+		c.Simple("testEventCode", "test_event_code", c.SkipZeroValue),
+		c.Simple("eventsToEvents", "events_to_events", c.SkipZeroValue),
+		c.ArrayWithStrings("eventCustomProperties", "eventCustomProperties", "event_custom_properties"),
+		c.ArrayWithObjects("blacklistPiiProperties", "blacklist_pii_properties", map[string]string{
+			"blacklistPiiProperties": "property",
+			"blacklistPiiHash":       "hash",
+		}),
+		c.ArrayWithObjects("whitelistPiiProperties", "whitelist_pii_properties", map[string]string{
+			"whitelistPiiProperties": "property",
+		}),
+		c.Simple("categoryToContent", "category_to_content", c.SkipZeroValue),
+		c.Simple("legacyConversionPixelId.from", "legacy_conversion_pixel_id.0.from"),
+		c.Simple("legacyConversionPixelId.to", "legacy_conversion_pixel_id.0.to"),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"pixel_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Facebook Pixel ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"access_token": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Sensitive:        true,
+			Description:      "Enter your Facebook business access token required to send the events via the cloud mode.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,208})$"),
+		},
+		"standard_page_call": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If this setting is enabled, RudderStack sets `pageview` as a standard event for all the `page` and `screen` calls.",
+		},
+		"value_field_identifier": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "You can set this field to `properties.price` or `properties.value`. RudderStack will then assign this to the value field of the Facebook payload.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(properties.value|properties.price)$"),
+		},
+		"advanced_mapping": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "With this setting, you can enable the advanced mapping feature.",
+		},
+		"test_destination": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting if you are using this destination for testing purposes.",
+		},
+		"test_event_code": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "If the above setting is enabled, enter the relevant test event code.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"events_to_events": {
+			Type:        schema.TypeList,
+			MaxItems:    10,
+			Optional:    true,
+			Description: "You can map your events to standard Facebook events using this setting.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"event_custom_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "For the standard events, some predefined properties are taken by Facebook. If you want to send more properties for your events, mention those properties in this field.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"blacklist_pii_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Enter the PII properties to be blacklisted.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"property": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"hash": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+		"whitelist_pii_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Enter the PII properties to be whitelisted.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"property": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"category_to_content": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "This option lets you specify the category fields to specific Facebook content type.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"legacy_conversion_pixel_id": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "With this setting, you can send specific events to a legacy conversion Pixel by specifying the event-Pixel ID mapping. Note that this option is available only when sending events via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send events from the web SDK to Facebook Pixel via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "This setting lets you determine which events are blocked or allowed to flowed through to Facebook Pixel.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("facebook_pixel", c.ConfigMeta{
 		APIType: "FACEBOOK_PIXEL",
-		Properties: []c.ConfigProperty{
-			c.Simple("pixelId", "pixel_id"),
-			c.Simple("accessToken", "access_token", c.SkipZeroValue),
-			c.Simple("standardPageCall", "standard_page_call", c.SkipZeroValue),
-			c.Simple("valueFieldIdentifier", "value_field_identifier", c.SkipZeroValue),
-			c.Simple("advancedMapping", "advanced_mapping", c.SkipZeroValue),
-			c.Simple("testDestination", "test_destination", c.SkipZeroValue),
-			c.Simple("testEventCode", "test_event_code", c.SkipZeroValue),
-			c.Simple("eventsToEvents", "events_to_events", c.SkipZeroValue),
-			c.ArrayWithStrings("eventCustomProperties", "eventCustomProperties", "event_custom_properties"),
-			c.ArrayWithObjects("blacklistPiiProperties", "blacklist_pii_properties", map[string]string{
-				"blacklistPiiProperties": "property",
-				"blacklistPiiHash":       "hash",
-			}),
-			c.ArrayWithObjects("whitelistPiiProperties", "whitelist_pii_properties", map[string]string{
-				"whitelistPiiProperties": "property",
-			}),
-			c.Simple("categoryToContent", "category_to_content", c.SkipZeroValue),
-			c.Simple("legacyConversionPixelId.from", "legacy_conversion_pixel_id.0.from"),
-			c.Simple("legacyConversionPixelId.to", "legacy_conversion_pixel_id.0.to"),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"pixel_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Facebook Pixel ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"access_token": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Sensitive:        true,
-				Description:      "Enter your Facebook business access token required to send the events via the cloud mode.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,208})$"),
-			},
-			"standard_page_call": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If this setting is enabled, RudderStack sets `pageview` as a standard event for all the `page` and `screen` calls.",
-			},
-			"value_field_identifier": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "You can set this field to `properties.price` or `properties.value`. RudderStack will then assign this to the value field of the Facebook payload.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(properties.value|properties.price)$"),
-			},
-			"advanced_mapping": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "With this setting, you can enable the advanced mapping feature.",
-			},
-			"test_destination": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting if you are using this destination for testing purposes.",
-			},
-			"test_event_code": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "If the above setting is enabled, enter the relevant test event code.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"events_to_events": {
-				Type:        schema.TypeList,
-				MaxItems:    10,
-				Optional:    true,
-				Description: "You can map your events to standard Facebook events using this setting.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"event_custom_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "For the standard events, some predefined properties are taken by Facebook. If you want to send more properties for your events, mention those properties in this field.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"blacklist_pii_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Enter the PII properties to be blacklisted.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"property": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"hash": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-					},
-				},
-			},
-			"whitelist_pii_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Enter the PII properties to be whitelisted.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"property": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"category_to_content": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "This option lets you specify the category fields to specific Facebook content type.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"legacy_conversion_pixel_id": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "With this setting, you can send specific events to a legacy conversion Pixel by specifying the event-Pixel ID mapping. Note that this option is available only when sending events via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send events from the web SDK to Facebook Pixel via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "This setting lets you determine which events are blocked or allowed to flowed through to Facebook Pixel.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_facebook_pixel_test.go
+++ b/rudderstack/integrations/destinations/destination_facebook_pixel_test.go
@@ -75,7 +75,19 @@ func TestDestinationResourceFacebookPixel(t *testing.T) {
 				  blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"pixelId": "facebook pixel id",
@@ -105,11 +117,63 @@ func TestDestinationResourceFacebookPixel(t *testing.T) {
 				"categoryToContent": [{ "from": "from", "to": "to" }],
 				"legacyConversionPixelId": { "from": "from", "to": "to" },
 				"useNativeSDK": { "web": true },
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				],
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				},
 				"blacklistedEvents": [
 				  { "eventName": "one" },
 				  { "eventName": "two" },

--- a/rudderstack/integrations/destinations/destination_gcs.go
+++ b/rudderstack/integrations/destinations/destination_gcs.go
@@ -6,42 +6,46 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("bucketName", "bucket_name"),
+		c.Simple("prefix", "prefix", c.SkipZeroValue),
+		c.Simple("credentials", "credentials", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"bucket_name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter your Google Cloud Storage bucket name.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"prefix": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Enter your prefix which RudderStack associates with your GCS bucket before loading all the data into it.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"credentials": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Enter the contents of your Google Cloud connection credentials JSON.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("gcs", c.ConfigMeta{
 		APIType: "GCS",
-		Properties: []c.ConfigProperty{
-			c.Simple("bucketName", "bucket_name"),
-			c.Simple("prefix", "prefix", c.SkipZeroValue),
-			c.Simple("credentials", "credentials", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"bucket_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter your Google Cloud Storage bucket name.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"prefix": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter your prefix which RudderStack associates with your GCS bucket before loading all the data into it.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"credentials": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Enter the contents of your Google Cloud connection credentials JSON.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_gcs_test.go
+++ b/rudderstack/integrations/destinations/destination_gcs_test.go
@@ -20,17 +20,81 @@ func TestDestinationResourceGCS(t *testing.T) {
 				bucket_name = "bucket"
 				prefix        = "prefix"
 				credentials   = "..."
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"bucketName": "bucket",
 				"prefix": "prefix",
 				"credentials": "...",
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_google_ads.go
+++ b/rudderstack/integrations/destinations/destination_google_ads.go
@@ -6,168 +6,172 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("conversionID", "conversion_id"),
+		c.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]string{
+			"conversionLabel": "label",
+			"name":            "name",
+		}),
+		c.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]string{
+			"conversionLabel": "label",
+			"name":            "name",
+		}),
+		c.Simple("defaultPageConversion", "default_page_conversion", c.SkipZeroValue),
+		c.Simple("dynamicRemarketing.web", "dynamic_remarketing.0.web"),
+		c.Simple("conversionLinker", "conversion_linker", c.SkipZeroValue),
+		c.Simple("sendPageView", "send_page_view", c.SkipZeroValue),
+		c.Simple("disableAdPersonalization", "disable_ad_personalization", c.SkipZeroValue),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"conversion_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Google Ads Conversion ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^AW-(.{0,100})$"),
+		},
+		"page_load_conversions": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "You can configure the page load conversions for multiple instances.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"label": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Provide the conversion label from Google Ads.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the name of the `page` event to be sent to Google Ads.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"click_event_conversions": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "For `track` calls, you can configure these fields.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"label": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter your Google Ads conversion label.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the name of the `track` event to be sent to Google Ads.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"default_page_conversion": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter the default conversion label.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"dynamic_remarketing": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enabling this tracking mode allows RudderStack to leverage Google Ads' Dynamic Remarketing feature for event tracking.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"conversion_linker": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This setting is enabled by default. If you don't want the global site tag (gtag.js) to set first-party cookies on your website domain, you should disable this setting.",
+		},
+		"send_page_view": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enabling this setting configures Google Ads to automatically send your `page` events.",
+		},
+		"disable_ad_personalization": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to programmatically disable ad personalization.",
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "With this option, you can determine which events are blocked or allowed to flow through to Google Ads.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "As this is a device mode destination, this setting will always be enabled.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("google_ads", c.ConfigMeta{
 		APIType: "GOOGLEADS",
-		Properties: []c.ConfigProperty{
-			c.Simple("conversionID", "conversion_id"),
-			c.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]string{
-				"conversionLabel": "label",
-				"name":            "name",
-			}),
-			c.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]string{
-				"conversionLabel": "label",
-				"name":            "name",
-			}),
-			c.Simple("defaultPageConversion", "default_page_conversion", c.SkipZeroValue),
-			c.Simple("dynamicRemarketing.web", "dynamic_remarketing.0.web"),
-			c.Simple("conversionLinker", "conversion_linker", c.SkipZeroValue),
-			c.Simple("sendPageView", "send_page_view", c.SkipZeroValue),
-			c.Simple("disableAdPersonalization", "disable_ad_personalization", c.SkipZeroValue),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"conversion_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Google Ads Conversion ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^AW-(.{0,100})$"),
-			},
-			"page_load_conversions": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "You can configure the page load conversions for multiple instances.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"label": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Provide the conversion label from Google Ads.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the name of the `page` event to be sent to Google Ads.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"click_event_conversions": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "For `track` calls, you can configure these fields.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"label": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter your Google Ads conversion label.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the name of the `track` event to be sent to Google Ads.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"default_page_conversion": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter the default conversion label.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"dynamic_remarketing": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enabling this tracking mode allows RudderStack to leverage Google Ads' Dynamic Remarketing feature for event tracking.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"conversion_linker": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This setting is enabled by default. If you don't want the global site tag (gtag.js) to set first-party cookies on your website domain, you should disable this setting.",
-			},
-			"send_page_view": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enabling this setting configures Google Ads to automatically send your `page` events.",
-			},
-			"disable_ad_personalization": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to programmatically disable ad personalization.",
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "With this option, you can determine which events are blocked or allowed to flow through to Google Ads.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "As this is a device mode destination, this setting will always be enabled.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_google_ads_test.go
+++ b/rudderstack/integrations/destinations/destination_google_ads_test.go
@@ -51,7 +51,9 @@ func TestDestinationResourceGoogleAds(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"conversionID": "AW-00000000",
@@ -89,11 +91,13 @@ func TestDestinationResourceGoogleAds(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_google_analytics.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics.go
@@ -6,348 +6,352 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("trackingID", "tracking_id"),
+		c.Simple("doubleClick", "double_click", c.SkipZeroValue),
+		c.Simple("enhancedLinkAttribution", "enhanced_link_attribution", c.SkipZeroValue),
+		c.Simple("includeSearch", "include_search", c.SkipZeroValue),
+		c.Simple("serverSideIdentifyEventCategory", "server_side_identify.0.event_category"),
+		c.Simple("serverSideIdentifyEventAction", "server_side_identify.0.event_action"),
+		c.Discriminator("enableServerSideIdentify", c.DiscriminatorValues{
+			"server_side_identify.0.event_category": true,
+		}),
+		c.Simple("disableMd5", "disable_md5", c.SkipZeroValue),
+		c.Simple("anonymizeIp", "anonymize_ip", c.SkipZeroValue),
+		c.Simple("enhancedEcommerce", "enhanced_ecommerce", c.SkipZeroValue),
+		c.Simple("nonInteraction", "non_interaction", c.SkipZeroValue),
+		c.Simple("sendUserId", "send_user_id", c.SkipZeroValue),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.Simple("trackCategorizedPages.web", "track_categorized_pages.0.web"),
+		c.Simple("trackNamedPages.web", "track_named_pages.0.web"),
+		c.Simple("sampleRate.web", "sample_rate.0.web"),
+		c.Simple("siteSpeedSampleRate.web", "site_speed_sample_rate.0.web"),
+		c.ArrayWithStrings("resetCustomDimensionsOnPage.web", "resetCustomDimensionsOnPage", "reset_custom_dimensions_on_page.0.web"),
+		c.Simple("setAllMappedProps.web", "set_all_mapped_props.0.web"),
+		c.Simple("domain.web", "domain.0.web"),
+		c.Simple("optimize.web", "optimize.0.web"),
+		c.Simple("useGoogleAmpClientId.web", "use_google_amp_client_id.0.web"),
+		c.Simple("namedTracker.web", "named_tracker.0.web"),
+		c.Simple("dimensions", "dimensions", c.SkipZeroValue),
+		c.Simple("contentGroupings", "content_groupings", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"tracking_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Google Analytics Tracking ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(UA|YT|MO)-\\d+-\\d{0,100}$)"),
+		},
+		"double_click": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"enhanced_link_attribution": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to activate the Google Analytics enhanced link attribution feature.",
+		},
+		"include_search": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to include the querystring in `page` views.",
+		},
+		"server_side_identify": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"event_category": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the server-side `identify` event category.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
+					},
+					"event_action": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the server-side `identify` event action.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
+					},
+				},
+			},
+		},
+		"disable_md5": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to disable client ID MD5 encryption.",
+		},
+		"anonymize_ip": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enabling this setting anonymizes your IP address information.",
+		},
+		"enhanced_ecommerce": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to activate the enhanced e-commerce feature.",
+		},
+		"non_interaction": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to add the non-interaction flag to all the events.",
+		},
+		"send_user_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to send the `userId` to Google Analytics.",
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "This setting allows you to specify which events should be blocked or allowed to flow through to Google Analytics.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted..",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events via the web device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"track_categorized_pages": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to track categorized pages.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"track_named_pages": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to track named pages.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"sample_rate": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enter the sample rate.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
+					},
+				},
+			},
+		},
+		"site_speed_sample_rate": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enter the site speed sample rate.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
+					},
+				},
+			},
+		},
+		"reset_custom_dimensions_on_page": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Use this field to reset the dimensions for the `page` calls.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"set_all_mapped_props": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Use this field to set all the mapped properties.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"domain": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enter your cookie domain name.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
+					},
+				},
+			},
+		},
+		"optimize": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enter your Google Optimize Container ID.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
+					},
+				},
+			},
+		},
+		"use_google_amp_client_id": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to use the Google AMP Client ID",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+		"named_tracker": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send events with the `track` name `rudderGATracker`.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+		"content_groupings": {
+			Type:       schema.TypeList,
+			MaxItems:   10,
+			Optional:   true,
+			ConfigMode: schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+		"dimensions": {
+			Type:       schema.TypeList,
+			MaxItems:   10,
+			Optional:   true,
+			ConfigMode: schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("google_analytics", c.ConfigMeta{
 		APIType: "GA",
-		Properties: []c.ConfigProperty{
-			c.Simple("trackingID", "tracking_id"),
-			c.Simple("doubleClick", "double_click", c.SkipZeroValue),
-			c.Simple("enhancedLinkAttribution", "enhanced_link_attribution", c.SkipZeroValue),
-			c.Simple("includeSearch", "include_search", c.SkipZeroValue),
-			c.Simple("serverSideIdentifyEventCategory", "server_side_identify.0.event_category"),
-			c.Simple("serverSideIdentifyEventAction", "server_side_identify.0.event_action"),
-			c.Discriminator("enableServerSideIdentify", c.DiscriminatorValues{
-				"server_side_identify.0.event_category": true,
-			}),
-			c.Simple("disableMd5", "disable_md5", c.SkipZeroValue),
-			c.Simple("anonymizeIp", "anonymize_ip", c.SkipZeroValue),
-			c.Simple("enhancedEcommerce", "enhanced_ecommerce", c.SkipZeroValue),
-			c.Simple("nonInteraction", "non_interaction", c.SkipZeroValue),
-			c.Simple("sendUserId", "send_user_id", c.SkipZeroValue),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.Simple("trackCategorizedPages.web", "track_categorized_pages.0.web"),
-			c.Simple("trackNamedPages.web", "track_named_pages.0.web"),
-			c.Simple("sampleRate.web", "sample_rate.0.web"),
-			c.Simple("siteSpeedSampleRate.web", "site_speed_sample_rate.0.web"),
-			c.ArrayWithStrings("resetCustomDimensionsOnPage.web", "resetCustomDimensionsOnPage", "reset_custom_dimensions_on_page.0.web"),
-			c.Simple("setAllMappedProps.web", "set_all_mapped_props.0.web"),
-			c.Simple("domain.web", "domain.0.web"),
-			c.Simple("optimize.web", "optimize.0.web"),
-			c.Simple("useGoogleAmpClientId.web", "use_google_amp_client_id.0.web"),
-			c.Simple("namedTracker.web", "named_tracker.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-			c.Simple("dimensions", "dimensions", c.SkipZeroValue),
-			c.Simple("contentGroupings", "content_groupings", c.SkipZeroValue),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"tracking_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Google Analytics Tracking ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(UA|YT|MO)-\\d+-\\d{0,100}$)"),
-			},
-			"double_click": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"enhanced_link_attribution": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to activate the Google Analytics enhanced link attribution feature.",
-			},
-			"include_search": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to include the querystring in `page` views.",
-			},
-			"server_side_identify": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"event_category": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the server-side `identify` event category.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
-						},
-						"event_action": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the server-side `identify` event action.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
-						},
-					},
-				},
-			},
-			"disable_md5": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to disable client ID MD5 encryption.",
-			},
-			"anonymize_ip": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enabling this setting anonymizes your IP address information.",
-			},
-			"enhanced_ecommerce": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to activate the enhanced e-commerce feature.",
-			},
-			"non_interaction": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to add the non-interaction flag to all the events.",
-			},
-			"send_user_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to send the `userId` to Google Analytics.",
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "This setting allows you to specify which events should be blocked or allowed to flow through to Google Analytics.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted..",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events via the web device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"track_categorized_pages": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to track categorized pages.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"track_named_pages": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to track named pages.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"sample_rate": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enter the sample rate.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
-						},
-					},
-				},
-			},
-			"site_speed_sample_rate": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enter the site speed sample rate.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
-						},
-					},
-				},
-			},
-			"reset_custom_dimensions_on_page": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Use this field to reset the dimensions for the `page` calls.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"set_all_mapped_props": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Use this field to set all the mapped properties.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"domain": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enter your cookie domain name.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
-						},
-					},
-				},
-			},
-			"optimize": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enter your Google Optimize Container ID.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^(.{0,100})$)"),
-						},
-					},
-				},
-			},
-			"use_google_amp_client_id": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to use the Google AMP Client ID",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-					},
-				},
-			},
-			"named_tracker": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send events with the `track` name `rudderGATracker`.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"content_groupings": {
-				Type:       schema.TypeList,
-				MaxItems:   10,
-				Optional:   true,
-				ConfigMode: schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-			"dimensions": {
-				Type:       schema.TypeList,
-				MaxItems:   10,
-				Optional:   true,
-				ConfigMode: schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-					},
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_google_analytics4.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics4.go
@@ -6,116 +6,120 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("apiSecret", "api_secret", c.SkipZeroValue),
+		c.Simple("typesOfClient", "types_of_client", c.SkipZeroValue),
+		c.Simple("measurementId", "measurement_id", c.SkipZeroValue),
+		c.Simple("firebaseAppId", "firebase_app_id", c.SkipZeroValue),
+		c.Simple("blockPageViewEvent", "block_page_view_event", c.SkipZeroValue),
+		c.Simple("extendPageViewParams", "extend_page_view_params", c.SkipZeroValue),
+		c.Simple("sendUserId", "send_user_id", c.SkipZeroValue),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"api_secret": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Sensitive:        true,
+			Description:      "This field is required only for the cloud mode setup where you can enter the API Secret generated through the Google Analytics dashboard.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"types_of_client": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Select the client type as gtag or Firebase.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(gtag|firebase)$"),
+		},
+		"measurement_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter the Measurement Id which is the identifier for a data stream.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(G-.{1,100})$|^$"),
+		},
+		"firebase_app_id": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter the Firebase App ID which is the identifier for Firebase app.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"block_page_view_event": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to disable sending `page_view` events on load. This setting is applicable only for device mode.",
+		},
+		"extend_page_view_params": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to send `url` and `search` along with any other custom property to the `page` call of the RudderStack SDK. This setting is applicable only for device mode.",
+		},
+		"send_user_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If enabled, the user ID is set to the identified visitors and sent to Google Analytics 4.",
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "With this option, you can determine which events are blocked or allowed to flow through to Google Analytics 4.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("google_analytics4", c.ConfigMeta{
 		APIType: "GA4",
-		Properties: []c.ConfigProperty{
-			c.Simple("apiSecret", "api_secret", c.SkipZeroValue),
-			c.Simple("typesOfClient", "types_of_client", c.SkipZeroValue),
-			c.Simple("measurementId", "measurement_id", c.SkipZeroValue),
-			c.Simple("firebaseAppId", "firebase_app_id", c.SkipZeroValue),
-			c.Simple("blockPageViewEvent", "block_page_view_event", c.SkipZeroValue),
-			c.Simple("extendPageViewParams", "extend_page_view_params", c.SkipZeroValue),
-			c.Simple("sendUserId", "send_user_id", c.SkipZeroValue),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"api_secret": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Sensitive:        true,
-				Description:      "This field is required only for the cloud mode setup where you can enter the API Secret generated through the Google Analytics dashboard.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"types_of_client": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Select the client type as gtag or Firebase.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(gtag|firebase)$"),
-			},
-			"measurement_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter the Measurement Id which is the identifier for a data stream.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(G-.{1,100})$|^$"),
-			},
-			"firebase_app_id": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter the Firebase App ID which is the identifier for Firebase app.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"block_page_view_event": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to disable sending `page_view` events on load. This setting is applicable only for device mode.",
-			},
-			"extend_page_view_params": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to send `url` and `search` along with any other custom property to the `page` call of the RudderStack SDK. This setting is applicable only for device mode.",
-			},
-			"send_user_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If enabled, the user ID is set to the identified visitors and sent to Google Analytics 4.",
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "With this option, you can determine which events are blocked or allowed to flow through to Google Analytics 4.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_google_analytics4_test.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics4_test.go
@@ -37,7 +37,19 @@ func TestDestinationResourceGoogleAnalytics4(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"apiSecret": "...",
@@ -62,11 +74,63 @@ func TestDestinationResourceGoogleAnalytics4(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_google_analytics_test.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics_test.go
@@ -76,7 +76,19 @@ func TestDestinationResourceGoogleAnalytics(t *testing.T) {
 			      blacklist = ["one", "two", "three"]
 			    }
 		
-			    onetrust_cookie_categories = ["one", "two", "three"]
+			    onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 
 				reset_custom_dimensions_on_page {
 				   web = ["one", "two", "three"]
@@ -127,11 +139,63 @@ func TestDestinationResourceGoogleAnalytics(t *testing.T) {
 						{ "resetCustomDimensionsOnPage": "three" }
 					]
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				],
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				},
 				"contentGroupings": [{ "from": "from", "to": "to" }],
 				"dimensions": [{ "from": "from", "to": "to" }]
 			}`,

--- a/rudderstack/integrations/destinations/destination_google_tag_manager.go
+++ b/rudderstack/integrations/destinations/destination_google_tag_manager.go
@@ -6,83 +6,87 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("containerID", "container_id"),
+		c.Simple("serverUrl", "server_url", c.SkipZeroValue),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"container_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Google Tag Manager container ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"server_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Specify Tag Manager server container URL.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"),
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "With this option, you can determine which events are blocked or allowed to flow through to GTM.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("google_tag_manager", c.ConfigMeta{
 		APIType: "GTM",
-		Properties: []c.ConfigProperty{
-			c.Simple("containerID", "container_id"),
-			c.Simple("serverUrl", "server_url", c.SkipZeroValue),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"container_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Google Tag Manager container ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"server_url": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Specify Tag Manager server container URL.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"),
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "With this option, you can determine which events are blocked or allowed to flow through to GTM.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_google_tag_manager_test.go
+++ b/rudderstack/integrations/destinations/destination_google_tag_manager_test.go
@@ -29,7 +29,9 @@ func TestDestinationResourceGoogleTagManager(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"containerID": "GTM-000000",
@@ -49,11 +51,13 @@ func TestDestinationResourceGoogleTagManager(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_iterable.go
+++ b/rudderstack/integrations/destinations/destination_iterable.go
@@ -6,378 +6,382 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("apiKey", "api_key", c.SkipZeroValue),
+		c.Simple("mapToSingleEvent", "map_to_single_event"),
+		c.Simple("trackAllPages", "track_all_pages", c.SkipZeroValue),
+		c.Simple("trackCategorisedPages", "track_categorized_pages"),
+		c.Simple("trackNamedPages", "track_named_pages"),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.Simple("initialisationIdentifier.web", "initialisation_identifier.0.web", c.SkipZeroValue),
+		c.ArrayWithStrings("getInAppEventMapping.web", "eventName", "get_in_app_event_mapping.0.web"),
+		c.ArrayWithStrings("purchaseEventMapping.web", "eventName", "purchase_event_mapping.0.web"),
+		c.Simple("sendTrackForInapp.web", "send_track_for_inapp.0.web",),
+		c.Simple("animationDuration.web", "animation_duration.0.web"),
+		c.Simple("displayInterval.web", "display_interval.0.web"),
+		c.Simple("onOpenScreenReaderMessage.web", "on_open_screen_reader_message.0.web"),
+		c.Simple("onOpenNodeToTakeFocus.web", "on_open_node_to_take_focus.0.web"),
+		c.Simple("packageName.web", "package_name.0.web"),
+		c.Simple("rightOffset.web", "right_offset.0.web"),
+		c.Simple("topOffset.web", "top_offset.0.web"),
+		c.Simple("bottomOffset.web", "bottom_offset.0.web"),
+		c.Simple("handleLinks.web", "handle_links.0.web"),
+		c.Simple("closeButtonColor.web", "close_button_color.0.web"),
+		c.Simple("closeButtonSize.web", "close_button_size.0.web"),
+		c.Simple("closeButtonColorTopOffset.web", "close_button_color_top_offset.0.web"),
+		c.Simple("closeButtonColorSideOffset.web", "close_button_color_side_offset.0.web"),
+		c.Simple("iconPath.web", "icon_path.0.web"),
+		c.Simple("isRequiredToDismissMessage.web", "is_required_to_dismiss_message.0.web"),
+		c.Simple("closeButtonPosition.web", "close_button_position.0.web"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"api_key": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your Iterable Api Key",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"map_to_single_event": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Map All Pages to Single Event Name",
+		},
+		"track_all_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Track All Pages",
+		},
+		"track_categorized_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Track Categorised Pages",
+		},
+		"track_named_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Track Named Pages",
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send events to Iterable via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+				},
+			},
+		},
+		"initialisation_identifier": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Identifier to identify a user over a session",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"get_in_app_event_mapping": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Mapping to trigger the getInApp messages",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"purchase_event_mapping": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Mapping to trigger the getInApp messages",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"send_track_for_inapp": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Trigger a track event for web in-app push",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default: false,
+					},
+				},
+			},
+		},
+		"animation_duration": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Time (in ms) for messages to animate in and out.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"display_interval": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Wait time for next message",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"on_open_screen_reader_message": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Screen Reader Text",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"on_open_node_to_take_focus": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Focus Element",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"package_name": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Package Name",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		"right_offset": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Space (px or %) between screen right & messages.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"top_offset": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Space (px or %) between screen top & messages.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"bottom_offset": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Space (px or %) between screen bottom & messages.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"handle_links": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Control how to open links.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"close_button_color": {
+			Type:            schema.TypeList,
+			MaxItems:        1,
+			Optional:        true,
+			Description:     "Color of Close button",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"close_button_size": {
+			Type:            schema.TypeList,
+			MaxItems:    	 1,
+			Optional:        true,
+			Description:     "Size of Close button",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"close_button_color_top_offset": {
+			Type:            schema.TypeList,
+			MaxItems:    	 1,
+			Optional:        true,
+			Description:     "Space between button & container top",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"close_button_color_side_offset": {
+			Type:            schema.TypeList,
+			MaxItems:    	 1,
+			Optional:        true,
+			Description:     "Space between button & container side",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"icon_path": {
+			Type:            schema.TypeList,
+			MaxItems:    	 1,
+			Optional:        true,
+			Description:     "Custom pathname",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"is_required_to_dismiss_message": {	
+			Type:            schema.TypeList,
+			MaxItems:    	 1,
+			Optional:        true,
+			Description:     "Prevent user dismissing in-app message by clicking outside message",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"close_button_position": {
+			Type:            schema.TypeList,
+			MaxItems:    	 1,
+			Optional:        true,
+			Description:     "Position",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("iterable", c.ConfigMeta{
 		APIType: "ITERABLE",
-		Properties: []c.ConfigProperty{
-			c.Simple("apiKey", "api_key", c.SkipZeroValue),
-			c.Simple("mapToSingleEvent", "map_to_single_event"),
-			c.Simple("trackAllPages", "track_all_pages", c.SkipZeroValue),
-			c.Simple("trackCategorisedPages", "track_categorized_pages"),
-			c.Simple("trackNamedPages", "track_named_pages"),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.Simple("initialisationIdentifier.web", "initialisation_identifier.0.web", c.SkipZeroValue),
-			c.ArrayWithStrings("getInAppEventMapping.web", "eventName", "get_in_app_event_mapping.0.web"),
-			c.ArrayWithStrings("purchaseEventMapping.web", "eventName", "purchase_event_mapping.0.web"),
-			c.Simple("sendTrackForInapp.web", "send_track_for_inapp.0.web",),
-			c.Simple("animationDuration.web", "animation_duration.0.web"),
-			c.Simple("displayInterval.web", "display_interval.0.web"),
-			c.Simple("onOpenScreenReaderMessage.web", "on_open_screen_reader_message.0.web"),
-			c.Simple("onOpenNodeToTakeFocus.web", "on_open_node_to_take_focus.0.web"),
-			c.Simple("packageName.web", "package_name.0.web"),
-			c.Simple("rightOffset.web", "right_offset.0.web"),
-			c.Simple("topOffset.web", "top_offset.0.web"),
-			c.Simple("bottomOffset.web", "bottom_offset.0.web"),
-			c.Simple("handleLinks.web", "handle_links.0.web"),
-			c.Simple("closeButtonColor.web", "close_button_color.0.web"),
-			c.Simple("closeButtonSize.web", "close_button_size.0.web"),
-			c.Simple("closeButtonColorTopOffset.web", "close_button_color_top_offset.0.web"),
-			c.Simple("closeButtonColorSideOffset.web", "close_button_color_side_offset.0.web"),
-			c.Simple("iconPath.web", "icon_path.0.web"),
-			c.Simple("isRequiredToDismissMessage.web", "is_required_to_dismiss_message.0.web"),
-			c.Simple("closeButtonPosition.web", "close_button_position.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"api_key": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your Iterable Api Key",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"map_to_single_event": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Map All Pages to Single Event Name",
-			},
-			"track_all_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Track All Pages",
-			},
-			"track_categorized_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Track Categorised Pages",
-			},
-			"track_named_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Track Named Pages",
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send events to Iterable via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-					},
-				},
-			},
-			"initialisation_identifier": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Identifier to identify a user over a session",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"get_in_app_event_mapping": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Mapping to trigger the getInApp messages",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"purchase_event_mapping": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Mapping to trigger the getInApp messages",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"send_track_for_inapp": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Trigger a track event for web in-app push",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default: false,
-						},
-					},
-				},
-			},
-			"animation_duration": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Time (in ms) for messages to animate in and out.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"display_interval": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Wait time for next message",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"on_open_screen_reader_message": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Screen Reader Text",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"on_open_node_to_take_focus": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Focus Element",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"package_name": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Package Name",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-			"right_offset": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Space (px or %) between screen right & messages.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"top_offset": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Space (px or %) between screen top & messages.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"bottom_offset": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Space (px or %) between screen bottom & messages.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"handle_links": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Control how to open links.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"close_button_color": {
-				Type:            schema.TypeList,
-				MaxItems:        1,
-				Optional:        true,
-				Description:     "Color of Close button",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"close_button_size": {
-				Type:            schema.TypeList,
-				MaxItems:    	 1,
-				Optional:        true,
-				Description:     "Size of Close button",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"close_button_color_top_offset": {
-				Type:            schema.TypeList,
-				MaxItems:    	 1,
-				Optional:        true,
-				Description:     "Space between button & container top",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"close_button_color_side_offset": {
-				Type:            schema.TypeList,
-				MaxItems:    	 1,
-				Optional:        true,
-				Description:     "Space between button & container side",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"icon_path": {
-				Type:            schema.TypeList,
-				MaxItems:    	 1,
-				Optional:        true,
-				Description:     "Custom pathname",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"is_required_to_dismiss_message": {	
-				Type:            schema.TypeList,
-				MaxItems:    	 1,
-				Optional:        true,
-				Description:     "Prevent user dismissing in-app message by clicking outside message",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"close_button_position": {
-				Type:            schema.TypeList,
-				MaxItems:    	 1,
-				Optional:        true,
-				Description:     "Position",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_iterable_test.go
+++ b/rudderstack/integrations/destinations/destination_iterable_test.go
@@ -91,7 +91,19 @@ func TestDestinationResourceIterable(t *testing.T) {
 				close_button_position { 
 					web = "..." 
 				}
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 
 			`,
 			APIUpdate: `{
@@ -135,11 +147,63 @@ func TestDestinationResourceIterable(t *testing.T) {
 				"iconPath": { "web": "..." },
 				"isRequiredToDismissMessage": { "web": true },
 				"closeButtonPosition": { "web": "..." },
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_mixpanel.go
+++ b/rudderstack/integrations/destinations/destination_mixpanel.go
@@ -6,201 +6,205 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("token", "token"),
+		c.Simple("apiSecret", "api_secret", c.SkipZeroValue),
+		c.Simple("dataResidency", "data_residency"),
+		c.Simple("people", "people", c.SkipZeroValue),
+		c.Simple("setAllTraitsByDefault", "set_all_traits_by_default", c.SkipZeroValue),
+		c.Simple("consolidatedPageCalls", "consolidated_page_calls"),
+		c.Simple("trackCategorizedPages", "track_categorized_pages", c.SkipZeroValue),
+		c.Simple("trackNamedPages", "track_named_pages", c.SkipZeroValue),
+		c.Simple("sourceName", "source_name", c.SkipZeroValue),
+		c.Simple("crossSubdomainCookie", "cross_subdomain_cookie", c.SkipZeroValue),
+		c.Simple("persistence", "persistence"),
+		c.Simple("secureCookie", "secure_cookie", c.SkipZeroValue),
+		c.ArrayWithStrings("superProperties", "property", "super_properties"),
+		c.ArrayWithStrings("peopleProperties", "property", "people_properties"),
+		c.ArrayWithStrings("eventIncrements", "property", "event_increments"),
+		c.ArrayWithStrings("propIncrements", "property", "prop_increments"),
+		c.ArrayWithStrings("groupKeySettings", "groupKey", "group_key_settings"),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Simple("useNewMapping", "use_new_mapping", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"token": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Mixpanel API Token",
+			Sensitive:        true,
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"api_secret": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Sensitive:        true,
+			Description:      "Mixpanel API secret",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"data_residency": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Mixpanel Server region either us/eu",
+			ValidateDiagFunc: c.StringMatchesRegexp("^(us|eu)$"),
+		},
+		"people": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Boolean flag to send all of your identify calls to Mixpanel's People feature ",
+		},
+		"set_all_traits_by_default": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "While this is checked, our integration automatically sets all traits on identify calls as super properties and people properties if Mixpanel People is checked as well.",
+		},
+		"consolidated_page_calls": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "This will track Loaded a Page events to Mixpanel for all page method calls. We enable this by default as it's how Mixpanel suggests sending these calls.",
+		},
+		"track_categorized_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This will track events to Mixpanel for page method calls that have a category associated with them. For example page('Docs', 'Index') would translate to Viewed Docs Index Page.",
+		},
+		"track_named_pages": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This will track events to Mixpanel for page method calls that have a name associated with them. For example page('Signup') would translate to Viewed Signup Page.",
+		},
+		"source_name": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "This value, if it's not blank, will be sent as rudderstack_source_name to Mixpanel for every event/page/screen call.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+		},
+		"cross_subdomain_cookie": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This will allow the Mixpanel cookie to persist between different pages of your application.",
+		},
+		"persistence": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Choose persistence for Mixpanel SDK. One of none|cookie|localStorage",
+			ValidateDiagFunc: c.StringMatchesRegexp("^(none|cookie|localStorage)$"),
+		},
+		"secure_cookie": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This will mark the Mixpanel cookie as secure, meaning it will only be transmitted over https.",
+		},
+		"super_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Property to send as super Properties.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"people_properties": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Traits to set as People Properties.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"event_increments": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Events to increment in People.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"prop_increments": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Properties to increment in People",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"group_key_settings": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Group Key",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "With this option, you can determine which events are blocked or allowed to flow through to Mixpanel.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"use_new_mapping": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "This value is true by default and when this flag is enabled, camel case fields are mapped to snake case fields while sending to Mixpanel. Please refer to https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/#connection-settings for more details.",
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("mixpanel", c.ConfigMeta{
 		APIType: "MP",
-		Properties: []c.ConfigProperty{
-			c.Simple("token", "token"),
-			c.Simple("apiSecret", "api_secret", c.SkipZeroValue),
-			c.Simple("dataResidency", "data_residency"),
-			c.Simple("people", "people", c.SkipZeroValue),
-			c.Simple("setAllTraitsByDefault", "set_all_traits_by_default", c.SkipZeroValue),
-			c.Simple("consolidatedPageCalls", "consolidated_page_calls"),
-			c.Simple("trackCategorizedPages", "track_categorized_pages", c.SkipZeroValue),
-			c.Simple("trackNamedPages", "track_named_pages", c.SkipZeroValue),
-			c.Simple("sourceName", "source_name", c.SkipZeroValue),
-			c.Simple("crossSubdomainCookie", "cross_subdomain_cookie", c.SkipZeroValue),
-			c.Simple("persistence", "persistence"),
-			c.Simple("secureCookie", "secure_cookie", c.SkipZeroValue),
-			c.ArrayWithStrings("superProperties", "property", "super_properties"),
-			c.ArrayWithStrings("peopleProperties", "property", "people_properties"),
-			c.ArrayWithStrings("eventIncrements", "property", "event_increments"),
-			c.ArrayWithStrings("propIncrements", "property", "prop_increments"),
-			c.ArrayWithStrings("groupKeySettings", "groupKey", "group_key_settings"),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-			c.Simple("useNewMapping", "use_new_mapping", c.SkipZeroValue),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"token": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Mixpanel API Token",
-				Sensitive:        true,
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"api_secret": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Sensitive:        true,
-				Description:      "Mixpanel API secret",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"data_residency": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Mixpanel Server region either us/eu",
-				ValidateDiagFunc: c.StringMatchesRegexp("^(us|eu)$"),
-			},
-			"people": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Boolean flag to send all of your identify calls to Mixpanel's People feature ",
-			},
-			"set_all_traits_by_default": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "While this is checked, our integration automatically sets all traits on identify calls as super properties and people properties if Mixpanel People is checked as well.",
-			},
-			"consolidated_page_calls": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "This will track Loaded a Page events to Mixpanel for all page method calls. We enable this by default as it's how Mixpanel suggests sending these calls.",
-			},
-			"track_categorized_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This will track events to Mixpanel for page method calls that have a category associated with them. For example page('Docs', 'Index') would translate to Viewed Docs Index Page.",
-			},
-			"track_named_pages": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This will track events to Mixpanel for page method calls that have a name associated with them. For example page('Signup') would translate to Viewed Signup Page.",
-			},
-			"source_name": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "This value, if it's not blank, will be sent as rudderstack_source_name to Mixpanel for every event/page/screen call.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-			},
-			"cross_subdomain_cookie": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This will allow the Mixpanel cookie to persist between different pages of your application.",
-			},
-			"persistence": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Choose persistence for Mixpanel SDK. One of none|cookie|localStorage",
-				ValidateDiagFunc: c.StringMatchesRegexp("^(none|cookie|localStorage)$"),
-			},
-			"secure_cookie": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This will mark the Mixpanel cookie as secure, meaning it will only be transmitted over https.",
-			},
-			"super_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Property to send as super Properties.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"people_properties": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Traits to set as People Properties.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"event_increments": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Events to increment in People.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"prop_increments": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Properties to increment in People",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"group_key_settings": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Group Key",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "With this option, you can determine which events are blocked or allowed to flow through to Mixpanel.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"use_new_mapping": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "This value is true by default and when this flag is enabled, camel case fields are mapped to snake case fields while sending to Mixpanel. Please refer to https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/#connection-settings for more details.",
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_mixpanel_test.go
+++ b/rudderstack/integrations/destinations/destination_mixpanel_test.go
@@ -50,7 +50,19 @@ func TestDestinationResourceMixpanel(t *testing.T) {
 					whitelist = ["one", "two", "three"]
 				}
 		
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 				use_new_mapping = true
 			`,
 			APIUpdate: `
@@ -131,11 +143,63 @@ func TestDestinationResourceMixpanel(t *testing.T) {
 						"eventName": "three"
 					}
 				],
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				],
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				},
 				"useNewMapping": true
 			}			
 			`,

--- a/rudderstack/integrations/destinations/destination_redis.go
+++ b/rudderstack/integrations/destinations/destination_redis.go
@@ -6,74 +6,78 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("address", "address"),
+		c.Simple("password", "password", c.SkipZeroValue),
+		c.Simple("clusterMode", "cluster_mode"),
+		c.Simple("secure", "secure"),
+		c.Simple("prefix", "prefix", c.SkipZeroValue),
+		c.Simple("database", "database", c.SkipZeroValue),
+		c.Simple("caCertificate", "ca_certificate", c.SkipZeroValue),
+		c.Simple("skipVerify", "skip_verify"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"address": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter the address associated with your Redis cluster.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Enter the password associated with your Redis user.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"cluster_mode": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Use this setting to enable the Redis cluster mode.",
+		},
+		"secure": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting if you want to send the data to Redis via SSL.",
+		},
+		"prefix": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "By default, RudderStack stores user traits with the key user:<user_id>. An extra prefix can be added in the destination configuration to distinguish all RudderStack-stored keys with a prefix.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"database": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "RudderStack stores the user traits in the default database of the Redis instance. A different database inside the Redis instance can be configured using this setting.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"ca_certificate": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Enter the certificate which needs to be verified while establishing a secure connection. Skip setting this if Root CA of your server can be verified with any client, e.g. AWS Elasticache.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"skip_verify": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to skip the client's verification of the server's certificate chain and host name.",
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("redis", c.ConfigMeta{
 		APIType: "REDIS",
-		Properties: []c.ConfigProperty{
-			c.Simple("address", "address"),
-			c.Simple("password", "password", c.SkipZeroValue),
-			c.Simple("clusterMode", "cluster_mode"),
-			c.Simple("secure", "secure"),
-			c.Simple("prefix", "prefix", c.SkipZeroValue),
-			c.Simple("database", "database", c.SkipZeroValue),
-			c.Simple("caCertificate", "ca_certificate", c.SkipZeroValue),
-			c.Simple("skipVerify", "skip_verify"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"address": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter the address associated with your Redis cluster.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"password": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Enter the password associated with your Redis user.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"cluster_mode": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Use this setting to enable the Redis cluster mode.",
-			},
-			"secure": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting if you want to send the data to Redis via SSL.",
-			},
-			"prefix": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "By default, RudderStack stores user traits with the key user:<user_id>. An extra prefix can be added in the destination configuration to distinguish all RudderStack-stored keys with a prefix.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"database": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "RudderStack stores the user traits in the default database of the Redis instance. A different database inside the Redis instance can be configured using this setting.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"ca_certificate": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter the certificate which needs to be verified while establishing a secure connection. Skip setting this if Root CA of your server can be verified with any client, e.g. AWS Elasticache.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"skip_verify": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to skip the client's verification of the server's certificate chain and host name.",
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_redis_test.go
+++ b/rudderstack/integrations/destinations/destination_redis_test.go
@@ -29,7 +29,19 @@ func TestDestinationResourceRedis(t *testing.T) {
 				database      = "..."
 				ca_certificate = "..."
 				skip_verify   = true
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"address": "1.2.3.4",
@@ -40,11 +52,63 @@ func TestDestinationResourceRedis(t *testing.T) {
 				"database": "...",
 				"caCertificate": "...",
 				"skipVerify": true,
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_redshift.go
+++ b/rudderstack/integrations/destinations/destination_redshift.go
@@ -6,148 +6,152 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("host", "host"),
+		c.Simple("port", "port"),
+		c.Simple("database", "database"),
+		c.Simple("user", "user"),
+		c.Simple("password", "password"),
+		c.Simple("namespace", "namespace", c.SkipZeroValue),
+		c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
+		c.Simple("useRudderStorage", "use_rudder_storage"),
+		c.Simple("syncFrequency", "sync.0.frequency"),
+		c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
+		c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
+		c.Simple("excludeWindow.excludeWindowEndTime", "sync.0.exclude_window_end_time", c.SkipZeroValue),
+		c.Simple("bucketName", "s3.0.bucket_name"),
+		c.Simple("accessKeyID", "s3.0.access_key_id"),
+		c.Simple("accessKey", "s3.0.access_key"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"host": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "The host name of your Redshift service.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,255})$"),
+		},
+		"port": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "The port number associated with the Redshift database instance.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"user": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "The name of the user with the required read/write access to the above database.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"password": {
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+			Sensitive:        true,
+			Description:      "The password for the above user.",
+		},
+		"database": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "The database name in your Redshift instance where the data will be sent.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"namespace": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter the schema name where RudderStack will create all the tables. If you don't specify any namespace, RudderStack will set this to the source name, by default.",
+			ValidateDiagFunc: c.ValidateAll(
+				c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
+				c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
+			),
+		},
+		"enable_sse": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This setting enables server-side encryption.",
+		},
+		"use_rudder_storage": {
+			Type:        schema.TypeBool,
+			Required:    true,
+			Description: "Enable this setting to use the RudderStack-hosted object storage.",
+		},
+		"sync": {
+			Type:     schema.TypeList,
+			MinItems: 1, MaxItems: 1,
+			Required:    true,
+			Description: "Specify your sync settings.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"frequency": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify how often RudderStack should sync the data to your Redshift database.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
+					},
+					"start_at": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+					"exclude_window_start_time": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "This optional setting lets you set a time window when RudderStack will not sync the data to your database.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+					"exclude_window_end_time": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Set the end time of the exclusion window.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+				},
+			},
+		},
+		"s3": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"bucket_name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the name of your S3 bucket.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"access_key_id": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Enter your AWS access key ID.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"access_key": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Sensitive:        true,
+						Description:      "Enter your AWS secret access key.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("redshift", c.ConfigMeta{
 		APIType: "RS",
-		Properties: []c.ConfigProperty{
-			c.Simple("host", "host"),
-			c.Simple("port", "port"),
-			c.Simple("database", "database"),
-			c.Simple("user", "user"),
-			c.Simple("password", "password"),
-			c.Simple("namespace", "namespace", c.SkipZeroValue),
-			c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
-			c.Simple("useRudderStorage", "use_rudder_storage"),
-			c.Simple("syncFrequency", "sync.0.frequency"),
-			c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
-			c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
-			c.Simple("excludeWindow.excludeWindowEndTime", "sync.0.exclude_window_end_time", c.SkipZeroValue),
-			c.Simple("bucketName", "s3.0.bucket_name"),
-			c.Simple("accessKeyID", "s3.0.access_key_id"),
-			c.Simple("accessKey", "s3.0.access_key"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"host": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "The host name of your Redshift service.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,255})$"),
-			},
-			"port": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "The port number associated with the Redshift database instance.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"user": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "The name of the user with the required read/write access to the above database.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"password": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-				Sensitive:        true,
-				Description:      "The password for the above user.",
-			},
-			"database": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "The database name in your Redshift instance where the data will be sent.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"namespace": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter the schema name where RudderStack will create all the tables. If you don't specify any namespace, RudderStack will set this to the source name, by default.",
-				ValidateDiagFunc: c.ValidateAll(
-					c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
-					c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
-				),
-			},
-			"enable_sse": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This setting enables server-side encryption.",
-			},
-			"use_rudder_storage": {
-				Type:        schema.TypeBool,
-				Required:    true,
-				Description: "Enable this setting to use the RudderStack-hosted object storage.",
-			},
-			"sync": {
-				Type:     schema.TypeList,
-				MinItems: 1, MaxItems: 1,
-				Required:    true,
-				Description: "Specify your sync settings.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"frequency": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify how often RudderStack should sync the data to your Redshift database.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
-						},
-						"start_at": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-						"exclude_window_start_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "This optional setting lets you set a time window when RudderStack will not sync the data to your database.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-						"exclude_window_end_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Set the end time of the exclusion window.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-					},
-				},
-			},
-			"s3": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bucket_name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the name of your S3 bucket.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"access_key_id": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Enter your AWS access key ID.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"access_key": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Sensitive:        true,
-							Description:      "Enter your AWS secret access key.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_redshift_test.go
+++ b/rudderstack/integrations/destinations/destination_redshift_test.go
@@ -55,7 +55,19 @@ func TestDestinationResourceRedshift(t *testing.T) {
 					access_key_id = "some-access-key-id"
 					access_key = "some-access-key"
 				}
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 				`,
 			APIUpdate: `{
 				"host": "example.com",
@@ -75,11 +87,63 @@ func TestDestinationResourceRedshift(t *testing.T) {
 					"excludeWindowStartTime": "11:00",
 					"excludeWindowEndTime": "12:00"	
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_s3.go
+++ b/rudderstack/integrations/destinations/destination_s3.go
@@ -6,55 +6,59 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("bucketName", "bucket_name"),
+		c.Simple("prefix", "prefix", c.SkipZeroValue),
+		c.Simple("accessKeyID", "access_key_id", c.SkipZeroValue),
+		c.Simple("accessKey", "access_key", c.SkipZeroValue),
+		c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"bucket_name": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter the name of your S3 bucket.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"prefix": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter a prefix which RudderStack associates as the path prefix to all the files stored in your S3 bucket.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"access_key_id": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your AWS access key ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"access_key": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Sensitive:        true,
+			Description:      "Enter your AWS secret access key.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"enable_sse": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This setting enables server-side encryption.",
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("s3", c.ConfigMeta{
 		APIType: "S3",
-		Properties: []c.ConfigProperty{
-			c.Simple("bucketName", "bucket_name"),
-			c.Simple("prefix", "prefix", c.SkipZeroValue),
-			c.Simple("accessKeyID", "access_key_id", c.SkipZeroValue),
-			c.Simple("accessKey", "access_key", c.SkipZeroValue),
-			c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"bucket_name": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter the name of your S3 bucket.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"prefix": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter a prefix which RudderStack associates as the path prefix to all the files stored in your S3 bucket.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"access_key_id": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your AWS access key ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"access_key": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Sensitive:        true,
-				Description:      "Enter your AWS secret access key.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"enable_sse": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This setting enables server-side encryption.",
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_s3_datalake.go
+++ b/rudderstack/integrations/destinations/destination_s3_datalake.go
@@ -6,102 +6,106 @@ import (
 )
 
 func init() {
-	c.Destinations.Register("s3_datalake", c.ConfigMeta{
-		APIType: "S3_DATALAKE",
-		Properties: []c.ConfigProperty{
-			c.Simple("bucketName", "bucket_name"),
-			c.Simple("namespace", "namespace", c.SkipZeroValue),
-			c.Simple("prefix", "prefix", c.SkipZeroValue),
-			c.Simple("accessKeyID", "access_key_id", c.SkipZeroValue),
-			c.Simple("accessKey", "access_key", c.SkipZeroValue),
-			c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
-			c.Simple("useGlue", "use_glue"),
-			c.Simple("region", "region", c.SkipZeroValue),
-			c.Simple("syncFrequency", "sync.0.frequency"),
-			c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("bucketName", "bucket_name"),
+		c.Simple("namespace", "namespace", c.SkipZeroValue),
+		c.Simple("prefix", "prefix", c.SkipZeroValue),
+		c.Simple("accessKeyID", "access_key_id", c.SkipZeroValue),
+		c.Simple("accessKey", "access_key", c.SkipZeroValue),
+		c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
+		c.Simple("useGlue", "use_glue"),
+		c.Simple("region", "region", c.SkipZeroValue),
+		c.Simple("syncFrequency", "sync.0.frequency"),
+		c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"bucket_name": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "The name of the S3 bucket that will be used to store the data before loading it into the S3 data lake.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
 		},
-		ConfigSchema: map[string]*schema.Schema{
-			"bucket_name": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "The name of the S3 bucket that will be used to store the data before loading it into the S3 data lake.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"namespace": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "If specified, all the data for the destination will be pushed to `s3://<bucketName>/<prefix>/rudder-datalake/<namespace>`. ",
-				ValidateDiagFunc: c.ValidateAll(
-					c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
-					c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
-				),
-			},
-			"prefix": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "If specified, RudderStack creates a folder in the bucket with this prefix and push all the data within that folder.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"access_key_id": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your AWS access key ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"access_key": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Sensitive:        true,
-				Description:      "Enter your AWS secret access key.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"enable_sse": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "This setting enables server-side encryption.",
-			},
-			"use_glue": {
-				Type:        schema.TypeBool,
-				Required:    true,
-				Description: "This setting enables AWS Glue.",
-			},
-			"region": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter your AWS Glue region. For example, for N.Virginia, it would be `us-east-1`.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
-			},
-			"sync": {
-				Type:     schema.TypeList,
-				MinItems: 1, MaxItems: 1,
-				Required:    true,
-				Description: "Specify your data sync settings.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"frequency": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify how often RudderStack should sync the data to your S3 Datalake.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
-						},
-						"start_at": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "This optional setting lets you specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
+		"namespace": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "If specified, all the data for the destination will be pushed to `s3://<bucketName>/<prefix>/rudder-datalake/<namespace>`. ",
+			ValidateDiagFunc: c.ValidateAll(
+				c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
+				c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
+			),
+		},
+		"prefix": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "If specified, RudderStack creates a folder in the bucket with this prefix and push all the data within that folder.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"access_key_id": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your AWS access key ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"access_key": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Sensitive:        true,
+			Description:      "Enter your AWS secret access key.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"enable_sse": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "This setting enables server-side encryption.",
+		},
+		"use_glue": {
+			Type:        schema.TypeBool,
+			Required:    true,
+			Description: "This setting enables AWS Glue.",
+		},
+		"region": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter your AWS Glue region. For example, for N.Virginia, it would be `us-east-1`.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
+		},
+		"sync": {
+			Type:     schema.TypeList,
+			MinItems: 1, MaxItems: 1,
+			Required:    true,
+			Description: "Specify your data sync settings.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"frequency": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify how often RudderStack should sync the data to your S3 Datalake.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
+					},
+					"start_at": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "This optional setting lets you specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
 					},
 				},
 			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
+	c.Destinations.Register("s3_datalake", c.ConfigMeta{
+		APIType: "S3_DATALAKE",
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_s3_datalake_test.go
+++ b/rudderstack/integrations/destinations/destination_s3_datalake_test.go
@@ -39,7 +39,19 @@ func TestDestinationResourceS3Datalake(t *testing.T) {
 					frequency = "30"
 					start_at  = "10:00"
 				}
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"bucketName": "bucket",
@@ -52,11 +64,63 @@ func TestDestinationResourceS3Datalake(t *testing.T) {
 				"region": "region",
 				"syncFrequency": "30",
 				"syncStartAt": "10:00",
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_s3_test.go
+++ b/rudderstack/integrations/destinations/destination_s3_test.go
@@ -24,7 +24,19 @@ func TestDestinationResourceS3(t *testing.T) {
 				access_key    = "..."
 			
 				enable_sse    = true
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"bucketName": "bucket",
@@ -32,11 +44,63 @@ func TestDestinationResourceS3(t *testing.T) {
 				"accessKeyID": "...",
 				"accessKey": "...",
 				"enableSSE": true,
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_sentry.go
+++ b/rudderstack/integrations/destinations/destination_sentry.go
@@ -6,149 +6,153 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("dsn", "dsn"),
+		c.Simple("environment", "environment", c.SkipZeroValue),
+		c.Simple("customVersionProperty", "custom_version_property", c.SkipZeroValue),
+		c.Simple("release", "release", c.SkipZeroValue),
+		c.Simple("serverName", "server_name", c.SkipZeroValue),
+		c.Simple("logger", "logger", c.SkipZeroValue),
+		c.Simple("debugMode", "debug_mode"),
+		c.ArrayWithStrings("ignoreErrors", "ignoreErrors", "ignore_errors"),
+		c.ArrayWithStrings("includePaths", "includePaths", "include_paths"),
+		c.ArrayWithStrings("allowUrls", "allowUrls", "allow_urls"),
+		c.ArrayWithStrings("denyUrls", "denyUrls", "deny_urls"),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"dsn": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter the public DSN of your Sentry project. This is a mandatory field.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"environment": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Enter the value you want RudderStack to set as the environment configuration in your Sentry dashboard.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"custom_version_property": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "This field helps you dynamically track the application version in Sentry.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"release": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "This field is used for tracking your application's version in Sentry.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"server_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "This option is used to track the host on which the client is running.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"logger": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set the name you want Sentry to use as logger.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"debug_mode": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If enabled, no events are sent to your Sentry instance.",
+		},
+		"ignore_errors": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "This option refers to a list of error messages that you do not want Sentry to notify you.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"include_paths": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "This field should contain the regex patterns of URLs that are part of the app in the stack trace.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"allow_urls": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"deny_urls": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "This is the list of the regex patterns or exact URL strings - from which the errors need to be exclusively sent to Sentry.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "With this option, you can determine which events are blocked or allowed to flow through to Sentry.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("sentry", c.ConfigMeta{
 		APIType: "SENTRY",
-		Properties: []c.ConfigProperty{
-			c.Simple("dsn", "dsn"),
-			c.Simple("environment", "environment", c.SkipZeroValue),
-			c.Simple("customVersionProperty", "custom_version_property", c.SkipZeroValue),
-			c.Simple("release", "release", c.SkipZeroValue),
-			c.Simple("serverName", "server_name", c.SkipZeroValue),
-			c.Simple("logger", "logger", c.SkipZeroValue),
-			c.Simple("debugMode", "debug_mode"),
-			c.ArrayWithStrings("ignoreErrors", "ignoreErrors", "ignore_errors"),
-			c.ArrayWithStrings("includePaths", "includePaths", "include_paths"),
-			c.ArrayWithStrings("allowUrls", "allowUrls", "allow_urls"),
-			c.ArrayWithStrings("denyUrls", "denyUrls", "deny_urls"),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"dsn": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter the public DSN of your Sentry project. This is a mandatory field.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"environment": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter the value you want RudderStack to set as the environment configuration in your Sentry dashboard.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"custom_version_property": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "This field helps you dynamically track the application version in Sentry.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"release": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "This field is used for tracking your application's version in Sentry.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"server_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "This option is used to track the host on which the client is running.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"logger": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Set the name you want Sentry to use as logger.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"debug_mode": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "If enabled, no events are sent to your Sentry instance.",
-			},
-			"ignore_errors": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "This option refers to a list of error messages that you do not want Sentry to notify you.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"include_paths": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "This field should contain the regex patterns of URLs that are part of the app in the stack trace.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"allow_urls": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"deny_urls": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "This is the list of the regex patterns or exact URL strings - from which the errors need to be exclusively sent to Sentry.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "With this option, you can determine which events are blocked or allowed to flow through to Sentry.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_sentry_test.go
+++ b/rudderstack/integrations/destinations/destination_sentry_test.go
@@ -39,7 +39,9 @@ func TestDestinationResourceSentry(t *testing.T) {
 				  whitelist = ["one", "two", "three"]
 				}
 
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"dsn": "https://some-url",
@@ -77,11 +79,13 @@ func TestDestinationResourceSentry(t *testing.T) {
 					{ "eventName": "two" },
 					{ "eventName": "three" }
 				],
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_slack.go
+++ b/rudderstack/integrations/destinations/destination_slack.go
@@ -6,103 +6,107 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("webhookUrl", "webhook_url"),
+		c.Simple("identifyTemplate", "identify_template", c.SkipZeroValue),
+		c.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]string{
+			"eventName":    "name",
+			"eventChannel": "channel",
+			"eventRegex":   "regex",
+		}),
+		c.ArrayWithObjects("eventTemplateSettings", "event_template_settings", map[string]string{
+			"eventName":     "name",
+			"eventTemplate": "template",
+			"eventRegex":    "regex",
+		}),
+		c.ArrayWithStrings("whitelistedTraitsSettings", "trait", "whitelisted_trait_settings"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"webhook_url": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter your Slack's incoming webhook URL.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"identify_template": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Specify the template that you want the `identify` event to be transformed to before it is sent to Slack.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"event_channel_settings": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Specify your event channel settings.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Enter the event name or the regex to match the RudderStack event name.",
+					},
+					"channel": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Enter the name of the Slack channel where the event will be sent.",
+					},
+					"regex": {
+						Type:        schema.TypeBool,
+						Required:    true,
+						Description: "Enable this setting if the event name in the first parameter is a regular expression.",
+					},
+				},
+			},
+		},
+		"event_template_settings": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Specify your event template settings.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Enter the event name or the regex to match the RudderStack event name.",
+					},
+					"template": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Specify the template for the above event names matching the regex.",
+					},
+					"regex": {
+						Type:        schema.TypeBool,
+						Required:    true,
+						Description: "Enable this setting if the event name is a regex in the first parameter.",
+					},
+				},
+			},
+		},
+		"whitelisted_trait_settings": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Only the traits listed in this section are considered to be a part of the identify template. The rest are sent to Slack.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("slack", c.ConfigMeta{
 		APIType: "SLACK",
-		Properties: []c.ConfigProperty{
-			c.Simple("webhookUrl", "webhook_url"),
-			c.Simple("identifyTemplate", "identify_template", c.SkipZeroValue),
-			c.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]string{
-				"eventName":    "name",
-				"eventChannel": "channel",
-				"eventRegex":   "regex",
-			}),
-			c.ArrayWithObjects("eventTemplateSettings", "event_template_settings", map[string]string{
-				"eventName":     "name",
-				"eventTemplate": "template",
-				"eventRegex":    "regex",
-			}),
-			c.ArrayWithStrings("whitelistedTraitsSettings", "trait", "whitelisted_trait_settings"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"webhook_url": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter your Slack's incoming webhook URL.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"identify_template": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Specify the template that you want the `identify` event to be transformed to before it is sent to Slack.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"event_channel_settings": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify your event channel settings.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Enter the event name or the regex to match the RudderStack event name.",
-						},
-						"channel": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Enter the name of the Slack channel where the event will be sent.",
-						},
-						"regex": {
-							Type:        schema.TypeBool,
-							Required:    true,
-							Description: "Enable this setting if the event name in the first parameter is a regular expression.",
-						},
-					},
-				},
-			},
-			"event_template_settings": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify your event template settings.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Enter the event name or the regex to match the RudderStack event name.",
-						},
-						"template": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Specify the template for the above event names matching the regex.",
-						},
-						"regex": {
-							Type:        schema.TypeBool,
-							Required:    true,
-							Description: "Enable this setting if the event name is a regex in the first parameter.",
-						},
-					},
-				},
-			},
-			"whitelisted_trait_settings": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Only the traits listed in this section are considered to be a part of the identify template. The rest are sent to Slack.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_slack_test.go
+++ b/rudderstack/integrations/destinations/destination_slack_test.go
@@ -37,7 +37,19 @@ func TestDestinationResourceSlack(t *testing.T) {
 				]
 			  
 				whitelisted_trait_settings = ["one", "two", "three"]
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"webhookUrl": "https://some-url",
@@ -61,11 +73,63 @@ func TestDestinationResourceSlack(t *testing.T) {
 					{ "trait": "two" },
 					{ "trait": "three" }
 				],
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_snowflake.go
+++ b/rudderstack/integrations/destinations/destination_snowflake.go
@@ -6,247 +6,251 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("account", "account"),
+		c.Simple("database", "database"),
+		c.Simple("warehouse", "warehouse"),
+		c.Simple("user", "user"),
+		c.Simple("password", "password"),
+		c.Simple("namespace", "namespace", c.SkipZeroValue),
+		c.Simple("syncFrequency", "sync.0.frequency"),
+		c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
+		c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
+		c.Simple("excludeWindow.excludeWindowEndTime", "sync.0.exclude_window_end_time", c.SkipZeroValue),
+		c.Simple("jsonPaths", "json_paths", c.SkipZeroValue),
+		c.Simple("useRudderStorage", "use_rudder_storage"),
+		c.Discriminator("cloudProvider", c.DiscriminatorValues{
+			"s3":    "AWS",
+			"gcp":   "GCP",
+			"azure": "AZURE",
+		}),
+		c.Simple("additionalProperties", "additional_properties"),
+		c.Conditional("bucketName", "s3.0.bucket_name", c.Equals("cloudProvider", "AWS")),
+		c.Simple("accessKeyID", "s3.0.access_key_id", c.SkipZeroValue),
+		c.Simple("accessKey", "s3.0.access_key", c.SkipZeroValue),
+		c.Simple("enableSSE", "s3.0.enable_sse", c.SkipZeroValue),
+		c.Conditional("bucketName", "gcp.0.bucket_name", c.Equals("cloudProvider", "GCP")),
+		c.Simple("credentials", "gcp.0.credentials", c.SkipZeroValue),
+		c.Conditional("storageIntegration", "gcp.0.storage_integration", c.Equals("cloudProvider", "GCP")),
+		c.Simple("containerName", "azure.0.container_name", c.SkipZeroValue),
+		c.Simple("accountName", "azure.0.account_name", c.SkipZeroValue),
+		c.Simple("accountKey", "azure.0.account_key", c.SkipZeroValue),
+		c.Conditional("storageIntegration", "azure.0.storage_integration", c.Equals("cloudProvider", "AZURE")),
+		c.Simple("prefix", "prefix", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"account": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Account ID of your Snowflake warehouse. This account ID is part of the Snowflake URL. Example : https://www.rudderstack.com/docs/destinations/warehouse-destinations/faq/#while-configuring-the-snowflake-destination-what-should-i-enter-in-the-account-field",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"database": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Name of the database.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"warehouse": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Name of the warehouse.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"user": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Name of the user.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+		},
+		"password": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Sensitive:        true,
+			Description:      "Password for the user.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
+		},
+		"namespace": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Schema name for the warehouse where the tables are created by Rudderstack.",
+			ValidateDiagFunc: c.ValidateAll(
+				c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
+				c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
+			),
+		},
+		"sync": {
+			Type:     schema.TypeList,
+			MinItems: 1, MaxItems: 1,
+			Required:    true,
+			Description: "Specify your sync settings.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"frequency": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify how often RudderStack should sync the data to your snowflake database.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
+					},
+					"start_at": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+					"exclude_window_start_time": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "This optional setting lets you set a time window when RudderStack will not sync the data to your database.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+					"exclude_window_end_time": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Description:      "Set the end time of the exclusion window.",
+						ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
+					},
+				},
+			},
+		},
+		"json_paths": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Specify required json properties in dot notation separated by commas.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].*)|.*"),
+		},
+		"use_rudder_storage": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to use RudderStack-managed buckets for object storage.",
+			Default:     false,
+		},
+		"additional_properties": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		"s3": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			Description:   "",
+			ConflictsWith: []string{"config.0.gcp", "config.0.azure"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"bucket_name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify the name of your S3 bucket where RudderStack will store the data before loading it into Snowflake.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"access_key_id": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Sensitive:        true,
+						Description:      "Enter your AWS access key ID obtained from the AWS console.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"access_key": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						Sensitive:        true,
+						Description:      "Enter your AWS secret access key.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"enable_sse": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Toggle on this setting to enable server-side encryption for your S3 bucket.",
+					},
+				},
+			},
+		},
+		"gcp": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			Description:   "",
+			ConflictsWith: []string{"config.0.s3", "config.0.azure"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"bucket_name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify the name of your GCS bucket where RudderStack will store the data before loading it into Snowflake.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"credentials": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "GCP Service Account credentials JSON for RudderStack to use in loading data into your Google Cloud Storage.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
+					},
+					"storage_integration": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Create the cloud storage integration in Snowflake and enter the name of integration.Please refer to this for more details -> https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/#configuring-cloud-storage-integration-with-snowflake",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+				},
+			},
+		},
+		"azure": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			Description:   "",
+			ConflictsWith: []string{"config.0.s3", "config.0.gcp"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"container_name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Specify the name of your Azure container where RudderStack will store the data before loading it into Snowflake.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"account_name": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the account name for the Azure container.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"account_key": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Enter the account key for your Azure container.",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+					"storage_integration": {
+						Type:             schema.TypeString,
+						Required:         true,
+						Description:      "Create the cloud storage integration in Snowflake and enter the name of integration. Please refer to this for more details -> https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/#configuring-cloud-storage-integration-with-snowflake",
+						ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
+					},
+				},
+			},
+		},
+		"prefix": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "If specified, RudderStack will create a folder in the bucket with this prefix and push all the data within that folder.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].*)|^(.{0,100})$"),
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("snowflake", c.ConfigMeta{
 		APIType: "SNOWFLAKE",
-		Properties: []c.ConfigProperty{
-			c.Simple("account", "account"),
-			c.Simple("database", "database"),
-			c.Simple("warehouse", "warehouse"),
-			c.Simple("user", "user"),
-			c.Simple("password", "password"),
-			c.Simple("namespace", "namespace", c.SkipZeroValue),
-			c.Simple("syncFrequency", "sync.0.frequency"),
-			c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
-			c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
-			c.Simple("excludeWindow.excludeWindowEndTime", "sync.0.exclude_window_end_time", c.SkipZeroValue),
-			c.Simple("jsonPaths", "json_paths", c.SkipZeroValue),
-			c.Simple("useRudderStorage", "use_rudder_storage"),
-			c.Discriminator("cloudProvider", c.DiscriminatorValues{
-				"s3":    "AWS",
-				"gcp":   "GCP",
-				"azure": "AZURE",
-			}),
-			c.Simple("additionalProperties", "additional_properties"),
-			c.Conditional("bucketName", "s3.0.bucket_name", c.Equals("cloudProvider", "AWS")),
-			c.Simple("accessKeyID", "s3.0.access_key_id", c.SkipZeroValue),
-			c.Simple("accessKey", "s3.0.access_key", c.SkipZeroValue),
-			c.Simple("enableSSE", "s3.0.enable_sse", c.SkipZeroValue),
-			c.Conditional("bucketName", "gcp.0.bucket_name", c.Equals("cloudProvider", "GCP")),
-			c.Simple("credentials", "gcp.0.credentials", c.SkipZeroValue),
-			c.Conditional("storageIntegration", "gcp.0.storage_integration", c.Equals("cloudProvider", "GCP")),
-			c.Simple("containerName", "azure.0.container_name", c.SkipZeroValue),
-			c.Simple("accountName", "azure.0.account_name", c.SkipZeroValue),
-			c.Simple("accountKey", "azure.0.account_key", c.SkipZeroValue),
-			c.Conditional("storageIntegration", "azure.0.storage_integration", c.Equals("cloudProvider", "AZURE")),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-			c.Simple("prefix", "prefix", c.SkipZeroValue),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"account": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Account ID of your Snowflake warehouse. This account ID is part of the Snowflake URL. Example : https://www.rudderstack.com/docs/destinations/warehouse-destinations/faq/#while-configuring-the-snowflake-destination-what-should-i-enter-in-the-account-field",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"database": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Name of the database.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"warehouse": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Name of the warehouse.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"user": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Name of the user.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-			},
-			"password": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Sensitive:        true,
-				Description:      "Password for the user.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
-			},
-			"namespace": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Schema name for the warehouse where the tables are created by Rudderstack.",
-				ValidateDiagFunc: c.ValidateAll(
-					c.StringMatchesRegexp("(^env[.].*)|^(.{0,64})$"),
-					c.StringNotMatchesRegexp("^(pg_|PG_|pG_|Pg_)"),
-				),
-			},
-			"sync": {
-				Type:     schema.TypeList,
-				MinItems: 1, MaxItems: 1,
-				Required:    true,
-				Description: "Specify your sync settings.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"frequency": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify how often RudderStack should sync the data to your snowflake database.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^(30|60|180|360|720|1440)$"),
-						},
-						"start_at": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-						"exclude_window_start_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "This optional setting lets you set a time window when RudderStack will not sync the data to your database.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-						"exclude_window_end_time": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Set the end time of the exclusion window.",
-							ValidateDiagFunc: c.StringMatchesRegexp("^([01][0-9]|2[0-3]):[0-5][0-9]$"),
-						},
-					},
-				},
-			},
-			"json_paths": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Specify required json properties in dot notation separated by commas.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].*)|.*"),
-			},
-			"use_rudder_storage": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to use RudderStack-managed buckets for object storage.",
-				Default:     false,
-			},
-			"additional_properties": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"s3": {
-				Type:          schema.TypeList,
-				MaxItems:      1,
-				Optional:      true,
-				Description:   "",
-				ConflictsWith: []string{"config.0.gcp", "config.0.azure"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bucket_name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify the name of your S3 bucket where RudderStack will store the data before loading it into Snowflake.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"access_key_id": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Sensitive:        true,
-							Description:      "Enter your AWS access key ID obtained from the AWS console.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"access_key": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Sensitive:        true,
-							Description:      "Enter your AWS secret access key.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"enable_sse": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Toggle on this setting to enable server-side encryption for your S3 bucket.",
-						},
-					},
-				},
-			},
-			"gcp": {
-				Type:          schema.TypeList,
-				MaxItems:      1,
-				Optional:      true,
-				Description:   "",
-				ConflictsWith: []string{"config.0.s3", "config.0.azure"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bucket_name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify the name of your GCS bucket where RudderStack will store the data before loading it into Snowflake.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"credentials": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "GCP Service Account credentials JSON for RudderStack to use in loading data into your Google Cloud Storage.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|.+"),
-						},
-						"storage_integration": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Create the cloud storage integration in Snowflake and enter the name of integration.Please refer to this for more details -> https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/#configuring-cloud-storage-integration-with-snowflake",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-					},
-				},
-			},
-			"azure": {
-				Type:          schema.TypeList,
-				MaxItems:      1,
-				Optional:      true,
-				Description:   "",
-				ConflictsWith: []string{"config.0.s3", "config.0.gcp"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"container_name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Specify the name of your Azure container where RudderStack will store the data before loading it into Snowflake.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"account_name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the account name for the Azure container.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"account_key": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Enter the account key for your Azure container.",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-						"storage_integration": {
-							Type:             schema.TypeString,
-							Required:         true,
-							Description:      "Create the cloud storage integration in Snowflake and enter the name of integration. Please refer to this for more details -> https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/#configuring-cloud-storage-integration-with-snowflake",
-							ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^(.{1,100})$"),
-						},
-					},
-				},
-			},
-			"prefix": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "If specified, RudderStack will create a folder in the bucket with this prefix and push all the data within that folder.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].*)|^(.{0,100})$"),
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_snowflake_test.go
+++ b/rudderstack/integrations/destinations/destination_snowflake_test.go
@@ -53,7 +53,19 @@ func TestDestinationResourceSnowflake(t *testing.T) {
 					access_key = "example-access-key"
 					enable_sse = true
 				}
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"account": "example-account",
@@ -77,11 +89,63 @@ func TestDestinationResourceSnowflake(t *testing.T) {
         		"accessKeyID": "example-access-key-id",
         		"accessKey": "example-access-key",
         		"enableSSE": true,
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_vwo.go
+++ b/rudderstack/integrations/destinations/destination_vwo.go
@@ -6,114 +6,118 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("accountId", "account_id"),
+		c.Simple("isSPA", "is_spa", c.SkipZeroValue),
+		c.Simple("sendExperimentTrack", "send_experiment_track", c.SkipZeroValue),
+		c.Simple("sendExperimentIdentify", "send_experiment_identify", c.SkipZeroValue),
+		c.Simple("libraryTolerance", "library_tolerance", c.SkipZeroValue),
+		c.Simple("settingsTolerance", "settings_tolerance", c.SkipZeroValue),
+		c.Simple("useExistingJquery", "use_existing_jquery", c.SkipZeroValue),
+		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
+		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
+		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
+			"event_filtering.0.whitelist": "whitelistedEvents",
+			"event_filtering.0.blacklist": "blacklistedEvents",
+		}),
+		c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"account_id": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter your VWO account ID.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"is_spa": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting if the page is a single page application (SPA).",
+		},
+		"send_experiment_track": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to send the experiment data as `track` events.",
+		},
+		"send_experiment_identify": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to send the experiments viewed as `identify` traits.",
+		},
+		"library_tolerance": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter the value for the library tolerance setting.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"settings_tolerance": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Enter the value for the setting tolerance.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"use_existing_jquery": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to use the existing jQuery.",
+		},
+		"event_filtering": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Specify which events should be blocked or allowed to flow through to VWO.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"whitelist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event nams to be whitelisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"blacklist": {
+						Type:         schema.TypeList,
+						Optional:     true,
+						Description:  "Enter the event names to be blacklisted.",
+						ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"use_native_sdk": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Enable this setting to send the events via the device mode.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("vwo", c.ConfigMeta{
 		APIType: "VWO",
-		Properties: []c.ConfigProperty{
-			c.Simple("accountId", "account_id"),
-			c.Simple("isSPA", "is_spa", c.SkipZeroValue),
-			c.Simple("sendExperimentTrack", "send_experiment_track", c.SkipZeroValue),
-			c.Simple("sendExperimentIdentify", "send_experiment_identify", c.SkipZeroValue),
-			c.Simple("libraryTolerance", "library_tolerance", c.SkipZeroValue),
-			c.Simple("settingsTolerance", "settings_tolerance", c.SkipZeroValue),
-			c.Simple("useExistingJquery", "use_existing_jquery", c.SkipZeroValue),
-			c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
-			c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
-			c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
-				"event_filtering.0.whitelist": "whitelistedEvents",
-				"event_filtering.0.blacklist": "blacklistedEvents",
-			}),
-			c.Simple("useNativeSDK.web", "use_native_sdk.0.web"),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"account_id": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter your VWO account ID.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"is_spa": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting if the page is a single page application (SPA).",
-			},
-			"send_experiment_track": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to send the experiment data as `track` events.",
-			},
-			"send_experiment_identify": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to send the experiments viewed as `identify` traits.",
-			},
-			"library_tolerance": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter the value for the library tolerance setting.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"settings_tolerance": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Enter the value for the setting tolerance.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"use_existing_jquery": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to use the existing jQuery.",
-			},
-			"event_filtering": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Specify which events should be blocked or allowed to flow through to VWO.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"whitelist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event nams to be whitelisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"blacklist": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Description:  "Enter the event names to be blacklisted.",
-							ExactlyOneOf: []string{"config.0.event_filtering.0.whitelist", "config.0.event_filtering.0.blacklist"},
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"use_native_sdk": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Enable this setting to send the events via the device mode.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"web": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_vwo_test.go
+++ b/rudderstack/integrations/destinations/destination_vwo_test.go
@@ -35,7 +35,9 @@ func TestDestinationResourceVWO(t *testing.T) {
 				event_filtering {
 					whitelist = ["one", "two", "three"]
 				}
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"accountId": "...",
@@ -59,11 +61,13 @@ func TestDestinationResourceVWO(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_webhook.go
+++ b/rudderstack/integrations/destinations/destination_webhook.go
@@ -6,56 +6,60 @@ import (
 )
 
 func init() {
-	c.Destinations.Register("webhook", c.ConfigMeta{
-		APIType: "WEBHOOK",
-		Properties: []c.ConfigProperty{
-			c.Simple("webhookUrl", "webhook_url"),
-			c.Simple("webhookMethod", "webhook_method", c.SkipZeroValue),
-			c.Simple("headers", "headers", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("webhookUrl", "webhook_url"),
+		c.Simple("webhookMethod", "webhook_method", c.SkipZeroValue),
+		c.Simple("headers", "headers", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"webhook_url": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "Enter the endpoint where RudderStack will send the events.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"),
 		},
-		ConfigSchema: map[string]*schema.Schema{
-			"webhook_url": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Enter the endpoint where RudderStack will send the events.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$"),
-			},
-			"webhook_method": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "This is the HTTP method of the request sent to the configured endpoint. By default, `POST` is used.",
-				ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|(^(POST|PUT|GET)$)"),
-			},
-			"headers": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Add custom headers for your events via this option. These headers will be added to the request made from RudderStack to your webhook.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
-						},
-						"to": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,500})$"),
-						},
+		"webhook_method": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "This is the HTTP method of the request sent to the configured endpoint. By default, `POST` is used.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|(^(POST|PUT|GET)$)"),
+		},
+		"headers": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Add custom headers for your events via this option. These headers will be added to the request made from RudderStack to your webhook.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,100})$"),
+					},
+					"to": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{0,500})$"),
 					},
 				},
 			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
+	c.Destinations.Register("webhook", c.ConfigMeta{
+		APIType: "WEBHOOK",
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_webhook_test.go
+++ b/rudderstack/integrations/destinations/destination_webhook_test.go
@@ -31,7 +31,19 @@ func TestDestinationResourceWebhook(t *testing.T) {
 						to   = "b2"
 					}
 				]
-				onetrust_cookie_categories = ["one", "two", "three"]
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"webhookUrl": "https://example.com/some/path?query=a",
@@ -46,11 +58,63 @@ func TestDestinationResourceWebhook(t *testing.T) {
 						"to": "b2"
 					}
 				],
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_zendesk.go
+++ b/rudderstack/integrations/destinations/destination_zendesk.go
@@ -6,66 +6,70 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("email", "email"),
+		c.Simple("apiToken", "api_token"),
+		c.Simple("domain", "domain"),
+		c.Simple("createUsersAsVerified", "create_users_as_verified", c.SkipZeroValue),
+		c.Simple("sendGroupCallsWithoutUserId", "send_group_calls_without_user_id", c.SkipZeroValue),
+		c.Simple("removeUsersFromOrganization", "remove_users_from_organization", c.SkipZeroValue),
+		c.Simple("searchByExternalId", "search_by_external_id", c.SkipZeroValue),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"email": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter the email used to log into your Zendesk dashboard.",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"api_token": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Enter the Zendesk API token used to authenticate the request. To create an API token, refer to this [Zendesk support page](https://support.zendesk.com/hc/en-us/articles/226022787-Generating-a-new-API-token-).",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"domain": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Enter your Zendesk subdomain without `.zendesk.com`",
+			// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
+		},
+		"create_users_as_verified": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enabling this setting creates verified users in Zendesk, that is, the email verification is skipped.",
+		},
+		"send_group_calls_without_user_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting if you don't want to associate the user with a group. ",
+		},
+		"remove_users_from_organization": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable this setting to remove users from an organization.",
+		},
+		"search_by_external_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Update user's primary email.",
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("zendesk", c.ConfigMeta{
 		APIType: "ZENDESK",
-		Properties: []c.ConfigProperty{
-			c.Simple("email", "email"),
-			c.Simple("apiToken", "api_token"),
-			c.Simple("domain", "domain"),
-			c.Simple("createUsersAsVerified", "create_users_as_verified", c.SkipZeroValue),
-			c.Simple("sendGroupCallsWithoutUserId", "send_group_calls_without_user_id", c.SkipZeroValue),
-			c.Simple("removeUsersFromOrganization", "remove_users_from_organization", c.SkipZeroValue),
-			c.Simple("searchByExternalId", "search_by_external_id", c.SkipZeroValue),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"email": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter the email used to log into your Zendesk dashboard.",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"api_token": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Sensitive:   true,
-				Description: "Enter the Zendesk API token used to authenticate the request. To create an API token, refer to this [Zendesk support page](https://support.zendesk.com/hc/en-us/articles/226022787-Generating-a-new-API-token-).",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"domain": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Enter your Zendesk subdomain without `.zendesk.com`",
-				// ValidateDiagFunc: c.StringMatchesRegexp("(^\\{\\{.*\\|\\|(.*)\\}\\}$)|(^env[.].+)|^(.{1,100})$"),
-			},
-			"create_users_as_verified": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enabling this setting creates verified users in Zendesk, that is, the email verification is skipped.",
-			},
-			"send_group_calls_without_user_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting if you don't want to associate the user with a group. ",
-			},
-			"remove_users_from_organization": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enable this setting to remove users from an organization.",
-			},
-			"search_by_external_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Update user's primary email.",
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		Properties: properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_zendesk_test.go
+++ b/rudderstack/integrations/destinations/destination_zendesk_test.go
@@ -11,9 +11,9 @@ func TestDestinationResourceZendesk(t *testing.T) {
 	cmt.AssertDestination(t, "zendesk", []c.TestConfig{
 		{
 			TerraformCreate: `
-				email     = "test@example.com"
+				email = "test@example.com"
 				api_token = "..."
-				domain    = "..."
+				domain = "..."
 			`,
 			APICreate: `{
 				"email": "test@example.com",
@@ -21,15 +21,25 @@ func TestDestinationResourceZendesk(t *testing.T) {
 				"domain": "..."
 			}`,
 			TerraformUpdate: `
-				email     = "test@example.com"
+				email = "test@example.com"
 				api_token = "..."
-				domain    = "..."
-			
-				create_users_as_verified         = true
+				domain = "..."
+				create_users_as_verified = true
 				send_group_calls_without_user_id = true
-				remove_users_from_organization   = true
-				search_by_external_id = false
-				onetrust_cookie_categories = ["one", "two", "three"]
+				remove_users_from_organization = true
+				onetrust_cookie_categories {
+					web = ["one", "two", "three"]
+					android = ["one", "two", "three"]
+					ios = ["one", "two", "three"]
+					unity = ["one", "two", "three"]
+					reactnative = ["one", "two", "three"]
+					flutter = ["one", "two", "three"]
+					cordova = ["one", "two", "three"]
+					amp = ["one", "two", "three"]
+					cloud = ["one", "two", "three"]
+					warehouse = ["one", "two", "three"]
+					shopify = ["one", "two", "three"]
+				}
 			`,
 			APIUpdate: `{
 				"email": "test@example.com",
@@ -38,12 +48,63 @@ func TestDestinationResourceZendesk(t *testing.T) {
 				"createUsersAsVerified": true,
 				"sendGroupCallsWithoutUserId": true,
 				"removeUsersFromOrganization": true,
-				"searchByExternalId": false,
-				"oneTrustCookieCategories": [
-					{ "oneTrustCookieCategory": "one" },
-					{ "oneTrustCookieCategory": "two" },
-					{ "oneTrustCookieCategory": "three" }
-				]
+				"oneTrustCookieCategories": {
+					"web": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"android": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"ios": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"unity": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"reactnative": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"flutter": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cordova": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"amp": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"cloud": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"warehouse": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					],
+					"shopify": [
+						{ "oneTrustCookieCategory": "one" },
+						{ "oneTrustCookieCategory": "two" },
+						{ "oneTrustCookieCategory": "three" }
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/provider.go
+++ b/rudderstack/provider.go
@@ -73,7 +73,7 @@ func configureClient(ctx context.Context, d *schema.ResourceData) (*Client, diag
 	accessToken := d.Get("access_token").(string)
 	client, err := NewAPIClient(accessToken,
 		client.WithBaseURL(apiUrl),
-		client.WithUserAgent("terraform-provider-rudderstack/0.7.2"))
+		client.WithUserAgent("terraform-provider-rudderstack/1.0.0"))
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}


### PR DESCRIPTION
## Description of the change

Made OneTrust consent manager fields source type specific.

## Liear Link

https://linear.app/rudderstack/issue/SDK-998/make-legacy-consent-configuration-fields-source-specific

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
