### PR TITLE
feat!: add generic consent management fields to destinations config

### DIFF
--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -230,7 +230,7 @@ func generateBlock(name string, data map[string]interface{}, configSchema map[st
 	block := hclwrite.NewBlock(name, []string{})
 	body := block.Body()
 
-	// go does not garantee the order of range in maps, we sort the keys so that the output is predictable
+	// go does not guarantee the order of range in maps, we sort the keys so that the output is predictable
 	var keys []string
 	for k := range data {
 		keys = append(keys, k)

--- a/rudderstack/configs/configproperty.go
+++ b/rudderstack/configs/configproperty.go
@@ -41,7 +41,7 @@ type APINestedObject struct {
 	NestedKey    string
 }
 
-type TerraformNestedObject struct {
+type terraformNestedObject struct {
 	APIKey    string
 	NestedKey string
 }
@@ -154,7 +154,7 @@ func GetInverseFields(fields map[string]interface{}) map[string]interface{} {
 		case APINestedObject:
 			tfKey := fieldVal.TerraformKey
 			nestedKey := fieldVal.NestedKey
-			inverseFields[tfKey] = TerraformNestedObject{APIKey: a, NestedKey: nestedKey}
+			inverseFields[tfKey] = terraformNestedObject{APIKey: a, NestedKey: nestedKey}
 		}
 	}
 	return inverseFields
@@ -252,7 +252,7 @@ func GetConfigValue(stateValue []interface{}, fields map[string]interface{}) []i
 				switch fieldVal := fields[tf].(type) {
 				case string:
 					av[fieldVal] = tfValue
-				case TerraformNestedObject:
+				case terraformNestedObject:
 					tfValues := []interface{}{}
 					af := fieldVal.APIKey
 					nestedKey := fieldVal.NestedKey

--- a/rudderstack/configs/configproperty_test.go
+++ b/rudderstack/configs/configproperty_test.go
@@ -125,37 +125,41 @@ func TestArrayWithStrings(t *testing.T) {
 }
 
 func TestArrayWithObjects(t *testing.T) {
-	p := configs.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]string{
+	p := configs.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]interface{}{
 		"eventName":    "name",
 		"eventChannel": "channel",
 		"eventRegex":   "regex",
+		"eventNestedValues": configs.APINestedObject{
+			TerraformKey: "event_nested_values",
+			NestedKey: "nestedKey",
+		},
 	})
 
 	a, err := p.FromStateFunc(`{}`, `{
 		"event_channel_settings": [
-			{ "name": "n1", "channel": "c1", "regex": "r1" },
-			{ "name": "n2", "channel": "c2", "regex": "r2" }
+			{ "name": "n1", "channel": "c1", "regex": "r1", "event_nested_values": [ "val1", "val2" ] },
+			{ "name": "n2", "channel": "c2", "regex": "r2", "event_nested_values": [ "val3", "val4" ] }
 		]
 	}`)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"eventChannelSettings": [
-			{ "eventName": "n1", "eventChannel": "c1", "eventRegex": "r1" },
-			{ "eventName": "n2", "eventChannel": "c2", "eventRegex": "r2" }
+			{ "eventName": "n1", "eventChannel": "c1", "eventRegex": "r1", "eventNestedValues": [ { "nestedKey": "val1" }, { "nestedKey": "val2" } ] },
+			{ "eventName": "n2", "eventChannel": "c2", "eventRegex": "r2", "eventNestedValues": [ { "nestedKey": "val3" }, { "nestedKey": "val4" } ] }
 		]
 	}`, a)
 
 	s, err := p.ToStateFunc(`{}`, `{
 		"eventChannelSettings": [
-			{ "eventName": "n1", "eventChannel": "c1", "eventRegex": "r1", "extra": "e1" },
-			{ "eventName": "n2", "eventChannel": "c2", "eventRegex": "r2", "extra": "e2" }
+			{ "eventName": "n1", "eventChannel": "c1", "eventRegex": "r1", "extra": "e1", "eventNestedValues": [ { "nestedKey": "val1" }, { "nestedKey": "val2" } ] },
+			{ "eventName": "n2", "eventChannel": "c2", "eventRegex": "r2", "extra": "e2", "eventNestedValues": [ { "nestedKey": "val3" }, { "nestedKey": "val4" } ] }
 		]
 	}`)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{
 		"event_channel_settings": [
-			{ "name": "n1", "channel": "c1", "regex": "r1" },
-			{ "name": "n2", "channel": "c2", "regex": "r2" }
+			{ "name": "n1", "channel": "c1", "regex": "r1", "event_nested_values": [ "val1", "val2" ] },
+			{ "name": "n2", "channel": "c2", "regex": "r2", "event_nested_values": [ "val3", "val4" ] }
 		]
 	}`, s)
 }

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -7,6 +7,67 @@ import (
 	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
 
+func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
+	consentManagementProperties := []c.ConfigProperty{}
+	consentManagementSchema := map[string]*schema.Schema{}
+
+	if len(supportedSourceTypes) != 0 && supportedSourceTypes != nil {
+		consent_management_terraform_key := "consent_management"
+		consent_management_elements_schema := map[string]*schema.Schema{}
+
+		// Create property and schema for each source type
+		for _, sourceType := range supportedSourceTypes {
+			consentManagementProperties = append(consentManagementProperties, c.ArrayWithObjects(fmt.Sprintf("consentManagement.%s", sourceType), fmt.Sprintf("%s.0.%s", consent_management_terraform_key, sourceType), map[string]interface{}{
+				"provider": "provider",
+				"resolutionStrategy": "resolution_strategy",
+				"consents": c.APINestedObject{
+					TerraformKey: "consents",
+					NestedKey: 	"consent",
+				},
+			}))
+
+			consent_management_elements_schema[sourceType] = &schema.Schema{
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The provider name.",
+						},
+						"resolution_strategy": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The resolution strategy for the provider.",
+						},
+						"consents": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "The list of consent IDs for the provider.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			}
+		}
+
+		consentManagementSchema[consent_management_terraform_key] = &schema.Schema{
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Specify consent IDs for each CMP.",
+			Elem: &schema.Resource{
+				Schema: consent_management_elements_schema,
+			},
+		};
+	}
+
+	return consentManagementProperties, consentManagementSchema
+}
+
 func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
 	oneTrustConsentsProperties := []c.ConfigProperty{}
 	oneTrustConsentsSchema := map[string]*schema.Schema{}
@@ -51,6 +112,14 @@ func GetCommonConfigMeta(supportedSourceTypes []string) ([]c.ConfigProperty, map
 	commonProperties = append(commonProperties, oneTrustConsentFieldProperties...)
 
 	for key, value := range oneTrustConsentFieldSchema {
+		commonSchema[key] = value
+	}
+
+	gcmFieldProperties, gcmFieldSchema := GetConfigMetaForGenericConsentManagement(supportedSourceTypes)
+
+	commonProperties = append(commonProperties, gcmFieldProperties...)
+
+	for key, value := range gcmFieldSchema {
 		commonSchema[key] = value
 	}
 

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -29,6 +29,7 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 			consent_management_elements_schema[sourceType] = &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
+				ConfigMode:  schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -76,6 +76,7 @@ func TestGetCommonConfigMeta(t *testing.T) {
 							"web": {
 								Type:        schema.TypeList,
 								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
@@ -102,6 +103,7 @@ func TestGetCommonConfigMeta(t *testing.T) {
 							"android": {
 								Type:        schema.TypeList,
 								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
@@ -128,6 +130,7 @@ func TestGetCommonConfigMeta(t *testing.T) {
 							"ios": {
 								Type:        schema.TypeList,
 								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
@@ -205,6 +208,7 @@ func TestGetCommonConfigMeta(t *testing.T) {
 							"web": {
 								Type:        schema.TypeList,
 								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -24,6 +24,21 @@ func TestGetCommonConfigMeta(t *testing.T) {
 				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
 				c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
 				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
+				c.ArrayWithObjects("consentManagement.web", "consent_management.0.web", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
+				c.ArrayWithObjects("consentManagement.android", "consent_management.0.android", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
+				c.ArrayWithObjects("consentManagement.ios", "consent_management.0.ios", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
 			},
 			expectedSchema: map[string]*schema.Schema{
 				"onetrust_cookie_categories": {
@@ -51,6 +66,94 @@ func TestGetCommonConfigMeta(t *testing.T) {
 						},
 					},
 				},
+				"consent_management": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify consent IDs for each CMP.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+							"android": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+							"ios": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -70,6 +173,11 @@ func TestGetCommonConfigMeta(t *testing.T) {
 			supportedSourceTypes: []string{"web"},
 			expectedProperties: []c.ConfigProperty{
 				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+				c.ArrayWithObjects("consentManagement.web", "consent_management.0.web", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
 			},
 			expectedSchema: map[string]*schema.Schema{
 				"onetrust_cookie_categories": {
@@ -83,6 +191,42 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Type:        schema.TypeList,
 								Optional:    true,
 								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+				"consent_management": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify consent IDs for each CMP.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -37,16 +37,70 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 					shopify = ["one", "two", "three"]
 				}
 				consent_management {
-					web {
-						provider = "provider"
-						resolution_strategy = "resolution_strategy"
-						consents = ["one", "two", "three"]
-					}
-					android {
-						provider = "provider"
-						resolution_strategy = "resolution_strategy"
-						consents = ["one", "two", "three"]
-					}
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -114,34 +168,214 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 				"consentManagement": {
 					"web": [
 						{
-							"provider": "provider",
-							"resolutionStrategy": "resolution_strategy",
+							"provider": "oneTrust",
 							"consents": [
 								{
-									"consent": "one"
+									"consent": "one_web"
 								},
 								{
-									"consent": "two"
+									"consent": "two_web"
 								},
 								{
-									"consent": "three"
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
 								}
 							]
 						}
 					],
 					"android": [
 						{
-							"provider": "provider",
-							"resolutionStrategy": "resolution_strategy",
+							"provider": "ketch",
 							"consents": [
 								{
-									"consent": "one"
+									"consent": "one_android"
 								},
 								{
-									"consent": "two"
+									"consent": "two_android"
 								},
 								{
-									"consent": "three"
+									"consent": "three_android"
+								}
+							]
+						}
+					],
+					"ios": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
+					],
+					"unity": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
+					],
+					"reactnative": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
+					],
+					"flutter": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
+					],
+					"cordova": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
+					],
+					"amp": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
+					],
+					"cloud": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
+					],
+					"warehouse": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
+					],
+					"shopify": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
 								}
 							]
 						}

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -36,6 +36,18 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 					warehouse = ["one", "two", "three"]
 					shopify = ["one", "two", "three"]
 				}
+				consent_management {
+					web {
+						provider = "provider"
+						resolution_strategy = "resolution_strategy"
+						consents = ["one", "two", "three"]
+					}
+					android {
+						provider = "provider"
+						resolution_strategy = "resolution_strategy"
+						consents = ["one", "two", "three"]
+					}
+				}
 			`,
 			APIUpdate: `{
 				"apiUrl": "https://some-url",
@@ -97,6 +109,42 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 						{ "oneTrustCookieCategory": "one" },
 						{ "oneTrustCookieCategory": "two" },
 						{ "oneTrustCookieCategory": "three" }
+					]
+				},
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "provider",
+							"resolutionStrategy": "resolution_strategy",
+							"consents": [
+								{
+									"consent": "one"
+								},
+								{
+									"consent": "two"
+								},
+								{
+									"consent": "three"
+								}
+							]
+						}
+					],
+					"android": [
+						{
+							"provider": "provider",
+							"resolutionStrategy": "resolution_strategy",
+							"consents": [
+								{
+									"consent": "one"
+								},
+								{
+									"consent": "two"
+								},
+								{
+									"consent": "three"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_adobe_analytics.go
+++ b/rudderstack/integrations/destinations/destination_adobe_analytics.go
@@ -19,7 +19,7 @@ func init() {
 		c.Simple("useSecureServerSide", "use_secure_server_side"),
 		c.Simple("proxyNormalUrl", "proxy_normal_url", c.SkipZeroValue),
 		c.Simple("proxyHeartbeatUrl", "proxy_heartbeat_url", c.SkipZeroValue),
-		c.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]string{
+		c.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
@@ -29,61 +29,61 @@ func init() {
 		c.Simple("timestampOptionalReporting", "timestamp_optional_reporting"),
 		c.Simple("noFallbackVisitorId", "no_fallback_visitor_id"),
 		c.Simple("preferVisitorId", "prefer_visitor_id"),
-		c.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]string{
+		c.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.Simple("trackPageName", "track_page_name"),
-		c.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]string{
+		c.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.Simple("contextDataPrefix", "context_data_prefix", c.SkipZeroValue),
 		c.Simple("useLegacyLinkName", "use_legacy_link_name"),
 		c.Simple("pageNameFallbackTostring", "page_name_fallback_tostring"),
-		c.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]string{
+		c.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.Simple("sendFalseValues", "send_false_values"),
-		c.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]string{
+		c.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("hierMapping", "hier_mapping", map[string]string{
+		c.ArrayWithObjects("hierMapping", "hier_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("listMapping", "list_mapping", map[string]string{
+		c.ArrayWithObjects("listMapping", "list_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]string{
+		c.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 
-		c.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]string{
+		c.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]string{
+		c.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]string{
+		c.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.ArrayWithStrings("eventMerchProperties", "eventMerchProperties", "event_merch_properties"),
 
-		c.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]string{
+		c.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.ArrayWithStrings("productMerchProperties", "productMerchProperties", "product_merch_properties"),
 
-		c.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]string{
+		c.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),

--- a/rudderstack/integrations/destinations/destination_facebook_pixel.go
+++ b/rudderstack/integrations/destinations/destination_facebook_pixel.go
@@ -19,11 +19,11 @@ func init() {
 		c.Simple("testEventCode", "test_event_code", c.SkipZeroValue),
 		c.Simple("eventsToEvents", "events_to_events", c.SkipZeroValue),
 		c.ArrayWithStrings("eventCustomProperties", "eventCustomProperties", "event_custom_properties"),
-		c.ArrayWithObjects("blacklistPiiProperties", "blacklist_pii_properties", map[string]string{
+		c.ArrayWithObjects("blacklistPiiProperties", "blacklist_pii_properties", map[string]interface{}{
 			"blacklistPiiProperties": "property",
 			"blacklistPiiHash":       "hash",
 		}),
-		c.ArrayWithObjects("whitelistPiiProperties", "whitelist_pii_properties", map[string]string{
+		c.ArrayWithObjects("whitelistPiiProperties", "whitelist_pii_properties", map[string]interface{}{
 			"whitelistPiiProperties": "property",
 		}),
 		c.Simple("categoryToContent", "category_to_content", c.SkipZeroValue),

--- a/rudderstack/integrations/destinations/destination_google_ads.go
+++ b/rudderstack/integrations/destinations/destination_google_ads.go
@@ -11,11 +11,11 @@ func init() {
 
 	properties := []c.ConfigProperty{
 		c.Simple("conversionID", "conversion_id"),
-		c.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]string{
+		c.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]interface{}{
 			"conversionLabel": "label",
 			"name":            "name",
 		}),
-		c.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]string{
+		c.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]interface{}{
 			"conversionLabel": "label",
 			"name":            "name",
 		}),

--- a/rudderstack/integrations/destinations/destination_slack.go
+++ b/rudderstack/integrations/destinations/destination_slack.go
@@ -12,12 +12,12 @@ func init() {
 	properties := []c.ConfigProperty{
 		c.Simple("webhookUrl", "webhook_url"),
 		c.Simple("identifyTemplate", "identify_template", c.SkipZeroValue),
-		c.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]string{
+		c.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]interface{}{
 			"eventName":    "name",
 			"eventChannel": "channel",
 			"eventRegex":   "regex",
 		}),
-		c.ArrayWithObjects("eventTemplateSettings", "event_template_settings", map[string]string{
+		c.ArrayWithObjects("eventTemplateSettings", "event_template_settings", map[string]interface{}{
 			"eventName":     "name",
 			"eventTemplate": "template",
 			"eventRegex":    "regex",


### PR DESCRIPTION
## Description of the change

Added Generic Consent Management (GCM) fields to all the destinations.


## Linear Link

https://linear.app/rudderstack/issue/SDK-746/add-new-generic-consent-fields-for-all-destinations-in-terraform-files

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
