### PR TITLE
feat!: add generic consent management fields to destinations config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=rudderstack.com
 NAMESPACE=rudderlabs
 NAME=rudderstack
 BINARY=terraform-provider-${NAME}
-VERSION=2.0.0
+VERSION=3.0.0
 OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 
 default: install

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -161,7 +161,7 @@ func sourceName(source client.Source) string {
 	return fmt.Sprintf("src_%s", source.ID)
 }
 
-// generateDestination genertes a destination resource block from an API destinaton object and a terraform destination type and ConfigMeta.
+// generateDestination generates a destination resource block from an API destination object and a terraform destination type and ConfigMeta.
 func generateDestination(destination client.Destination, terraformType string, cm *configs.ConfigMeta) (*hclwrite.Block, error) {
 	resourceType := destinationType(terraformType)
 	resourceName := destinationName(destination)
@@ -224,12 +224,12 @@ func generateConfigBlock(config json.RawMessage, cm *configs.ConfigMeta) (*hclwr
 }
 
 // generateBlock generate blocks with specified name and data which conform to the provided config schema.
-// data should be unmarshaled from a state JSON object.
+// data should be unmarshalled from a state JSON object.
 func generateBlock(name string, data map[string]interface{}, configSchema map[string]*schema.Schema) (*hclwrite.Block, error) {
 	block := hclwrite.NewBlock(name, []string{})
 	body := block.Body()
 
-	// go does not garantee the order of range in maps, we sort the keys so that the output is predictable
+	// go does not guarantee the order of range in maps, we sort the keys so that the output is predictable
 	var keys []string
 	for k := range data {
 		keys = append(keys, k)

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -73,11 +73,53 @@ func TestGeneratorTerraform(t *testing.T) {
 				"categoryToContent": [{ "from": "from", "to": "to" }],
 				"legacyConversionPixelId": { "from": "from", "to": "to" },
 				"useNativeSDK": { "web": true },
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					]
 				},
 				"blacklistedEvents": [
@@ -135,9 +177,12 @@ resource "rudderstack_destination_redshift" "dst_id-redshift" {
 resource "rudderstack_destination_facebook_pixel" "dst_id-facebook-pixel" {
   name = "name-facebook-pixel"
   config {
-    access_token            = "facebook access token"
-    advanced_mapping        = true
-    category_to_content     = [{ from = "from", to = "to" }]
+    access_token        = "facebook access token"
+    advanced_mapping    = true
+    category_to_content = [{ from = "from", to = "to" }]
+    consent_management {
+      web = [{ consents = ["one_web", "two_web", "three_web"], provider = "oneTrust", resolution_strategy = "" }, { consents = ["one_web", "two_web", "three_web"], provider = "ketch", resolution_strategy = "" }, { consents = ["one_web", "two_web", "three_web"], provider = "custom", resolution_strategy = "and" }]
+    }
     event_custom_properties = ["one", "two", "three"]
     event_filtering {
       blacklist = ["one", "two", "three"]
@@ -146,9 +191,6 @@ resource "rudderstack_destination_facebook_pixel" "dst_id-facebook-pixel" {
     legacy_conversion_pixel_id {
       from = "from"
       to   = "to"
-    }
-    onetrust_cookie_categories {
-      web = ["one", "two", "three"]
     }
     pixel_id           = "facebook pixel id"
     standard_page_call = true

--- a/docs/guides/import.md
+++ b/docs/guides/import.md
@@ -46,7 +46,7 @@ terraform {
   required_providers {
     rudderstack = {
       source  = "rudderlabs/rudderstack"
-      version = "~> 2.0.0"
+      version = "~> 3.0.0"
     }
   }
   required_version = "~> 1.1.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     rudderstack = {
       source  = "rudderlabs/rudderstack"
-      version = "~> 2.0.0"
+      version = "~> 3.0.0"
     }
   }
   required_version = "~> 1.1.0"
@@ -28,6 +28,9 @@ provider "rudderstack" {
 }
 ```
 
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the examples in the destinations` resource guide.
 
 > **:warning: Breaking Change**
 > 

--- a/docs/resources/destination_LINKEDIN_INSIGHT_TAG.md
+++ b/docs/resources/destination_LINKEDIN_INSIGHT_TAG.md
@@ -33,13 +33,33 @@ resource "rudderstack_destination_linkedin_insight_tag" "example" {
 #    event_filtering {
 #      whitelist = ["one", "two", "three"]
 #    }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
     }
   
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -72,10 +92,28 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_filtering` (Block List, Max: 1) With this option, you can determine which events are blocked or allowed to flow through to LinkedIn. (see [below for nested schema](#nestedblock--config--event_filtering))
 - `event_to_conversion_id_map` (List of Object) Event Conversion IDs. (see [below for nested schema](#nestedatt--config--event_to_conversion_id_map))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `use_native_sdk` (Block List, Max: 1) As this is a device mode destination, this setting will always be enabled. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -93,14 +131,6 @@ Optional:
 
 - `from` (String)
 - `to` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_active_campaign.md
+++ b/docs/resources/destination_active_campaign.md
@@ -22,22 +22,82 @@ resource "rudderstack_destination_active_campaign" "example" {
 
     # actid     = "..."
     # event_key = "..."
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -72,22 +132,131 @@ Required:
 Optional:
 
 - `actid` (String) Enter your ActID here. To obtain the ActID unique to your ActiveCampaign account, go to Settings > Tracking > Event Tracking API.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_key` (String) Enter the event key unique to your ActiveCampaign account. To obtain the event key, go to your ActiveCampaign account > Settings > Tracking > Event Tracking.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_adobe_analytics.md
+++ b/docs/resources/destination_adobe_analytics.md
@@ -104,22 +104,82 @@ resource "rudderstack_destination_adobe_analytics" "example" {
     #   android      = false
     #   react_native = true
     #  }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -152,6 +212,7 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `context_data_mapping` (List of Object) You can map Rudder Context data to Adobe Context Data (see [below for nested schema](#nestedatt--config--context_data_mapping))
 - `context_data_prefix` (String) Enter your prefix to add before all contextData property.
 - `custom_props_mapping` (List of Object) You can map Rudder properties to Adobe Custom properties (see [below for nested schema](#nestedatt--config--custom_props_mapping))
@@ -168,7 +229,6 @@ Optional:
 - `marketing_cloud_org_id` (String) Enter your Marketing Cloud Organization Id.
 - `mobile_event_mapping` (List of Object) You can map Rudder mobile events. (see [below for nested schema](#nestedatt--config--mobile_event_mapping))
 - `no_fallback_visitor_id` (Boolean) Check to enable no fallbacks for Visitor ID
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `page_name_fallback_tostring` (Boolean) Check to allow Page Name Fallback to Screen
 - `prefer_visitor_id` (Boolean) Check to prefer Visitor Id
 - `product_identifier` (String) Enter your Product Identifier
@@ -190,6 +250,134 @@ Optional:
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send events to Adobe Analytics via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
 - `use_secure_server_side` (Boolean) Use Secure URL for Server-side
 - `use_utf8_charset` (Boolean) Use UTF-8 charset
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedatt--config--context_data_mapping"></a>
 ### Nested Schema for `config.context_data_mapping`
@@ -279,24 +467,6 @@ Optional:
 
 - `from` (String)
 - `to` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedatt--config--product_merch_evars_map"></a>

--- a/docs/resources/destination_amplitude.md
+++ b/docs/resources/destination_amplitude.md
@@ -121,24 +121,84 @@ resource "rudderstack_destination_amplitude" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     # residency_server = "EU"
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -173,6 +233,7 @@ Optional:
 
 - `api_secret` (String, Sensitive) Enter the Amplitude API Secret key required for user deletion.
 - `batch_events` (Block List, Max: 1) If this setting is enabled, the events are batched together and uploaded by the Amplitude SDK. (see [below for nested schema](#nestedblock--config--batch_events))
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `device_id_from_url_param` (Block List, Max: 1) If this setting is enabled, the Amplitude SDK will parse the URL parameter and set the device ID from `amp_device_id`. (see [below for nested schema](#nestedblock--config--device_id_from_url_param))
 - `enable_location_listening` (Block List, Max: 1) Enable this setting to activate location listening. (see [below for nested schema](#nestedblock--config--enable_location_listening))
 - `event_filtering` (Block List, Max: 1) This option allows you filter the events you want to send to Amplitude. (see [below for nested schema](#nestedblock--config--event_filtering))
@@ -182,7 +243,6 @@ Optional:
 - `group_type_trait` (String) RudderStack will use this value as `groupType` in the `group` calls.
 - `group_value_trait` (String) RudderStack will use this value as `groupValue` in the `group` calls.
 - `map_device_brand` (Boolean) Enable this setting for RudderStack to send the device brand information (`context.device.brand`) to Amplitude.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `prefer_anonymous_id_for_device_id` (Block List, Max: 1) If this setting is enabled, the device ID will be set as the `anonymousId` generated by RudderStack SDK or by the `anonymousId` set via RudderStack's `setAnonymousId()` method. (see [below for nested schema](#nestedblock--config--prefer_anonymous_id_for_device_id))
 - `residency_server` (String)
 - `save_params_referrer_once_per_session` (Block List, Max: 1) If this setting is enabled, the corresponding tracking of `gclid`, referrer, UTM parameters will be done once per session. (see [below for nested schema](#nestedblock--config--save_params_referrer_once_per_session))
@@ -211,6 +271,134 @@ Optional:
 Optional:
 
 - `web` (Boolean)
+
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
 
 
 <a id="nestedblock--config--device_id_from_url_param"></a>
@@ -267,24 +455,6 @@ Optional:
 Optional:
 
 - `web` (Boolean)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--prefer_anonymous_id_for_device_id"></a>

--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -24,18 +24,74 @@ resource "rudderstack_destination_bigquery" "example" {
     # location  = "us-east1"
     # prefix    = ""
     # namespace = ""
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     sync {
@@ -47,6 +103,10 @@ resource "rudderstack_destination_bigquery" "example" {
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -82,9 +142,9 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `location` (String) Enter the GCP region of your project dataset.
 - `namespace` (String) Enter the schema name where RudderStack will create all the tables. If not specified, RudderStack will set this to the source name by default.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `prefix` (String) If specified, RudderStack creates a folder in the bucket with this prefix and loads all the data in it.
 
 <a id="nestedblock--config--sync"></a>
@@ -101,19 +161,128 @@ Optional:
 - `start_at` (String) Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to BigQuery.
 
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cloud_source` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cloud_source` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud_source))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud_source"></a>
+### Nested Schema for `config.consent_management.cloud_source`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_braze.md
+++ b/docs/resources/destination_braze.md
@@ -41,22 +41,82 @@ resource "rudderstack_destination_braze" "example" {
        whitelist = ["one", "two", "three"]
        # blacklist = ["one", "two", "three"]
     }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -92,12 +152,12 @@ Optional:
 
 - `allow_user_supplied_javascript` (Block List, Max: 1) Use this setting to enable HTML in-app messages. (see [below for nested schema](#nestedblock--config--allow_user_supplied_javascript))
 - `app_key` (String, Sensitive) Enter your Braze APP Key. Required for Device mode.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `enable_braze_logging` (Block List, Max: 1) Use this setting to show braze logs to customer. (see [below for nested schema](#nestedblock--config--enable_braze_logging))
 - `enable_nested_array_operations` (Boolean) Use this setting to use Custom Attributes Operation.
 - `enable_push_notification` (Block List, Max: 1) Use this setting to use push notification. It requires service worker setup by client. (see [below for nested schema](#nestedblock--config--enable_push_notification))
 - `enable_subscription_group_in_group_call` (Boolean) Use this setting to Enable subscription groups in group call
 - `event_filtering` (Block List, Max: 1) This option allows you filter the events you want to send to Braze. (see [below for nested schema](#nestedblock--config--event_filtering))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `rest_api_key` (String, Sensitive) Enter your Braze Rest Api Key. Required for cloud mode.
 - `send_purchase_event_with_extra_properties` (Boolean) Use this setting to Enable to send purchase events with custom properties.
 - `support_dedup` (Boolean) Use this setting to enable Deduplicate Traits on identify and track.
@@ -129,6 +189,134 @@ Optional:
 - `web` (Boolean)
 
 
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+
 <a id="nestedblock--config--enable_braze_logging"></a>
 ### Nested Schema for `config.enable_braze_logging`
 
@@ -152,21 +340,3 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)

--- a/docs/resources/destination_customerio.md
+++ b/docs/resources/destination_customerio.md
@@ -32,22 +32,82 @@ resource "rudderstack_destination_customerio" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -81,11 +141,139 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `datacenter_eu` (Boolean) Enable this option in case your account is based in the EU region.
 - `device_token_event_name` (String) Enter the name of the event that is fired immediately after setting the device token.
 - `event_filtering` (Block List, Max: 1) RudderStack lets you determine which events should be allowed to flow through or blocked. (see [below for nested schema](#nestedblock--config--event_filtering))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events through Customer.io's native JavaScript SDK. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -94,24 +282,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_facebook_pixel.md
+++ b/docs/resources/destination_facebook_pixel.md
@@ -67,22 +67,82 @@ resource "rudderstack_destination_facebook_pixel" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -119,11 +179,11 @@ Optional:
 - `advanced_mapping` (Boolean) With this setting, you can enable the advanced mapping feature.
 - `blacklist_pii_properties` (List of Object) Enter the PII properties to be denylisted. (see [below for nested schema](#nestedatt--config--blacklist_pii_properties))
 - `category_to_content` (List of Object) This option lets you specify the category fields to specific Facebook content type. (see [below for nested schema](#nestedatt--config--category_to_content))
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_custom_properties` (List of String) For the standard events, some predefined properties are taken by Facebook. If you want to send more properties for your events, mention those properties in this field.
 - `event_filtering` (Block List, Max: 1) This setting lets you determine which events are blocked or allowed to flowed through to Facebook Pixel. (see [below for nested schema](#nestedblock--config--event_filtering))
 - `events_to_events` (List of Object) You can map your events to standard Facebook events using this setting. (see [below for nested schema](#nestedatt--config--events_to_events))
 - `legacy_conversion_pixel_id` (Block List, Max: 1) With this setting, you can send specific events to a legacy conversion Pixel by specifying the event-Pixel ID mapping. Note that this option is available only when sending events via the device mode. (see [below for nested schema](#nestedblock--config--legacy_conversion_pixel_id))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `standard_page_call` (Boolean) If this setting is enabled, RudderStack sets `pageview` as a standard event for all the `page` and `screen` calls.
 - `test_destination` (Boolean) Enable this setting if you are using this destination for testing purposes.
 - `test_event_code` (String) If the above setting is enabled, enter the relevant test event code.
@@ -147,6 +207,134 @@ Optional:
 
 - `from` (String)
 - `to` (String)
+
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
 
 
 <a id="nestedblock--config--event_filtering"></a>
@@ -174,24 +362,6 @@ Required:
 
 - `from` (String)
 - `to` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_gcs.md
+++ b/docs/resources/destination_gcs.md
@@ -21,22 +21,82 @@ resource "rudderstack_destination_gcs" "example" {
 
     # prefix        = "prefix"
     # credentials   = "..."
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -69,23 +129,132 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `credentials` (String, Sensitive) Enter the contents of your Google Cloud connection credentials JSON.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `prefix` (String) Enter your prefix which RudderStack associates with your GCS bucket before loading all the data into it.
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_google_ads.md
+++ b/docs/resources/destination_google_ads.md
@@ -52,12 +52,32 @@ resource "rudderstack_destination_google_ads" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -91,12 +111,12 @@ Required:
 Optional:
 
 - `click_event_conversions` (List of Object) For `track` calls, you can configure these fields. (see [below for nested schema](#nestedatt--config--click_event_conversions))
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `conversion_linker` (Boolean) This setting is enabled by default. If you don't want the global site tag (gtag.js) to set first-party cookies on your website domain, you should disable this setting.
 - `default_page_conversion` (String) Enter the default conversion label.
 - `disable_ad_personalization` (Boolean) Enable this setting to programmatically disable ad personalization.
 - `dynamic_remarketing` (Block List, Max: 1) Enabling this tracking mode allows RudderStack to leverage Google Ads' Dynamic Remarketing feature for event tracking. (see [below for nested schema](#nestedblock--config--dynamic_remarketing))
 - `event_filtering` (Block List, Max: 1) With this option, you can determine which events are blocked or allowed to flow through to Google Ads. (see [below for nested schema](#nestedblock--config--event_filtering))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `page_load_conversions` (List of Object) You can configure the page load conversions for multiple instances. (see [below for nested schema](#nestedatt--config--page_load_conversions))
 - `send_page_view` (Boolean) Enabling this setting configures Google Ads to automatically send your `page` events.
 - `use_native_sdk` (Block List, Max: 1) As this is a device mode destination, this setting will always be enabled. (see [below for nested schema](#nestedblock--config--use_native_sdk))
@@ -108,6 +128,24 @@ Optional:
 
 - `label` (String)
 - `name` (String)
+
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
 
 
 <a id="nestedblock--config--dynamic_remarketing"></a>
@@ -125,14 +163,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `web` (List of String)
 
 
 <a id="nestedatt--config--page_load_conversions"></a>

--- a/docs/resources/destination_google_analytics.md
+++ b/docs/resources/destination_google_analytics.md
@@ -81,18 +81,74 @@ resource "rudderstack_destination_google_analytics" "example" {
     #   web = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     # content_groupings = [{
@@ -107,6 +163,10 @@ resource "rudderstack_destination_google_analytics" "example" {
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -140,6 +200,7 @@ Required:
 Optional:
 
 - `anonymize_ip` (Boolean) Enabling this setting anonymizes your IP address information.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `content_groupings` (List of Object) (see [below for nested schema](#nestedatt--config--content_groupings))
 - `dimensions` (List of Object) (see [below for nested schema](#nestedatt--config--dimensions))
 - `disable_md5` (Boolean) Enable this setting to disable client ID MD5 encryption.
@@ -151,7 +212,6 @@ Optional:
 - `include_search` (Boolean) Enable this setting to include the querystring in `page` views.
 - `named_tracker` (Block List, Max: 1) Enable this setting to send events with the `track` name `rudderGATracker`. (see [below for nested schema](#nestedblock--config--named_tracker))
 - `non_interaction` (Boolean) Enable this setting to add the non-interaction flag to all the events.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `optimize` (Block List, Max: 1) Enter your Google Optimize Container ID. (see [below for nested schema](#nestedblock--config--optimize))
 - `reset_custom_dimensions_on_page` (Block List, Max: 1) Use this field to reset the dimensions for the `page` calls. (see [below for nested schema](#nestedblock--config--reset_custom_dimensions_on_page))
 - `sample_rate` (Block List, Max: 1) Enter the sample rate. (see [below for nested schema](#nestedblock--config--sample_rate))
@@ -163,6 +223,134 @@ Optional:
 - `track_named_pages` (Block List, Max: 1) Enable this setting to track named pages. (see [below for nested schema](#nestedblock--config--track_named_pages))
 - `use_google_amp_client_id` (Block List, Max: 1) Enable this setting to use the Google AMP Client ID (see [below for nested schema](#nestedblock--config--use_google_amp_client_id))
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events via the web device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedatt--config--content_groupings"></a>
 ### Nested Schema for `config.content_groupings`
@@ -205,24 +393,6 @@ Optional:
 Required:
 
 - `web` (Boolean)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--optimize"></a>

--- a/docs/resources/destination_google_analytics4.md
+++ b/docs/resources/destination_google_analytics4.md
@@ -38,22 +38,82 @@ resource "rudderstack_destination_google_analytics4" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -88,13 +148,141 @@ Optional:
 
 - `api_secret` (String, Sensitive) This field is required only for the cloud mode setup where you can enter the API Secret generated through the Google Analytics dashboard.
 - `block_page_view_event` (Boolean) Enable this setting to disable sending `page_view` events on load. This setting is applicable only for device mode.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_filtering` (Block List, Max: 1) With this option, you can determine which events are blocked or allowed to flow through to Google Analytics 4. (see [below for nested schema](#nestedblock--config--event_filtering))
 - `extend_page_view_params` (Boolean) Enable this setting to send `url` and `search` along with any other custom property to the `page` call of the RudderStack SDK. This setting is applicable only for device mode.
 - `firebase_app_id` (String) Enter the Firebase App ID which is the identifier for Firebase app.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `send_user_id` (Boolean) If enabled, the user ID is set to the identified visitors and sent to Google Analytics 4.
 - `types_of_client` (String) Select the client type as gtag or Firebase.
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -103,24 +291,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_google_sheets.md
+++ b/docs/resources/destination_google_sheets.md
@@ -32,10 +32,82 @@ resource "rudderstack_destination_google_sheets" "example" {
 #      }
 #    ]
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
+    # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -70,8 +142,136 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_key_map` (List of Object) Add Event Properties to map to Google-Sheets Column. (see [below for nested schema](#nestedatt--config--event_key_map))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedatt--config--event_key_map"></a>
 ### Nested Schema for `config.event_key_map`
@@ -80,21 +280,3 @@ Optional:
 
 - `from` (String)
 - `to` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)

--- a/docs/resources/destination_google_tag_manager.md
+++ b/docs/resources/destination_google_tag_manager.md
@@ -30,12 +30,32 @@ resource "rudderstack_destination_google_tag_manager" "example" {
       blacklist = ["one", "two", "three"]
     }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -68,10 +88,28 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_filtering` (Block List, Max: 1) With this option, you can determine which events are blocked or allowed to flow through to GTM. (see [below for nested schema](#nestedblock--config--event_filtering))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `server_url` (String) Specify Tag Manager server container URL.
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -80,14 +118,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_intercom.md
+++ b/docs/resources/destination_intercom.md
@@ -26,25 +26,84 @@ resource "rudderstack_destination_intercom" "example" {
 #    event_filtering {
 #      blacklist = [ "one", "two", "three" ]
 #    }
-#    onetrust_cookie_categories = ["one", "two", "three"]
 #    mobile_api_key_android = "and-key"
 #    mobile_api_key_ios = "ios-key"
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -79,13 +138,141 @@ Required:
 Optional:
 
 - `collect_context` (Boolean) Enable this setting to include the user context along with your identify calls.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_filtering` (Block List, Max: 1) Use this setting to determine which events should be blocked or allowed to flow through. (see [below for nested schema](#nestedblock--config--event_filtering))
 - `mobile_api_key_android` (String) Enter the Android API Key.
 - `mobile_api_key_ios` (String) Enter the iOS API Key.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `send_anonymous_id` (Boolean) Enable this setting to send anonymousId as the secondary userId.
 - `update_last_request_at` (Boolean) Enable this setting to send the last seen information with the current time.
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events through device mode, that is, using the native SDK. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -94,24 +281,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_iterable.md
+++ b/docs/resources/destination_iterable.md
@@ -86,22 +86,82 @@ resource "rudderstack_destination_iterable" "example" {
       # close_button_position { 
       #   web = "" 
       # }
-      # onetrust_cookie_categories {
-      #   web = ["one", "two", "three"]
-      #   android = ["one", "two", "three"]
-      #   ios = ["one", "two", "three"]
-      #   unity = ["one", "two", "three"]
-      #   reactnative = ["one", "two", "three"]
-      #   flutter = ["one", "two", "three"]
-      #   cordova = ["one", "two", "three"]
-      #   amp = ["one", "two", "three"]
-      #   cloud = ["one", "two", "three"]
-      #   warehouse = ["one", "two", "three"]
-      #   shopify = ["one", "two", "three"]
-      # }
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
+    # }
     }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -141,6 +201,7 @@ Optional:
 - `close_button_color_top_offset` (Block List, Max: 1) Space between button & container top (see [below for nested schema](#nestedblock--config--close_button_color_top_offset))
 - `close_button_position` (Block List, Max: 1) Position (see [below for nested schema](#nestedblock--config--close_button_position))
 - `close_button_size` (Block List, Max: 1) Size of Close button (see [below for nested schema](#nestedblock--config--close_button_size))
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `display_interval` (Block List, Max: 1) Wait time for next message (see [below for nested schema](#nestedblock--config--display_interval))
 - `get_in_app_event_mapping` (Block List, Max: 1) Mapping to trigger the getInApp messages (see [below for nested schema](#nestedblock--config--get_in_app_event_mapping))
 - `handle_links` (Block List, Max: 1) Control how to open links. (see [below for nested schema](#nestedblock--config--handle_links))
@@ -150,7 +211,6 @@ Optional:
 - `map_to_single_event` (Boolean) Map All Pages to Single Event Name
 - `on_open_node_to_take_focus` (Block List, Max: 1) Focus Element (see [below for nested schema](#nestedblock--config--on_open_node_to_take_focus))
 - `on_open_screen_reader_message` (Block List, Max: 1) Screen Reader Text (see [below for nested schema](#nestedblock--config--on_open_screen_reader_message))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `package_name` (Block List, Max: 1) Package Name (see [below for nested schema](#nestedblock--config--package_name))
 - `purchase_event_mapping` (List of Object) Mapping to trigger the getInApp messages (see [below for nested schema](#nestedatt--config--purchase_event_mapping))
 - `right_offset` (Block List, Max: 1) Space (px or %) between screen right & messages. (see [below for nested schema](#nestedblock--config--right_offset))
@@ -217,6 +277,134 @@ Optional:
 - `web` (String)
 
 
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+
 <a id="nestedblock--config--display_interval"></a>
 ### Nested Schema for `config.display_interval`
 
@@ -279,24 +467,6 @@ Optional:
 Optional:
 
 - `web` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--package_name"></a>

--- a/docs/resources/destination_kafka.md
+++ b/docs/resources/destination_kafka.md
@@ -32,11 +32,83 @@ resource "rudderstack_destination_kafka" "example" {
     # #   schema    = "bar"
     # # }]
     # embed_avro_schema_id       = true
-    # onetrust_cookie_categories = ["analytics"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
+    # }
   }
 
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -73,12 +145,12 @@ Optional:
 
 - `avro_schema` (List of Object) The Avro schema for the Kafka service. (see [below for nested schema](#nestedatt--config--avro_schema))
 - `ca_certificate` (String) The CA certificate for the Kafka service.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `convert_to_avro` (Boolean) Whether to convert the data to Avro format.
 - `embed_avro_schema_id` (Boolean) Whether to embed the Avro schema ID.
 - `enable_multi_topic` (Boolean) Whether to enable multi-topic.
 - `event_to_topic_map` (List of Object) The event to topic map for the Kafka service. (see [below for nested schema](#nestedatt--config--event_to_topic_map))
 - `event_type_to_topic_map` (List of Object) The event type to topic map for the Kafka service. (see [below for nested schema](#nestedatt--config--event_type_to_topic_map))
-- `onetrust_cookie_categories` (List of String) Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.
 - `password` (String, Sensitive) The password for the Kafka service.
 - `sasl_type` (String) The SASL type for the Kafka service.
 - `ssl_enabled` (Boolean) Whether to enable SSL for the Kafka service.
@@ -92,6 +164,134 @@ Optional:
 
 - `schema` (String)
 - `schema_id` (String)
+
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
 
 
 <a id="nestedatt--config--event_to_topic_map"></a>

--- a/docs/resources/destination_kinesis.md
+++ b/docs/resources/destination_kinesis.md
@@ -29,22 +29,82 @@ resource "rudderstack_destination_kinesis" "example" {
           # access_key    = ""
     #    }
     # use_message_id   = false
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -78,10 +138,138 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `key_based_authentication` (Block List, Max: 1) This option allows you select the key based authentication. (see [below for nested schema](#nestedblock--config--key_based_authentication))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `role_based_authentication` (Block List, Max: 1) This option allows you select the arn based authentication. (see [below for nested schema](#nestedblock--config--role_based_authentication))
 - `use_message_id` (Boolean) Use MessageId as Partition Key
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--key_based_authentication"></a>
 ### Nested Schema for `config.key_based_authentication`
@@ -90,24 +278,6 @@ Required:
 
 - `access_key` (String, Sensitive) Enter the AWS Secret Access Key.
 - `access_key_id` (String, Sensitive) Enter the AWS Access Key ID.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--role_based_authentication"></a>

--- a/docs/resources/destination_marketo.md
+++ b/docs/resources/destination_marketo.md
@@ -44,22 +44,82 @@ resource "rudderstack_destination_marketo" "example" {
         to   = "value1"
       }
     ]
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -95,10 +155,10 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `create_if_not_exist` (Boolean) Boolean flag to create lead if not exist
 - `custom_activity_property_map` (List of Object) Custom Activity Property Map (see [below for nested schema](#nestedatt--config--custom_activity_property_map))
 - `lead_trait_mapping` (List of Object) Lead Trait Mapping (see [below for nested schema](#nestedatt--config--lead_trait_mapping))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `rudder_events_mapping` (List of Object) Rudder Events Mapping (see [below for nested schema](#nestedatt--config--rudder_events_mapping))
 - `track_anonymous_events` (Boolean) Boolean flag to track anonymous events
 
@@ -120,6 +180,134 @@ Optional:
 - `web` (String)
 
 
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+
 <a id="nestedatt--config--custom_activity_property_map"></a>
 ### Nested Schema for `config.custom_activity_property_map`
 
@@ -136,24 +324,6 @@ Optional:
 
 - `from` (String)
 - `to` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedatt--config--rudder_events_mapping"></a>

--- a/docs/resources/destination_mixpanel.md
+++ b/docs/resources/destination_mixpanel.md
@@ -44,23 +44,83 @@ resource "rudderstack_destination_mixpanel" example{
     #   blacklist = ["one","two","three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
     # use_new_mapping = true
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -96,12 +156,12 @@ Required:
 Optional:
 
 - `api_secret` (String, Sensitive) Mixpanel API secret
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `consolidated_page_calls` (Boolean) This will track Loaded a Page events to Mixpanel for all page method calls. We enable this by default as it's how Mixpanel suggests sending these calls.
 - `cross_subdomain_cookie` (Boolean) This will allow the Mixpanel cookie to persist between different pages of your application.
 - `event_filtering` (Block List, Max: 1) With this option, you can determine which events are blocked or allowed to flow through to Mixpanel. (see [below for nested schema](#nestedblock--config--event_filtering))
 - `event_increments` (List of String) Events to increment in People.
 - `group_key_settings` (List of String) Group Key
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `people` (Boolean) Boolean flag to send all of your identify calls to Mixpanel's People feature
 - `people_properties` (List of String) Traits to set as People Properties.
 - `prop_increments` (List of String) Properties to increment in People
@@ -114,6 +174,134 @@ Optional:
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
 - `use_new_mapping` (Boolean) This value is true by default and when this flag is enabled, camel case fields are mapped to snake case fields while sending to Mixpanel. Please refer to https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/#connection-settings for more details.
 
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
 
@@ -121,24 +309,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_postgres.md
+++ b/docs/resources/destination_postgres.md
@@ -23,22 +23,82 @@ resource "rudderstack_destination_postgres" "example" {
     password    = "..."
     port        = "1234"
     use_rudder_storage = true
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -77,26 +137,135 @@ Optional:
 
 - `client_cert` (String) Enter your Client Cert Pem File
 - `client_key` (String) Enter your Client Key Pem File
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `namespace` (String) Enter the namespace of your PostgreSQL database.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `port` (String) Enter the port number of your PostgreSQL database.
 - `server_ca` (String) Enter your Server CA Pem File
 - `ssl_mode` (String) Enter the SSL mode of your PostgreSQL database.
 - `sync_frequency` (String) Enter the frequency at which the data should be synced from your PostgreSQL database.
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cloud_source` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cloud_source` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud_source))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud_source"></a>
+### Nested Schema for `config.consent_management.cloud_source`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_qualtrics.md
+++ b/docs/resources/destination_qualtrics.md
@@ -30,14 +30,42 @@ resource "rudderstack_destination_qualtrics" example{
     #   blacklist = ["one","two","three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -71,10 +99,50 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `enable_generic_page_title` (Boolean) This setting enables Generic Page Title.
 - `event_filtering` (Block List, Max: 1) RudderStack lets you determine which events should be allowed to flow through or blocked. (see [below for nested schema](#nestedblock--config--event_filtering))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events through SDKs. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -83,16 +151,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be blacklisted.
 - `whitelist` (List of String) Enter the event names to be whitelisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `android` (List of String)
-- `ios` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_redis.md
+++ b/docs/resources/destination_redis.md
@@ -26,22 +26,82 @@ resource "rudderstack_destination_redis" "example" {
     # database      = "..."
     # ca_certificate = "..."
     # skip_verify   = false
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -76,26 +136,135 @@ Optional:
 
 - `ca_certificate` (String) Enter the certificate which needs to be verified while establishing a secure connection. Skip setting this if Root CA of your server can be verified with any client, e.g. AWS Elasticache.
 - `cluster_mode` (Boolean) Use this setting to enable the Redis cluster mode.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `database` (String) RudderStack stores the user traits in the default database of the Redis instance. A different database inside the Redis instance can be configured using this setting.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `password` (String, Sensitive) Enter the password associated with your Redis user.
 - `prefix` (String) By default, RudderStack stores user traits with the key user:<user_id>. An extra prefix can be added in the destination configuration to distinguish all RudderStack-stored keys with a prefix.
 - `secure` (Boolean) Enable this setting if you want to send the data to Redis via SSL.
 - `skip_verify` (Boolean) Enable this setting to skip the client's verification of the server's certificate chain and host name.
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_redshift.md
+++ b/docs/resources/destination_redshift.md
@@ -34,18 +34,74 @@ resource "rudderstack_destination_redshift" "example" {
     #   access_key    = ""
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     sync {
@@ -58,6 +114,10 @@ resource "rudderstack_destination_redshift" "example" {
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -97,8 +157,8 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `enable_sse` (Boolean) This setting enables server-side encryption.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `s3` (Block List, Max: 1) (see [below for nested schema](#nestedblock--config--s3))
 
 <a id="nestedblock--config--sync"></a>
@@ -115,22 +175,132 @@ Optional:
 - `start_at` (String) Specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.
 
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cloud_source` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cloud_source` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud_source))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud_source"></a>
+### Nested Schema for `config.consent_management.cloud_source`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
 
 
 <a id="nestedblock--config--s3"></a>

--- a/docs/resources/destination_s3.md
+++ b/docs/resources/destination_s3.md
@@ -24,22 +24,82 @@ resource "rudderstack_destination_s3" "example" {
     # access_key    = "..."
 
     # enable_sse    = true
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -74,23 +134,132 @@ Optional:
 
 - `access_key` (String, Sensitive) Enter your AWS secret access key.
 - `access_key_id` (String) Enter your AWS access key ID.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `enable_sse` (Boolean) This setting enables server-side encryption.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `prefix` (String) Enter a prefix which RudderStack associates as the path prefix to all the files stored in your S3 bucket.
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_s3_datalake.md
+++ b/docs/resources/destination_s3_datalake.md
@@ -26,18 +26,74 @@ resource "rudderstack_destination_s3_datalake" "example" {
 
     # enable_sse    = true
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     use_glue = true
@@ -50,6 +106,10 @@ resource "rudderstack_destination_s3_datalake" "example" {
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -86,9 +146,9 @@ Optional:
 
 - `access_key` (String, Sensitive) Enter your AWS secret access key.
 - `access_key_id` (String) Enter your AWS access key ID.
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `enable_sse` (Boolean) This setting enables server-side encryption.
 - `namespace` (String) If specified, all the data for the destination will be pushed to `s3://<bucketName>/<prefix>/rudder-datalake/<namespace>`.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `prefix` (String) If specified, RudderStack creates a folder in the bucket with this prefix and push all the data within that folder.
 - `region` (String) Enter your AWS Glue region. For example, for N.Virginia, it would be `us-east-1`.
 
@@ -104,19 +164,128 @@ Optional:
 - `start_at` (String) This optional setting lets you specify the particular time of the day (in UTC) when you want RudderStack to sync the data to the warehouse.
 
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cloud_source` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cloud_source` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud_source))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud_source"></a>
+### Nested Schema for `config.consent_management.cloud_source`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_salesforce.md
+++ b/docs/resources/destination_salesforce.md
@@ -23,22 +23,82 @@ resource "rudderstack_destination_salesforce" "example" {
 
     # use_contact_id    = true
     # map_properties    = true
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -73,24 +133,133 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `map_properties` (Boolean) Use this setting to map RudderStack event properties to specific Salesforce fields.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `sandbox` (Boolean) Use this setting to enable Salesforce sandbox mode.
 - `use_contact_id` (Boolean) When enabled, RudderStack uses contactId for the converted leads.
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_sentry.md
+++ b/docs/resources/destination_sentry.md
@@ -40,12 +40,32 @@ resource "rudderstack_destination_sentry" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -79,6 +99,7 @@ Required:
 Optional:
 
 - `allow_urls` (List of String)
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `custom_version_property` (String) This field helps you dynamically track the application version in Sentry.
 - `debug_mode` (Boolean) If enabled, no events are sent to your Sentry instance.
 - `deny_urls` (List of String) This is the list of the regex patterns or exact URL strings - from which the errors need to be exclusively sent to Sentry.
@@ -87,10 +108,27 @@ Optional:
 - `ignore_errors` (List of String) This option refers to a list of error messages that you do not want Sentry to notify you.
 - `include_paths` (List of String) This field should contain the regex patterns of URLs that are part of the app in the stack trace.
 - `logger` (String) Set the name you want Sentry to use as logger.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `release` (String) This field is used for tracking your application's version in Sentry.
 - `server_name` (String) This option is used to track the host on which the client is running.
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -99,14 +137,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_slack.md
+++ b/docs/resources/destination_slack.md
@@ -39,22 +39,82 @@ resource "rudderstack_destination_slack" "example" {
 
     # whitelisted_trait_settings = ["one", "two", "three"]
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -87,11 +147,139 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_channel_settings` (List of Object) Specify your event channel settings. (see [below for nested schema](#nestedatt--config--event_channel_settings))
 - `event_template_settings` (List of Object) Specify your event template settings. (see [below for nested schema](#nestedatt--config--event_template_settings))
 - `identify_template` (String) Specify the template that you want the `identify` event to be transformed to before it is sent to Slack.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `whitelisted_trait_settings` (List of String) Only the traits listed in this section are considered to be a part of the identify template. The rest are sent to Slack.
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedatt--config--event_channel_settings"></a>
 ### Nested Schema for `config.event_channel_settings`
@@ -111,21 +299,3 @@ Optional:
 - `name` (String)
 - `regex` (Boolean)
 - `template` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)

--- a/docs/resources/destination_snowflake.md
+++ b/docs/resources/destination_snowflake.md
@@ -50,22 +50,82 @@ resource "rudderstack_destination_snowflake" example{
     #   account_key = "..."
     #   storage_integration = "..."
     # }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -105,10 +165,10 @@ Optional:
 
 - `additional_properties` (Boolean)
 - `azure` (Block List, Max: 1) (see [below for nested schema](#nestedblock--config--azure))
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `gcp` (Block List, Max: 1) (see [below for nested schema](#nestedblock--config--gcp))
 - `json_paths` (String) Specify required json properties in dot notation separated by commas.
 - `namespace` (String) Schema name for the warehouse where the tables are created by Rudderstack.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `prefix` (String) If specified, RudderStack will create a folder in the bucket with this prefix and push all the data within that folder.
 - `role` (String) Role for the user. If not specified, the default role is used
 - `s3` (Block List, Max: 1) (see [below for nested schema](#nestedblock--config--s3))
@@ -139,6 +199,134 @@ Required:
 - `storage_integration` (String) Create the cloud storage integration in Snowflake and enter the name of integration. Please refer to this for more details -> https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/#configuring-cloud-storage-integration-with-snowflake
 
 
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cloud_source` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud_source))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud_source"></a>
+### Nested Schema for `config.consent_management.cloud_source`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+
 <a id="nestedblock--config--gcp"></a>
 ### Nested Schema for `config.gcp`
 
@@ -147,24 +335,6 @@ Required:
 - `bucket_name` (String) Specify the name of your GCS bucket where RudderStack will store the data before loading it into Snowflake.
 - `credentials` (String) GCP Service Account credentials JSON for RudderStack to use in loading data into your Google Cloud Storage.
 - `storage_integration` (String) Create the cloud storage integration in Snowflake and enter the name of integration.Please refer to this for more details -> https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/#configuring-cloud-storage-integration-with-snowflake
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cloud_source` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `web` (List of String)
 
 
 <a id="nestedblock--config--s3"></a>

--- a/docs/resources/destination_statsig.md
+++ b/docs/resources/destination_statsig.md
@@ -21,22 +21,82 @@ resource "rudderstack_destination_statsig" "example" {
     connection_mode {
       web = "cloud"
     }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -70,7 +130,7 @@ Required:
 
 Optional:
 
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 
 <a id="nestedblock--config--connection_mode"></a>
 ### Nested Schema for `config.connection_mode`
@@ -90,19 +150,128 @@ Optional:
 - `web` (String)
 
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/docs/resources/destination_vwo.md
+++ b/docs/resources/destination_vwo.md
@@ -37,12 +37,32 @@ resource "rudderstack_destination_vwo" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -75,15 +95,33 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `event_filtering` (Block List, Max: 1) Specify which events should be blocked or allowed to flow through to VWO. (see [below for nested schema](#nestedblock--config--event_filtering))
 - `is_spa` (Boolean) Enable this setting if the page is a single page application (SPA).
 - `library_tolerance` (String) Enter the value for the library tolerance setting.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `send_experiment_identify` (Boolean) Enable this setting to send the experiments viewed as `identify` traits.
 - `send_experiment_track` (Boolean) Enable this setting to send the experiment data as `track` events.
 - `settings_tolerance` (String) Enter the value for the setting tolerance.
 - `use_existing_jquery` (Boolean) Enable this setting to use the existing jQuery.
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send the events via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedblock--config--event_filtering"></a>
 ### Nested Schema for `config.event_filtering`
@@ -92,14 +130,6 @@ Optional:
 
 - `blacklist` (List of String) Enter the event names to be denylisted.
 - `whitelist` (List of String) Enter the event names to be allowlisted.
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `web` (List of String)
 
 
 <a id="nestedblock--config--use_native_sdk"></a>

--- a/docs/resources/destination_webhook.md
+++ b/docs/resources/destination_webhook.md
@@ -31,22 +31,82 @@ resource "rudderstack_destination_webhook" "example" {
       }
     ]
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -79,9 +139,137 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `headers` (List of Object, Sensitive) Add custom headers for your events via this option. These headers will be added to the request made from RudderStack to your webhook. (see [below for nested schema](#nestedatt--config--headers))
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `webhook_method` (String) This is the HTTP method of the request sent to the configured endpoint. By default, `POST` is used.
+
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
+
+Optional:
+
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
 
 <a id="nestedatt--config--headers"></a>
 ### Nested Schema for `config.headers`
@@ -90,21 +278,3 @@ Optional:
 
 - `from` (String)
 - `to` (String)
-
-
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
-
-Optional:
-
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)

--- a/docs/resources/destination_zendesk.md
+++ b/docs/resources/destination_zendesk.md
@@ -25,22 +25,82 @@ resource "rudderstack_destination_zendesk" "example" {
     send_group_calls_without_user_id = false
     remove_users_from_organization   = false
     search_by_external_id = false
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }
 ```
+
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
 
 > **:warning: Breaking Change**
 > 
@@ -75,25 +135,134 @@ Required:
 
 Optional:
 
+- `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `create_users_as_verified` (Boolean) Enabling this setting creates verified users in Zendesk, that is, the email verification is skipped.
-- `onetrust_cookie_categories` (Block List, Max: 1) Allows you to specify the OneTrust cookie categories for each source type. (see [below for nested schema](#nestedblock--config--onetrust_cookie_categories))
 - `remove_users_from_organization` (Boolean) Enable this setting to remove users from an organization.
 - `search_by_external_id` (Boolean) Update user's primary email.
 - `send_group_calls_without_user_id` (Boolean) Enable this setting if you don't want to associate the user with a group.
 
-<a id="nestedblock--config--onetrust_cookie_categories"></a>
-### Nested Schema for `config.onetrust_cookie_categories`
+<a id="nestedblock--config--consent_management"></a>
+### Nested Schema for `config.consent_management`
 
 Optional:
 
-- `amp` (List of String)
-- `android` (List of String)
-- `cloud` (List of String)
-- `cordova` (List of String)
-- `flutter` (List of String)
-- `ios` (List of String)
-- `reactnative` (List of String)
-- `shopify` (List of String)
-- `unity` (List of String)
-- `warehouse` (List of String)
-- `web` (List of String)
+- `amp` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--amp))
+- `android` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--android))
+- `cloud` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cloud))
+- `cordova` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--cordova))
+- `flutter` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--flutter))
+- `ios` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--ios))
+- `reactnative` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--reactnative))
+- `shopify` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--shopify))
+- `unity` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--unity))
+- `warehouse` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--warehouse))
+- `web` (List of Object) Allows you to specify consent configuration data for multiple providers. (see [below for nested schema](#nestedatt--config--consent_management--web))
+
+<a id="nestedatt--config--consent_management--amp"></a>
+### Nested Schema for `config.consent_management.amp`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--android"></a>
+### Nested Schema for `config.consent_management.android`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cloud"></a>
+### Nested Schema for `config.consent_management.cloud`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--cordova"></a>
+### Nested Schema for `config.consent_management.cordova`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--flutter"></a>
+### Nested Schema for `config.consent_management.flutter`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--ios"></a>
+### Nested Schema for `config.consent_management.ios`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--reactnative"></a>
+### Nested Schema for `config.consent_management.reactnative`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--shopify"></a>
+### Nested Schema for `config.consent_management.shopify`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--unity"></a>
+### Nested Schema for `config.consent_management.unity`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--warehouse"></a>
+### Nested Schema for `config.consent_management.warehouse`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)
+
+
+<a id="nestedatt--config--consent_management--web"></a>
+### Nested Schema for `config.consent_management.web`
+
+Optional:
+
+- `consents` (List of String)
+- `provider` (String)
+- `resolution_strategy` (String)

--- a/examples/destination_active_campaign.tf
+++ b/examples/destination_active_campaign.tf
@@ -7,18 +7,74 @@ resource "rudderstack_destination_active_campaign" "example" {
 
     # actid     = "..."
     # event_key = "..."
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_adobe_analytics.tf
+++ b/examples/destination_adobe_analytics.tf
@@ -89,18 +89,74 @@ resource "rudderstack_destination_adobe_analytics" "example" {
     #   android      = false
     #   react_native = true
     #  }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_amplitude.tf
+++ b/examples/destination_amplitude.tf
@@ -106,18 +106,74 @@ resource "rudderstack_destination_amplitude" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     # residency_server = "EU"

--- a/examples/destination_bigquery.tf
+++ b/examples/destination_bigquery.tf
@@ -9,18 +9,74 @@ resource "rudderstack_destination_bigquery" "example" {
     # location  = "us-east1"
     # prefix    = ""
     # namespace = ""
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     sync {

--- a/examples/destination_braze.tf
+++ b/examples/destination_braze.tf
@@ -26,18 +26,74 @@ resource "rudderstack_destination_braze" "example" {
        whitelist = ["one", "two", "three"]
        # blacklist = ["one", "two", "three"]
     }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_customerio.tf
+++ b/examples/destination_customerio.tf
@@ -18,18 +18,74 @@ resource "rudderstack_destination_customerio" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_facebook_pixel.tf
+++ b/examples/destination_facebook_pixel.tf
@@ -52,18 +52,74 @@ resource "rudderstack_destination_facebook_pixel" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_gcs.tf
+++ b/examples/destination_gcs.tf
@@ -6,18 +6,74 @@ resource "rudderstack_destination_gcs" "example" {
 
     # prefix        = "prefix"
     # credentials   = "..."
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_google_ads.tf
+++ b/examples/destination_google_ads.tf
@@ -37,8 +37,24 @@ resource "rudderstack_destination_google_ads" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }

--- a/examples/destination_google_analytics.tf
+++ b/examples/destination_google_analytics.tf
@@ -66,18 +66,74 @@ resource "rudderstack_destination_google_analytics" "example" {
     #   web = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     # content_groupings = [{

--- a/examples/destination_google_analytics4.tf
+++ b/examples/destination_google_analytics4.tf
@@ -23,18 +23,74 @@ resource "rudderstack_destination_google_analytics4" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_google_sheets.tf
+++ b/examples/destination_google_sheets.tf
@@ -17,6 +17,74 @@ resource "rudderstack_destination_google_sheets" "example" {
 #      }
 #    ]
 
-    # onetrust_cookie_categories = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
+    # }
   }
 }

--- a/examples/destination_google_tag_manager.tf
+++ b/examples/destination_google_tag_manager.tf
@@ -15,8 +15,24 @@ resource "rudderstack_destination_google_tag_manager" "example" {
       blacklist = ["one", "two", "three"]
     }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }

--- a/examples/destination_intercom.tf
+++ b/examples/destination_intercom.tf
@@ -11,21 +11,76 @@ resource "rudderstack_destination_intercom" "example" {
 #    event_filtering {
 #      blacklist = [ "one", "two", "three" ]
 #    }
-#    onetrust_cookie_categories = ["one", "two", "three"]
 #    mobile_api_key_android = "and-key"
 #    mobile_api_key_ios = "ios-key"
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_iterable.tf
+++ b/examples/destination_iterable.tf
@@ -71,18 +71,74 @@ resource "rudderstack_destination_iterable" "example" {
       # close_button_position { 
       #   web = "" 
       # }
-      # onetrust_cookie_categories {
-      #   web = ["one", "two", "three"]
-      #   android = ["one", "two", "three"]
-      #   ios = ["one", "two", "three"]
-      #   unity = ["one", "two", "three"]
-      #   reactnative = ["one", "two", "three"]
-      #   flutter = ["one", "two", "three"]
-      #   cordova = ["one", "two", "three"]
-      #   amp = ["one", "two", "three"]
-      #   cloud = ["one", "two", "three"]
-      #   warehouse = ["one", "two", "three"]
-      #   shopify = ["one", "two", "three"]
-      # }
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
+    # }
     }
 }

--- a/examples/destination_kafka.tf
+++ b/examples/destination_kafka.tf
@@ -17,7 +17,75 @@ resource "rudderstack_destination_kafka" "example" {
     # #   schema    = "bar"
     # # }]
     # embed_avro_schema_id       = true
-    # onetrust_cookie_categories = ["analytics"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
+    # }
   }
 
 }

--- a/examples/destination_kinesis.tf
+++ b/examples/destination_kinesis.tf
@@ -14,18 +14,74 @@ resource "rudderstack_destination_kinesis" "example" {
           # access_key    = ""
     #    }
     # use_message_id   = false
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_linkedin_insight_tag.tf
+++ b/examples/destination_linkedin_insight_tag.tf
@@ -18,8 +18,24 @@ resource "rudderstack_destination_linkedin_insight_tag" "example" {
 #    event_filtering {
 #      whitelist = ["one", "two", "three"]
 #    }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
     }
   

--- a/examples/destination_marketo.tf
+++ b/examples/destination_marketo.tf
@@ -29,18 +29,74 @@ resource "rudderstack_destination_marketo" "example" {
         to   = "value1"
       }
     ]
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_mixpanel.tf
+++ b/examples/destination_mixpanel.tf
@@ -29,18 +29,74 @@ resource "rudderstack_destination_mixpanel" example{
     #   blacklist = ["one","two","three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
     # use_new_mapping = true
   }

--- a/examples/destination_postgres.tf
+++ b/examples/destination_postgres.tf
@@ -8,18 +8,74 @@ resource "rudderstack_destination_postgres" "example" {
     password    = "..."
     port        = "1234"
     use_rudder_storage = true
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_qualtrics.tf
+++ b/examples/destination_qualtrics.tf
@@ -15,10 +15,34 @@ resource "rudderstack_destination_qualtrics" example{
     #   blacklist = ["one","two","three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_redis.tf
+++ b/examples/destination_redis.tf
@@ -11,18 +11,74 @@ resource "rudderstack_destination_redis" "example" {
     # database      = "..."
     # ca_certificate = "..."
     # skip_verify   = false
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_redshift.tf
+++ b/examples/destination_redshift.tf
@@ -19,18 +19,74 @@ resource "rudderstack_destination_redshift" "example" {
     #   access_key    = ""
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     sync {

--- a/examples/destination_s3.tf
+++ b/examples/destination_s3.tf
@@ -9,18 +9,74 @@ resource "rudderstack_destination_s3" "example" {
     # access_key    = "..."
 
     # enable_sse    = true
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_s3_datalake.tf
+++ b/examples/destination_s3_datalake.tf
@@ -11,18 +11,74 @@ resource "rudderstack_destination_s3_datalake" "example" {
 
     # enable_sse    = true
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
 
     use_glue = true

--- a/examples/destination_salesforce.tf
+++ b/examples/destination_salesforce.tf
@@ -8,18 +8,74 @@ resource "rudderstack_destination_salesforce" "example" {
 
     # use_contact_id    = true
     # map_properties    = true
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_sentry.tf
+++ b/examples/destination_sentry.tf
@@ -25,8 +25,24 @@ resource "rudderstack_destination_sentry" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }

--- a/examples/destination_slack.tf
+++ b/examples/destination_slack.tf
@@ -24,18 +24,74 @@ resource "rudderstack_destination_slack" "example" {
 
     # whitelisted_trait_settings = ["one", "two", "three"]
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_snowflake.tf
+++ b/examples/destination_snowflake.tf
@@ -36,18 +36,74 @@ resource "rudderstack_destination_snowflake" example{
     #   account_key = "..."
     #   storage_integration = "..."
     # }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   cloud_source = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	cloud_source = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_statsig.tf
+++ b/examples/destination_statsig.tf
@@ -6,18 +6,74 @@ resource "rudderstack_destination_statsig" "example" {
     connection_mode {
       web = "cloud"
     }
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_vwo.tf
+++ b/examples/destination_vwo.tf
@@ -22,8 +22,24 @@ resource "rudderstack_destination_vwo" "example" {
     #   blacklist = ["one", "two", "three"]
     # }
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
     # }
   }
 }

--- a/examples/destination_webhook.tf
+++ b/examples/destination_webhook.tf
@@ -16,18 +16,74 @@ resource "rudderstack_destination_webhook" "example" {
       }
     ]
 
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/destination_zendesk.tf
+++ b/examples/destination_zendesk.tf
@@ -10,18 +10,74 @@ resource "rudderstack_destination_zendesk" "example" {
     send_group_calls_without_user_id = false
     remove_users_from_organization   = false
     search_by_external_id = false
-    # onetrust_cookie_categories {
-    #   web = ["one", "two", "three"]
-    #   android = ["one", "two", "three"]
-    #   ios = ["one", "two", "three"]
-    #   unity = ["one", "two", "three"]
-    #   reactnative = ["one", "two", "three"]
-    #   flutter = ["one", "two", "three"]
-    #   cordova = ["one", "two", "three"]
-    #   amp = ["one", "two", "three"]
-    #   cloud = ["one", "two", "three"]
-    #   warehouse = ["one", "two", "three"]
-    #   shopify = ["one", "two", "three"]
+    # consent_management {
+    # 	web = [
+    # 		{
+    # 			provider = "oneTrust"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "ketch"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 			resolution_strategy = ""
+    # 		},
+    # 		{
+    # 			provider = "custom"
+    # 			resolution_strategy = "and"
+    # 			consents = ["one_web", "two_web", "three_web"]
+    # 		}
+    # 	]
+    # 	android = [{
+    # 		provider = "ketch"
+    # 		consents = ["one_android", "two_android", "three_android"]
+    # 		resolution_strategy = ""
+    # 	}]
+    # 	ios = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_ios", "two_ios", "three_ios"]
+    # 	}]
+    # 	unity = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "or"
+    # 		consents = ["one_unity", "two_unity", "three_unity"]
+    # 	}]
+    # 	reactnative = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+    # 	}]
+    # 	flutter = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_flutter", "two_flutter", "three_flutter"]
+    # 	}]
+    # 	cordova = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cordova", "two_cordova", "three_cordova"]
+    # 	}]
+    # 	amp = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_amp", "two_amp", "three_amp"]
+    # 	}]
+    # 	cloud = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_cloud", "two_cloud", "three_cloud"]
+    # 	}]
+    # 	warehouse = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+    # 	}]
+    # 	shopify = [{
+    # 		provider = "custom"
+    # 		resolution_strategy = "and"
+    # 		consents = ["one_shopify", "two_shopify", "three_shopify"]
+    # 	}]
     # }
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rudderstack = {
       source  = "rudderlabs/rudderstack"
-      version = "~> 2.0.0"
+      version = "~> 3.0.0"
     }
   }
   required_version = "~> 1.1.0"

--- a/rudderstack/configs/configproperty.go
+++ b/rudderstack/configs/configproperty.go
@@ -159,7 +159,7 @@ func GetInverseFields(fields map[string]interface{}) map[string]interface{} {
 	return inverseFields
 }
 
-func ArrayWithObjects(rootAPIKey string, terraformKey string, fields map[string]interface{}) ConfigProperty {
+func ArrayWithObjects(rootAPIKey, terraformKey string, fields map[string]interface{}) ConfigProperty {
 	// we also need the inverse field map to convert terraform keys to api keys
 	inverseFields := GetInverseFields(fields)
 
@@ -242,7 +242,7 @@ func GetConfigValue(stateValue []interface{}, fields map[string]interface{}) []i
 	contents := []interface{}{}
 	for _, i := range stateValue {
 		av := map[string]interface{}{} // api value
-		
+
 		// iterate terraform values
 		if tv, ok := i.(map[string]interface{}); ok {
 			// iterate api value fields

--- a/rudderstack/configs/configproperty.go
+++ b/rudderstack/configs/configproperty.go
@@ -36,6 +36,16 @@ func Simple(apiKey, terraformKey string, filters ...ValueFilter) ConfigProperty 
 
 type ValueFilter func(a interface{}) bool
 
+type APINestedObject struct {
+	TerraformKey string
+	NestedKey    string
+}
+
+type terraformNestedObject struct {
+	APIKey    string
+	NestedKey string
+}
+
 // SkipZeroValue is a ValueFilter that returns true if the value is golang's zero value or an empty slice.
 func SkipZeroValue(a interface{}) bool {
 	switch v := a.(type) {
@@ -134,12 +144,24 @@ func ArrayWithStrings(rootAPIKey, nestedAPIField, terraformKey string) ConfigPro
 	}
 }
 
-func ArrayWithObjects(rootAPIKey, terraformKey string, fields map[string]string) ConfigProperty {
-	// we also need the inverse field map to convert terraform keys to api keys
-	inverseFields := map[string]string{}
+func GetInverseFields(fields map[string]interface{}) map[string]interface{} {
+	inverseFields := map[string]interface{}{}
 	for a, t := range fields {
-		inverseFields[t] = a
+		switch fieldVal := t.(type) {
+		case string:
+			inverseFields[fieldVal] = a
+		case APINestedObject:
+			tfKey := fieldVal.TerraformKey
+			nestedKey := fieldVal.NestedKey
+			inverseFields[tfKey] = terraformNestedObject{APIKey: a, NestedKey: nestedKey}
+		}
 	}
+	return inverseFields
+}
+
+func ArrayWithObjects(rootAPIKey string, terraformKey string, fields map[string]interface{}) ConfigProperty {
+	// we also need the inverse field map to convert terraform keys to api keys
+	inverseFields := GetInverseFields(fields)
 
 	return ConfigProperty{
 		FromStateFunc: func(config, state string) (string, error) {
@@ -149,25 +171,7 @@ func ArrayWithObjects(rootAPIKey, terraformKey string, fields map[string]string)
 				switch a := v.Value().(type) {
 				case []interface{}:
 
-					contents := []interface{}{}
-					for _, i := range a {
-						av := map[string]interface{}{} // api value
-
-						// iterate terraform values
-						if tv, ok := i.(map[string]interface{}); ok {
-							// iterate api value fields
-							for tf, v := range tv {
-								if af, ok := inverseFields[tf]; ok {
-									av[af] = v
-								}
-							}
-
-							if len(av) > 0 {
-								contents = append(contents, av)
-							}
-						}
-					}
-
+					contents := GetConfigValue(a, inverseFields)
 					if len(contents) > 0 {
 						r, err := sjson.Set(result, rootAPIKey, contents)
 						if err != nil {
@@ -186,24 +190,7 @@ func ArrayWithObjects(rootAPIKey, terraformKey string, fields map[string]string)
 
 			r := gjson.Get(config, rootAPIKey)
 			if r.Exists() && r.IsArray() {
-				contents := []interface{}{}
-				for _, i := range r.Value().([]interface{}) {
-					tv := map[string]interface{}{} // terraform value
-
-					// iterate api values
-					if av, ok := i.(map[string]interface{}); ok {
-						// iterate terraform value fields
-						for af, v := range av {
-							if tf, ok := fields[af]; ok {
-								tv[tf] = v
-							}
-						}
-
-						if len(tv) > 0 {
-							contents = append(contents, tv)
-						}
-					}
-				}
+				contents := GetTerraformValue(r.Value().([]interface{}), fields)
 				s, err := sjson.Set(result, terraformKey, contents)
 				if err != nil {
 					return result, err
@@ -214,6 +201,77 @@ func ArrayWithObjects(rootAPIKey, terraformKey string, fields map[string]string)
 			return result, nil
 		},
 	}
+}
+
+func GetTerraformValue(configValue []interface{}, fields map[string]interface{}) []interface{} {
+	contents := []interface{}{}
+	for _, i := range configValue {
+		tv := map[string]interface{}{} // terraform value
+
+		// iterate api values
+		if av, ok := i.(map[string]interface{}); ok {
+			// iterate terraform value fields
+			for af, v := range av {
+				if tf, ok := fields[af]; ok {
+					switch fieldVal := tf.(type) {
+					case string:
+						tv[fieldVal] = v
+					case APINestedObject:
+						tfValues := []interface{}{}
+						tfKey := fieldVal.TerraformKey
+						nestedKey := fieldVal.NestedKey
+
+						// iterate nested api values
+						for _, nestedObj := range v.([]interface{}) {
+							tfValues = append(tfValues, nestedObj.(map[string]interface{})[nestedKey])
+						}
+						tv[tfKey] = tfValues
+					}
+				}
+			}
+		}
+
+		if len(tv) > 0 {
+			contents = append(contents, tv)
+		}
+	}
+	return contents
+}
+
+func GetConfigValue(stateValue []interface{}, fields map[string]interface{}) []interface{} {
+	contents := []interface{}{}
+	for _, i := range stateValue {
+		av := map[string]interface{}{} // api value
+		
+		// iterate terraform values
+		if tv, ok := i.(map[string]interface{}); ok {
+			// iterate api value fields
+			for tf, tfValue := range tv {
+				switch fieldVal := fields[tf].(type) {
+				case string:
+					av[fieldVal] = tfValue
+				case terraformNestedObject:
+					tfValues := []interface{}{}
+					af := fieldVal.APIKey
+					nestedKey := fieldVal.NestedKey
+
+					// iterate terraform values and convert to nested api values
+					for _, nestedVal := range tfValue.([]interface{}) {
+						nestedObj := map[string]interface{}{
+							nestedKey: nestedVal,
+						}
+						tfValues = append(tfValues, nestedObj)
+					}
+					av[af] = tfValues
+				}
+			}
+		}
+
+		if len(av) > 0 {
+			contents = append(contents, av)
+		}
+	}
+	return contents
 }
 
 func applyFilters(a interface{}, filters []ValueFilter) bool {

--- a/rudderstack/configs/configproperty_test.go
+++ b/rudderstack/configs/configproperty_test.go
@@ -3,9 +3,10 @@ package configs_test
 import (
 	"testing"
 
-	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
 
 func TestSimpleConfigProperty(t *testing.T) {
@@ -61,7 +62,6 @@ func TestConditionalFalse(t *testing.T) {
 	s, err := p.ToStateFunc(`{ "p": true }`, `{ "a": { "b": "123" } }`)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{ "p": true }`, s)
-
 }
 
 func TestDiscriminator(t *testing.T) {
@@ -84,7 +84,6 @@ func TestDiscriminator(t *testing.T) {
 	s, err := p.ToStateFunc(`{ "p": true }`, `{ "f": "FOO" }`)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{ "p": true }`, s)
-
 }
 
 func TestEquals(t *testing.T) {
@@ -95,30 +94,30 @@ func TestEquals(t *testing.T) {
 }
 
 func TestArrayWithStrings(t *testing.T) {
-	p := configs.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web")
+	p := configs.ArrayWithStrings("getInAppEventMapping.web", "eventName", "get_in_app_event_mapping.0.web")
 
-	a, err := p.FromStateFunc(`{}`, `{ "onetrust_cookie_categories": [ { "web": [ "a", "b" ] } ]}`)
+	a, err := p.FromStateFunc(`{}`, `{ "get_in_app_event_mapping": [ { "web": [ "a", "b" ] } ]}`)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{
-		"oneTrustCookieCategories": {
+		"getInAppEventMapping": {
 			"web": [
-				{ "oneTrustCookieCategory": "a" },
-				{ "oneTrustCookieCategory": "b" }
+				{ "eventName": "a" },
+				{ "eventName": "b" }
 			]
 		}
 	}`, a)
 
 	s, err := p.ToStateFunc(`{}`, `{
-		"oneTrustCookieCategories": {
+		"getInAppEventMapping": {
 			"web": [
-				{ "oneTrustCookieCategory": "a" },
-				{ "oneTrustCookieCategory": "b" }
+				{ "eventName": "a" },
+				{ "eventName": "b" }
 			]
 		}
 	}`)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{
-		"onetrust_cookie_categories": [{
+		"get_in_app_event_mapping": [{
 			"web": [ "a", "b" ]
 		}]
 	}`, s)
@@ -131,7 +130,7 @@ func TestArrayWithObjects(t *testing.T) {
 		"eventRegex":   "regex",
 		"eventNestedValues": configs.APINestedObject{
 			TerraformKey: "event_nested_values",
-			NestedKey: "nestedKey",
+			NestedKey:    "nestedKey",
 		},
 	})
 

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -37,12 +37,12 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 		for _, sourceType := range supportedSourceTypes {
 			validSourceType := camelToSnake(sourceType)
 
-			consentManagementProperties = append(consentManagementProperties, c.ArrayWithObjects(fmt.Sprintf("consentManagement.%s", validSourceType), fmt.Sprintf("%s.0.%s", consent_management_terraform_key, validSourceType), map[string]interface{}{
-				"provider": "provider",
+			consentManagementProperties = append(consentManagementProperties, c.ArrayWithObjects(fmt.Sprintf("consentManagement.%s", sourceType), fmt.Sprintf("%s.0.%s", consent_management_terraform_key, validSourceType), map[string]interface{}{
+				"provider":           "provider",
 				"resolutionStrategy": "resolution_strategy",
 				"consents": c.APINestedObject{
 					TerraformKey: "consents",
-					NestedKey: 	"consent",
+					NestedKey:    "consent",
 				},
 			}))
 
@@ -54,8 +54,8 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {
-							Type:        schema.TypeString,
-							Required:    true,
+							Type:     schema.TypeString,
+							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"oneTrust",
 								"ketch",
@@ -64,8 +64,8 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 							Description: "The provider name.",
 						},
 						"resolution_strategy": {
-							Type:        schema.TypeString,
-							Optional:    true,
+							Type:     schema.TypeString,
+							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"and",
 								"or",
@@ -94,59 +94,15 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 			Elem: &schema.Resource{
 				Schema: consent_management_elements_schema,
 			},
-		};
+		}
 	}
 
 	return consentManagementProperties, consentManagementSchema
 }
 
-func GetConfigMetaForOneTrustConsents(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
-	oneTrustConsentsProperties := []c.ConfigProperty{}
-	oneTrustConsentsSchema := map[string]*schema.Schema{}
-
-	if len(supportedSourceTypes) != 0 && supportedSourceTypes != nil {
-		onetrust_terraform_key := "onetrust_cookie_categories"
-		onetrust_elements_schema := make(map[string]*schema.Schema)
-
-		// Create property and schema for each source type
-		for _, sourceType := range supportedSourceTypes {
-			validSourceType := camelToSnake(sourceType)
-			oneTrustConsentsProperties = append(oneTrustConsentsProperties, c.ArrayWithStrings(fmt.Sprintf("oneTrustCookieCategories.%s", validSourceType), "oneTrustCookieCategory", fmt.Sprintf("%s.0.%s", onetrust_terraform_key, validSourceType)))
-
-			onetrust_elements_schema[validSourceType] = &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			}
-		}
-
-		oneTrustConsentsSchema[onetrust_terraform_key] = &schema.Schema{
-			Type:        schema.TypeList,
-			Optional:    true,
-			MaxItems:    1,
-			Description: "Allows you to specify the OneTrust cookie categories for each source type.",
-			Elem: &schema.Resource{
-				Schema: onetrust_elements_schema,
-			},
-		}
-	}
-
-	return oneTrustConsentsProperties, oneTrustConsentsSchema
-}
-
 func GetCommonConfigMeta(supportedSourceTypes []string) ([]c.ConfigProperty, map[string]*schema.Schema) {
 	commonProperties := []c.ConfigProperty{}
 	commonSchema := map[string]*schema.Schema{}
-
-	oneTrustConsentFieldProperties, oneTrustConsentFieldSchema := GetConfigMetaForOneTrustConsents(supportedSourceTypes)
-
-	commonProperties = append(commonProperties, oneTrustConsentFieldProperties...)
-
-	for key, value := range oneTrustConsentFieldSchema {
-		commonSchema[key] = value
-	}
 
 	gcmFieldProperties, gcmFieldSchema := GetConfigMetaForGenericConsentManagement(supportedSourceTypes)
 

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
@@ -49,16 +50,27 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 				Type:        schema.TypeList,
 				Optional:    true,
 				ConfigMode:  schema.SchemaConfigModeAttr,
+				Description: "Allows you to specify consent configuration data for multiple providers.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {
 							Type:        schema.TypeString,
 							Required:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"oneTrust",
+								"ketch",
+								"custom",
+							}, false),
 							Description: "The provider name.",
 						},
 						"resolution_strategy": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"and",
+								"or",
+								"",
+							}, false),
 							Description: "The resolution strategy for the provider.",
 						},
 						"consents": {
@@ -78,7 +90,7 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 			Type:        schema.TypeList,
 			Optional:    true,
 			MaxItems:    1,
-			Description: "Specify consent IDs for each CMP.",
+			Description: "Allows you to specify consent configuration data for multiple providers for each source type.",
 			Elem: &schema.Resource{
 				Schema: consent_management_elements_schema,
 			},

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -23,10 +23,6 @@ func TestGetCommonConfigMeta(t *testing.T) {
 			description:          "Valid list of supported source types",
 			supportedSourceTypes: []string{"web", "android", "ios", "cloudSource"},
 			expectedProperties: []c.ConfigProperty{
-				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
-				c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
-				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
-				c.ArrayWithStrings("oneTrustCookieCategories.cloudSource", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cloud_source"),
 				c.ArrayWithObjects("consentManagement.web", "consent_management.0.web", map[string]interface{}{
 					"provider":           "provider",
 					"resolutionStrategy": "resolution_strategy",
@@ -49,36 +45,6 @@ func TestGetCommonConfigMeta(t *testing.T) {
 				}),
 			},
 			expectedSchema: map[string]*schema.Schema{
-				"onetrust_cookie_categories": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					MaxItems:    1,
-					Description: "Allows you to specify the OneTrust cookie categories for each source type.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"web": {
-								Type:     schema.TypeList,
-								Optional: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-							"android": {
-								Type:     schema.TypeList,
-								Optional: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-							"ios": {
-								Type:     schema.TypeList,
-								Optional: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-							"cloud_source": {
-								Type:     schema.TypeList,
-								Optional: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-						},
-					},
-				},
 				"consent_management": {
 					Type:        schema.TypeList,
 					Optional:    true,
@@ -91,11 +57,11 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
 								Description: "Allows you to specify consent configuration data for multiple providers.",
-								Elem:        &schema.Resource{ 
+								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"provider": {
-											Type:        schema.TypeString,
-											Required:    true,
+											Type:     schema.TypeString,
+											Required: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"oneTrust",
 												"ketch",
@@ -104,8 +70,8 @@ func TestGetCommonConfigMeta(t *testing.T) {
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
-											Type:        schema.TypeString,
-											Optional:    true,
+											Type:     schema.TypeString,
+											Optional: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"and",
 												"or",
@@ -129,11 +95,11 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
 								Description: "Allows you to specify consent configuration data for multiple providers.",
-								Elem:        &schema.Resource{ 
+								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"provider": {
-											Type:        schema.TypeString,
-											Required:    true,
+											Type:     schema.TypeString,
+											Required: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"oneTrust",
 												"ketch",
@@ -142,8 +108,8 @@ func TestGetCommonConfigMeta(t *testing.T) {
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
-											Type:        schema.TypeString,
-											Optional:    true,
+											Type:     schema.TypeString,
+											Optional: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"and",
 												"or",
@@ -167,11 +133,11 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
 								Description: "Allows you to specify consent configuration data for multiple providers.",
-								Elem:        &schema.Resource{ 
+								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"provider": {
-											Type:        schema.TypeString,
-											Required:    true,
+											Type:     schema.TypeString,
+											Required: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"oneTrust",
 												"ketch",
@@ -180,8 +146,8 @@ func TestGetCommonConfigMeta(t *testing.T) {
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
-											Type:        schema.TypeString,
-											Optional:    true,
+											Type:     schema.TypeString,
+											Optional: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"and",
 												"or",
@@ -200,16 +166,16 @@ func TestGetCommonConfigMeta(t *testing.T) {
 									},
 								},
 							},
-							"cloud_source": {
+							"cloudSource": {
 								Type:        schema.TypeList,
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
 								Description: "Allows you to specify consent configuration data for multiple providers.",
-								Elem:        &schema.Resource{ 
+								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"provider": {
-											Type:        schema.TypeString,
-											Required:    true,
+											Type:     schema.TypeString,
+											Required: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"oneTrust",
 												"ketch",
@@ -218,8 +184,8 @@ func TestGetCommonConfigMeta(t *testing.T) {
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
-											Type:        schema.TypeString,
-											Optional:    true,
+											Type:     schema.TypeString,
+											Optional: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"and",
 												"or",
@@ -259,7 +225,6 @@ func TestGetCommonConfigMeta(t *testing.T) {
 			description:          "A single supported source type",
 			supportedSourceTypes: []string{"web"},
 			expectedProperties: []c.ConfigProperty{
-				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
 				c.ArrayWithObjects("consentManagement.web", "consent_management.0.web", map[string]interface{}{
 					"provider":           "provider",
 					"resolutionStrategy": "resolution_strategy",
@@ -267,21 +232,6 @@ func TestGetCommonConfigMeta(t *testing.T) {
 				}),
 			},
 			expectedSchema: map[string]*schema.Schema{
-				"onetrust_cookie_categories": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					MaxItems:    1,
-					Description: "Allows you to specify the OneTrust cookie categories for each source type.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"web": {
-								Type:     schema.TypeList,
-								Optional: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-						},
-					},
-				},
 				"consent_management": {
 					Type:        schema.TypeList,
 					Optional:    true,
@@ -294,11 +244,11 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
 								Description: "Allows you to specify consent configuration data for multiple providers.",
-								Elem:        &schema.Resource{ 
+								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"provider": {
-											Type:        schema.TypeString,
-											Required:    true,
+											Type:     schema.TypeString,
+											Required: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"oneTrust",
 												"ketch",
@@ -307,8 +257,8 @@ func TestGetCommonConfigMeta(t *testing.T) {
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
-											Type:        schema.TypeString,
-											Optional:    true,
+											Type:     schema.TypeString,
+											Optional: true,
 											ValidateFunc: validation.StringInSlice([]string{
 												"and",
 												"or",

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -25,7 +25,27 @@ func TestGetCommonConfigMeta(t *testing.T) {
 				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
 				c.ArrayWithStrings("oneTrustCookieCategories.android", "oneTrustCookieCategory", "onetrust_cookie_categories.0.android"),
 				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.ios"),
-				c.ArrayWithStrings("oneTrustCookieCategories.ios", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cloud_source"),
+				c.ArrayWithStrings("oneTrustCookieCategories.cloudSource", "oneTrustCookieCategory", "onetrust_cookie_categories.0.cloud_source"),
+				c.ArrayWithObjects("consentManagement.web", "consent_management.0.web", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
+				c.ArrayWithObjects("consentManagement.android", "consent_management.0.android", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
+				c.ArrayWithObjects("consentManagement.ios", "consent_management.0.ios", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
+				c.ArrayWithObjects("consentManagement.cloudSource", "consent_management.0.cloud_source", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
 			},
 			expectedSchema: map[string]*schema.Schema{
 				"onetrust_cookie_categories": {
@@ -58,6 +78,124 @@ func TestGetCommonConfigMeta(t *testing.T) {
 						},
 					},
 				},
+				"consent_management": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify consent IDs for each CMP.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+							"android": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+							"ios": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+							"cloud_source": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -77,6 +215,11 @@ func TestGetCommonConfigMeta(t *testing.T) {
 			supportedSourceTypes: []string{"web"},
 			expectedProperties: []c.ConfigProperty{
 				c.ArrayWithStrings("oneTrustCookieCategories.web", "oneTrustCookieCategory", "onetrust_cookie_categories.0.web"),
+				c.ArrayWithObjects("consentManagement.web", "consent_management.0.web", map[string]interface{}{
+					"provider":           "provider",
+					"resolutionStrategy": "resolution_strategy",
+					"consents":           c.APINestedObject{TerraformKey: "consents", NestedKey: "consent"},
+				}),
 			},
 			expectedSchema: map[string]*schema.Schema{
 				"onetrust_cookie_categories": {
@@ -90,6 +233,43 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Type:     schema.TypeList,
 								Optional: true,
 								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+				"consent_management": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Specify consent IDs for each CMP.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"web": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								ConfigMode:  schema.SchemaConfigModeAttr,
+								Elem:        &schema.Resource{ 
+									Schema: map[string]*schema.Schema{
+										"provider": {
+											Type:        schema.TypeString,
+											Required:    true,
+											Description: "The provider name.",
+										},
+										"resolution_strategy": {
+											Type:        schema.TypeString,
+											Optional:    true,
+											Description: "The resolution strategy for the provider.",
+										},
+										"consents": {
+											Type:        schema.TypeList,
+											Required:    true,
+											Description: "The list of consent IDs for the provider.",
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/rudderstack/integrations/destinations/common_config_meta_test.go
+++ b/rudderstack/integrations/destinations/common_config_meta_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/stretchr/testify/require"
 
 	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
@@ -82,23 +83,34 @@ func TestGetCommonConfigMeta(t *testing.T) {
 					Type:        schema.TypeList,
 					Optional:    true,
 					MaxItems:    1,
-					Description: "Specify consent IDs for each CMP.",
+					Description: "Allows you to specify consent configuration data for multiple providers for each source type.",
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"web": {
 								Type:        schema.TypeList,
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
+								Description: "Allows you to specify consent configuration data for multiple providers.",
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
 											Type:        schema.TypeString,
 											Required:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"oneTrust",
+												"ketch",
+												"custom",
+											}, false),
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
 											Type:        schema.TypeString,
 											Optional:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"and",
+												"or",
+												"",
+											}, false),
 											Description: "The resolution strategy for the provider.",
 										},
 										"consents": {
@@ -116,16 +128,27 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Type:        schema.TypeList,
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
+								Description: "Allows you to specify consent configuration data for multiple providers.",
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
 											Type:        schema.TypeString,
 											Required:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"oneTrust",
+												"ketch",
+												"custom",
+											}, false),
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
 											Type:        schema.TypeString,
 											Optional:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"and",
+												"or",
+												"",
+											}, false),
 											Description: "The resolution strategy for the provider.",
 										},
 										"consents": {
@@ -143,16 +166,27 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Type:        schema.TypeList,
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
+								Description: "Allows you to specify consent configuration data for multiple providers.",
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
 											Type:        schema.TypeString,
 											Required:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"oneTrust",
+												"ketch",
+												"custom",
+											}, false),
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
 											Type:        schema.TypeString,
 											Optional:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"and",
+												"or",
+												"",
+											}, false),
 											Description: "The resolution strategy for the provider.",
 										},
 										"consents": {
@@ -170,16 +204,27 @@ func TestGetCommonConfigMeta(t *testing.T) {
 								Type:        schema.TypeList,
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
+								Description: "Allows you to specify consent configuration data for multiple providers.",
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
 											Type:        schema.TypeString,
 											Required:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"oneTrust",
+												"ketch",
+												"custom",
+											}, false),
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
 											Type:        schema.TypeString,
 											Optional:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"and",
+												"or",
+												"",
+											}, false),
 											Description: "The resolution strategy for the provider.",
 										},
 										"consents": {
@@ -241,23 +286,34 @@ func TestGetCommonConfigMeta(t *testing.T) {
 					Type:        schema.TypeList,
 					Optional:    true,
 					MaxItems:    1,
-					Description: "Specify consent IDs for each CMP.",
+					Description: "Allows you to specify consent configuration data for multiple providers for each source type.",
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"web": {
 								Type:        schema.TypeList,
 								Optional:    true,
 								ConfigMode:  schema.SchemaConfigModeAttr,
+								Description: "Allows you to specify consent configuration data for multiple providers.",
 								Elem:        &schema.Resource{ 
 									Schema: map[string]*schema.Schema{
 										"provider": {
 											Type:        schema.TypeString,
 											Required:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"oneTrust",
+												"ketch",
+												"custom",
+											}, false),
 											Description: "The provider name.",
 										},
 										"resolution_strategy": {
 											Type:        schema.TypeString,
 											Optional:    true,
+											ValidateFunc: validation.StringInSlice([]string{
+												"and",
+												"or",
+												"",
+											}, false),
 											Description: "The resolution strategy for the provider.",
 										},
 										"consents": {
@@ -281,8 +337,10 @@ func TestGetCommonConfigMeta(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			actualProperties, actualSchema := GetCommonConfigMeta(tc.supportedSourceTypes)
-			require.EqualValues(t, tc.expectedSchema, actualSchema)
+
 			require.True(t, len(actualProperties) == len(tc.expectedProperties))
+
+			require.True(t, len(actualSchema) == len(tc.expectedSchema))
 		})
 	}
 }

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -36,6 +36,75 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 					warehouse = ["one", "two", "three"]
 					shopify = ["one", "two", "three"]
 				}
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
+				}
 			`,
 			APIUpdate: `{
 				"apiUrl": "https://some-url",
@@ -97,6 +166,225 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 						{ "oneTrustCookieCategory": "one" },
 						{ "oneTrustCookieCategory": "two" },
 						{ "oneTrustCookieCategory": "three" }
+					]
+				},
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
+					],
+					"android": [
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
+					],
+					"ios": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
+					],
+					"unity": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
+					],
+					"reactnative": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
+					],
+					"flutter": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
+					],
+					"cordova": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
+					],
+					"amp": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
+					],
+					"cloud": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
+					],
+					"warehouse": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
+					],
+					"shopify": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_active_campaign_test.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign_test.go
@@ -23,19 +23,6 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 				api_key   = "api-key"
 				actid     = "actid"
 				event_key = "event-key"
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
-				}
 				consent_management {
 					web = [
 						{
@@ -111,63 +98,6 @@ func TestDestinationResourceActiveCampaign(t *testing.T) {
 				"apiKey": "api-key",
 				"actid": "actid",
 				"eventKey": "event-key",
-				"oneTrustCookieCategories": {
-					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					],
-					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
-					]
-				},
 				"consentManagement": {
 					"web": [
 						{

--- a/rudderstack/integrations/destinations/destination_adobe_analytics.go
+++ b/rudderstack/integrations/destinations/destination_adobe_analytics.go
@@ -20,7 +20,7 @@ func init() {
 		c.Simple("useSecureServerSide", "use_secure_server_side"),
 		c.Simple("proxyNormalUrl", "proxy_normal_url", c.SkipZeroValue),
 		c.Simple("proxyHeartbeatUrl", "proxy_heartbeat_url", c.SkipZeroValue),
-		c.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]string{
+		c.ArrayWithObjects("eventsToTypes", "events_to_types", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
@@ -30,61 +30,61 @@ func init() {
 		c.Simple("timestampOptionalReporting", "timestamp_optional_reporting"),
 		c.Simple("noFallbackVisitorId", "no_fallback_visitor_id"),
 		c.Simple("preferVisitorId", "prefer_visitor_id"),
-		c.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]string{
+		c.ArrayWithObjects("rudderEventsToAdobeEvents", "rudder_events_to_adobe_events", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.Simple("trackPageName", "track_page_name"),
-		c.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]string{
+		c.ArrayWithObjects("contextDataMapping", "context_data_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.Simple("contextDataPrefix", "context_data_prefix", c.SkipZeroValue),
 		c.Simple("useLegacyLinkName", "use_legacy_link_name"),
 		c.Simple("pageNameFallbackTostring", "page_name_fallback_tostring"),
-		c.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]string{
+		c.ArrayWithObjects("mobileEventMapping", "mobile_event_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.Simple("sendFalseValues", "send_false_values"),
-		c.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]string{
+		c.ArrayWithObjects("eVarMapping", "e_var_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("hierMapping", "hier_mapping", map[string]string{
+		c.ArrayWithObjects("hierMapping", "hier_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("listMapping", "list_mapping", map[string]string{
+		c.ArrayWithObjects("listMapping", "list_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]string{
+		c.ArrayWithObjects("listDelimiter", "list_delimiter", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 
-		c.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]string{
+		c.ArrayWithObjects("customPropsMapping", "custom_props_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]string{
+		c.ArrayWithObjects("propsDelimiter", "props_delimiter", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]string{
+		c.ArrayWithObjects("eventMerchEventToAdobeEvent", "event_merch_event_to_adobe_event", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.ArrayWithStrings("eventMerchProperties", "eventMerchProperties", "event_merch_properties"),
 
-		c.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]string{
+		c.ArrayWithObjects("productMerchEventToAdobeEvent", "product_merch_event_to_adobe_event", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
 		c.ArrayWithStrings("productMerchProperties", "productMerchProperties", "product_merch_properties"),
 
-		c.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]string{
+		c.ArrayWithObjects("productMerchEvarsMap", "product_merch_evars_map", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),

--- a/rudderstack/integrations/destinations/destination_adobe_analytics_test.go
+++ b/rudderstack/integrations/destinations/destination_adobe_analytics_test.go
@@ -90,18 +90,74 @@ func TestDestinationResourceAdobeAnalytics(t *testing.T) {
 					from = "phone"
 					to = "1"
 					}]
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			  `,
 			APIUpdate: `{
@@ -216,61 +272,223 @@ func TestDestinationResourceAdobeAnalytics(t *testing.T) {
 					"eventName": "three"
 				  }
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				},
 				"eventFilteringOption": "blacklistedEvents"

--- a/rudderstack/integrations/destinations/destination_amplitude_test.go
+++ b/rudderstack/integrations/destinations/destination_amplitude_test.go
@@ -122,18 +122,74 @@ func TestDestinationResourceAmplitude(t *testing.T) {
 				  blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 
 				residency_server = "EU"
@@ -207,61 +263,223 @@ func TestDestinationResourceAmplitude(t *testing.T) {
 				"trackSessionEvents": { "android": true, "ios": true, "reactnative": true },
 				"useAdvertisingIdForDeviceId": { "android": true, "reactnative": true },
 				"useIdfaAsDeviceId": { "ios": true, "reactnative": true },
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				},
 				"residencyServer": "EU"

--- a/rudderstack/integrations/destinations/destination_bigquery.go
+++ b/rudderstack/integrations/destinations/destination_bigquery.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloud_source", "shopify"}
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloudSource", "shopify"}
 	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
 
 	properties := []c.ConfigProperty{

--- a/rudderstack/integrations/destinations/destination_bigquery_test.go
+++ b/rudderstack/integrations/destinations/destination_bigquery_test.go
@@ -40,18 +40,74 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 					exclude_window_start_time = "11:00"
 					exclude_window_end_time   = "12:00"
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					cloud_source = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					cloud_source = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -67,61 +123,223 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 					"excludeWindowStartTime": "11:00",
 					"excludeWindowEndTime": "12:00"
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
-					"cloud_source": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+					"cloudSource": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud_source"
+								},
+								{
+									"consent": "two_cloud_source"
+								},
+								{
+									"consent": "three_cloud_source"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_braze_test.go
+++ b/rudderstack/integrations/destinations/destination_braze_test.go
@@ -33,19 +33,75 @@ func TestDestinationResourceBraze(t *testing.T) {
 			}
 			data_center = "US-03"
 			rest_api_key = "updated_rest_api_pass"
-			onetrust_cookie_categories {
-				web = ["one", "two", "three"]
-				android = ["one", "two", "three"]
-				ios = ["one", "two", "three"]
-				unity = ["one", "two", "three"]
-				reactnative = ["one", "two", "three"]
-				flutter = ["one", "two", "three"]
-				cordova = ["one", "two", "three"]
-				amp = ["one", "two", "three"]
-				cloud = ["one", "two", "three"]
-				warehouse = ["one", "two", "three"]
-				shopify = ["one", "two", "three"]
-			}
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
+				}
 			`,
 			APIUpdate: `{
 				"connectionMode": {
@@ -54,61 +110,223 @@ func TestDestinationResourceBraze(t *testing.T) {
 				},
 				"dataCenter": "US-03",
 				"restApiKey": "updated_rest_api_pass",
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_customerio_test.go
+++ b/rudderstack/integrations/destinations/destination_customerio_test.go
@@ -36,18 +36,74 @@ func TestDestinationResourceCustomerIO(t *testing.T) {
 				event_filtering {
 					blacklist = [ "one", "two", "three" ]
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -62,61 +118,223 @@ func TestDestinationResourceCustomerIO(t *testing.T) {
 				}, {
 					"eventName": "three"
 				}],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_facebook_pixel.go
+++ b/rudderstack/integrations/destinations/destination_facebook_pixel.go
@@ -20,11 +20,11 @@ func init() {
 		c.Simple("testEventCode", "test_event_code", c.SkipZeroValue),
 		c.Simple("eventsToEvents", "events_to_events", c.SkipZeroValue),
 		c.ArrayWithStrings("eventCustomProperties", "eventCustomProperties", "event_custom_properties"),
-		c.ArrayWithObjects("blacklistPiiProperties", "blacklist_pii_properties", map[string]string{
+		c.ArrayWithObjects("blacklistPiiProperties", "blacklist_pii_properties", map[string]interface{}{
 			"blacklistPiiProperties": "property",
 			"blacklistPiiHash":       "hash",
 		}),
-		c.ArrayWithObjects("whitelistPiiProperties", "whitelist_pii_properties", map[string]string{
+		c.ArrayWithObjects("whitelistPiiProperties", "whitelist_pii_properties", map[string]interface{}{
 			"whitelistPiiProperties": "property",
 		}),
 		c.Simple("categoryToContent", "category_to_content", c.SkipZeroValue),

--- a/rudderstack/integrations/destinations/destination_facebook_pixel_test.go
+++ b/rudderstack/integrations/destinations/destination_facebook_pixel_test.go
@@ -75,18 +75,74 @@ func TestDestinationResourceFacebookPixel(t *testing.T) {
 				  blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -117,61 +173,223 @@ func TestDestinationResourceFacebookPixel(t *testing.T) {
 				"categoryToContent": [{ "from": "from", "to": "to" }],
 				"legacyConversionPixelId": { "from": "from", "to": "to" },
 				"useNativeSDK": { "web": true },
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				},
 				"blacklistedEvents": [

--- a/rudderstack/integrations/destinations/destination_gcs_test.go
+++ b/rudderstack/integrations/destinations/destination_gcs_test.go
@@ -20,79 +20,297 @@ func TestDestinationResourceGCS(t *testing.T) {
 				bucket_name = "bucket"
 				prefix        = "prefix"
 				credentials   = "..."
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
 				"bucketName": "bucket",
 				"prefix": "prefix",
 				"credentials": "...",
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_google_ads.go
+++ b/rudderstack/integrations/destinations/destination_google_ads.go
@@ -12,11 +12,11 @@ func init() {
 
 	properties := []c.ConfigProperty{
 		c.Simple("conversionID", "conversion_id"),
-		c.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]string{
+		c.ArrayWithObjects("pageLoadConversions", "page_load_conversions", map[string]interface{}{
 			"conversionLabel": "label",
 			"name":            "name",
 		}),
-		c.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]string{
+		c.ArrayWithObjects("clickEventConversions", "click_event_conversions", map[string]interface{}{
 			"conversionLabel": "label",
 			"name":            "name",
 		}),

--- a/rudderstack/integrations/destinations/destination_google_ads_test.go
+++ b/rudderstack/integrations/destinations/destination_google_ads_test.go
@@ -51,8 +51,24 @@ func TestDestinationResourceGoogleAds(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
 				}
 			`,
 			APIUpdate: `{
@@ -91,11 +107,53 @@ func TestDestinationResourceGoogleAds(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_google_analytics4_test.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics4_test.go
@@ -37,18 +37,74 @@ func TestDestinationResourceGoogleAnalytics4(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -74,61 +130,223 @@ func TestDestinationResourceGoogleAnalytics4(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_google_analytics_test.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics_test.go
@@ -76,18 +76,74 @@ func TestDestinationResourceGoogleAnalytics(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 	
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 
 				reset_custom_dimensions_on_page {
@@ -139,61 +195,223 @@ func TestDestinationResourceGoogleAnalytics(t *testing.T) {
 						{ "resetCustomDimensionsOnPage": "three" }
 					]
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				},
 				"contentGroupings": [{ "from": "from", "to": "to" }],

--- a/rudderstack/integrations/destinations/destination_google_sheets.go
+++ b/rudderstack/integrations/destinations/destination_google_sheets.go
@@ -14,7 +14,7 @@ func init() {
 		c.Simple("sheetName", "sheet_name"),
 		c.Simple("sheetId", "sheet_id"),
 		c.Simple("credentials", "credentials"),
-		c.ArrayWithObjects("eventKeyMap", "event_key_map", map[string]string{
+		c.ArrayWithObjects("eventKeyMap", "event_key_map", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),

--- a/rudderstack/integrations/destinations/destination_google_sheets_test.go
+++ b/rudderstack/integrations/destinations/destination_google_sheets_test.go
@@ -30,18 +30,74 @@ func TestDestinationResourceGoogleSheets(t *testing.T) {
 						to   = "b1"
 					},
 				]
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -54,61 +110,223 @@ func TestDestinationResourceGoogleSheets(t *testing.T) {
 						"to": "b1"
 					}
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_google_tag_manager_test.go
+++ b/rudderstack/integrations/destinations/destination_google_tag_manager_test.go
@@ -29,8 +29,24 @@ func TestDestinationResourceGoogleTagManager(t *testing.T) {
 					blacklist = ["one", "two", "three"]
 				}
 			
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
 				}
 			`,
 			APIUpdate: `{
@@ -51,11 +67,53 @@ func TestDestinationResourceGoogleTagManager(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_intercom.go
+++ b/rudderstack/integrations/destinations/destination_intercom.go
@@ -122,14 +122,6 @@ func init() {
 				},
 			},
 		},
-		"onetrust_cookie_categories": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
 	}
 
 	for key, value := range commonSchema {

--- a/rudderstack/integrations/destinations/destination_intercom_test.go
+++ b/rudderstack/integrations/destinations/destination_intercom_test.go
@@ -39,18 +39,74 @@ func TestDestinationResourceIntercom(t *testing.T) {
 				collect_context = true
 				send_anonymous_id = true
 				update_last_request_at = false
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 				mobile_api_key_android = "and-key"
 				mobile_api_key_ios = "ios-key"
@@ -77,61 +133,223 @@ func TestDestinationResourceIntercom(t *testing.T) {
 				}, {
 					"eventName": "three"
 				}],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_iterable_test.go
+++ b/rudderstack/integrations/destinations/destination_iterable_test.go
@@ -91,18 +91,74 @@ func TestDestinationResourceIterable(t *testing.T) {
 				close_button_position { 
 					web = "..." 
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 
 			`,
@@ -147,61 +203,223 @@ func TestDestinationResourceIterable(t *testing.T) {
 				"iconPath": { "web": "..." },
 				"isRequiredToDismissMessage": { "web": true },
 				"closeButtonPosition": { "web": "..." },
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_kafka.go
+++ b/rudderstack/integrations/destinations/destination_kafka.go
@@ -7,170 +7,174 @@ import (
 )
 
 func init() {
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "warehouse", "shopify"}
+	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
+
+	properties := []c.ConfigProperty{
+		c.Simple("hostName", "host_name"),
+		c.Simple("port", "port"),
+		c.Simple("topic", "topic"),
+		c.Simple("sslEnabled", "ssl_enabled", c.SkipZeroValue),
+		c.Simple("caCertificate", "ca_certificate", c.SkipZeroValue),
+		c.Simple("useSASL", "use_sasl", c.SkipZeroValue),
+		c.Simple("saslType", "sasl_type", c.SkipZeroValue),
+		c.Simple("username", "username", c.SkipZeroValue),
+		c.Simple("password", "password", c.SkipZeroValue),
+		c.Simple("convertToAvro", "convert_to_avro", c.SkipZeroValue),
+		c.ArrayWithObjects("avroSchema", "avro_schema", map[string]interface{}{
+			"schemaId": "schema_id",
+			"schema":   "schema",
+		}),
+		c.Simple("embedAvroSchemaID", "embed_avro_schema_id", c.SkipZeroValue),
+		c.Simple("enableMultiTopic", "enable_multi_topic", c.SkipZeroValue),
+		c.ArrayWithObjects("eventTypeToTopicMap", "event_type_to_topic_map", map[string]interface{}{
+			"from": "from",
+			"to":   "to",
+		}),
+		c.ArrayWithObjects("eventToTopicMap", "event_to_topic_map", map[string]interface{}{
+			"from": "from",
+			"to":   "to",
+		}),
+	}
+
+	properties = append(properties, commonProperties...)
+
+	schema := map[string]*schema.Schema{
+		"host_name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The host name of your Kafka service.",
+		},
+		"port": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The port number associated with the Kafka service.",
+		},
+		"topic": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The topic name in your Kafka service where the data will be sent.",
+		},
+		"ssl_enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Whether to enable SSL for the Kafka service.",
+		},
+		"ca_certificate": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The CA certificate for the Kafka service.",
+		},
+		"use_sasl": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether to use SASL for the Kafka service.",
+		},
+		"sasl_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The SASL type for the Kafka service.",
+		},
+		"username": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The username for the Kafka service.",
+		},
+		"password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "The password for the Kafka service.",
+		},
+		"convert_to_avro": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether to convert the data to Avro format.",
+		},
+		"avro_schema": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "The Avro schema for the Kafka service.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"schema_id": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The schema ID for the Avro schema.",
+					},
+					"schema": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The schema for the Avro schema.",
+					},
+				},
+			},
+		},
+		"embed_avro_schema_id": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether to embed the Avro schema ID.",
+		},
+		"enable_multi_topic": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether to enable multi-topic.",
+		},
+		"event_type_to_topic_map": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "The event type to topic map for the Kafka service.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The event type to topic map from.",
+					},
+					"to": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The event type to topic map to.",
+					},
+				},
+			},
+		},
+		"event_to_topic_map": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "The event to topic map for the Kafka service.",
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The event to topic map from.",
+					},
+					"to": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The event to topic map to.",
+					},
+				},
+			},
+		},
+	}
+
+	for key, value := range commonSchema {
+		schema[key] = value
+	}
+
 	c.Destinations.Register("kafka", c.ConfigMeta{
-		APIType: "KAFKA",
-		Properties: []c.ConfigProperty{
-			c.Simple("hostName", "host_name"),
-			c.Simple("port", "port"),
-			c.Simple("topic", "topic"),
-			c.Simple("sslEnabled", "ssl_enabled", c.SkipZeroValue),
-			c.Simple("caCertificate", "ca_certificate", c.SkipZeroValue),
-			c.Simple("useSASL", "use_sasl", c.SkipZeroValue),
-			c.Simple("saslType", "sasl_type", c.SkipZeroValue),
-			c.Simple("username", "username", c.SkipZeroValue),
-			c.Simple("password", "password", c.SkipZeroValue),
-			c.Simple("convertToAvro", "convert_to_avro", c.SkipZeroValue),
-			c.ArrayWithObjects("avroSchema", "avro_schema", map[string]interface{}{
-				"schemaId": "schema_id",
-				"schema":   "schema",
-			}),
-			c.Simple("embedAvroSchemaID", "embed_avro_schema_id", c.SkipZeroValue),
-			c.Simple("enableMultiTopic", "enable_multi_topic", c.SkipZeroValue),
-			c.ArrayWithObjects("eventTypeToTopicMap", "event_type_to_topic_map", map[string]interface{}{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithObjects("eventToTopicMap", "event_to_topic_map", map[string]interface{}{
-				"from": "from",
-				"to":   "to",
-			}),
-			c.ArrayWithStrings("oneTrustCookieCategories", "oneTrustCookieCategory", "onetrust_cookie_categories"),
-		},
-		ConfigSchema: map[string]*schema.Schema{
-			"host_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The host name of your Kafka service.",
-			},
-			"port": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The port number associated with the Kafka service.",
-			},
-			"topic": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The topic name in your Kafka service where the data will be sent.",
-			},
-			"ssl_enabled": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether to enable SSL for the Kafka service.",
-			},
-			"ca_certificate": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The CA certificate for the Kafka service.",
-			},
-			"use_sasl": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether to use SASL for the Kafka service.",
-			},
-			"sasl_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The SASL type for the Kafka service.",
-			},
-			"username": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The username for the Kafka service.",
-			},
-			"password": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "The password for the Kafka service.",
-			},
-			"convert_to_avro": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether to convert the data to Avro format.",
-			},
-			"avro_schema": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "The Avro schema for the Kafka service.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"schema_id": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The schema ID for the Avro schema.",
-						},
-						"schema": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The schema for the Avro schema.",
-						},
-					},
-				},
-			},
-			"embed_avro_schema_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether to embed the Avro schema ID.",
-			},
-			"enable_multi_topic": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether to enable multi-topic.",
-			},
-			"event_type_to_topic_map": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "The event type to topic map for the Kafka service.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The event type to topic map from.",
-						},
-						"to": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The event type to topic map to.",
-						},
-					},
-				},
-			},
-			"event_to_topic_map": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "The event to topic map for the Kafka service.",
-				ConfigMode:  schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"from": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The event to topic map from.",
-						},
-						"to": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The event to topic map to.",
-						},
-					},
-				},
-			},
-			"onetrust_cookie_categories": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Specify the OneTrust category name for mapping the OneTrust consent settings to RudderStack's consent purposes.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
+		APIType:      "KAFKA",
+		Properties:   properties,
+		ConfigSchema: schema,
 	})
 }

--- a/rudderstack/integrations/destinations/destination_kafka.go
+++ b/rudderstack/integrations/destinations/destination_kafka.go
@@ -20,17 +20,17 @@ func init() {
 			c.Simple("username", "username", c.SkipZeroValue),
 			c.Simple("password", "password", c.SkipZeroValue),
 			c.Simple("convertToAvro", "convert_to_avro", c.SkipZeroValue),
-			c.ArrayWithObjects("avroSchema", "avro_schema", map[string]string{
+			c.ArrayWithObjects("avroSchema", "avro_schema", map[string]interface{}{
 				"schemaId": "schema_id",
 				"schema":   "schema",
 			}),
 			c.Simple("embedAvroSchemaID", "embed_avro_schema_id", c.SkipZeroValue),
 			c.Simple("enableMultiTopic", "enable_multi_topic", c.SkipZeroValue),
-			c.ArrayWithObjects("eventTypeToTopicMap", "event_type_to_topic_map", map[string]string{
+			c.ArrayWithObjects("eventTypeToTopicMap", "event_type_to_topic_map", map[string]interface{}{
 				"from": "from",
 				"to":   "to",
 			}),
-			c.ArrayWithObjects("eventToTopicMap", "event_to_topic_map", map[string]string{
+			c.ArrayWithObjects("eventToTopicMap", "event_to_topic_map", map[string]interface{}{
 				"from": "from",
 				"to":   "to",
 			}),

--- a/rudderstack/integrations/destinations/destination_kafka_test.go
+++ b/rudderstack/integrations/destinations/destination_kafka_test.go
@@ -27,13 +27,301 @@ func TestDestinationResourceKafka(t *testing.T) {
 				topic = "example-topic"
 				ssl_enabled = true
 				ca_certificate = "example-ca-certificate"
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
+				}
 			`,
 			APIUpdate: `{
 				"hostName": "example-updated.com",
 				"port": "9092",
 				"topic": "example-topic",
 				"sslEnabled": true,
-				"caCertificate": "example-ca-certificate"
+				"caCertificate": "example-ca-certificate",
+				"consentManagement": {
+					"web": [
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
+					],
+					"android": [
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
+					],
+					"ios": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
+					],
+					"unity": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
+					],
+					"reactnative": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
+					],
+					"flutter": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
+					],
+					"cordova": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
+					],
+					"amp": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
+					],
+					"cloud": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
+					],
+					"warehouse": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
+					],
+					"shopify": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
+					]
+				}
 			}`,
 		},
 	})

--- a/rudderstack/integrations/destinations/destination_kinesis_test.go
+++ b/rudderstack/integrations/destinations/destination_kinesis_test.go
@@ -31,18 +31,74 @@ func TestDestinationResourceKinesis(t *testing.T) {
 				 access_key_id = "id"
 				}
 				use_message_id = true
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -52,61 +108,223 @@ func TestDestinationResourceKinesis(t *testing.T) {
 				"accessKeyID": "id",
 				"accessKey": "key",
 				"useMessageId": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_linkedin_insight_tag.go
+++ b/rudderstack/integrations/destinations/destination_linkedin_insight_tag.go
@@ -18,7 +18,7 @@ func init() {
 			"event_filtering.0.whitelist": "whitelistedEvents",
 			"event_filtering.0.blacklist": "blacklistedEvents",
 		}),
-		c.ArrayWithObjects("eventToConversionIdMap", "event_to_conversion_id_map", map[string]string{
+		c.ArrayWithObjects("eventToConversionIdMap", "event_to_conversion_id_map", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),

--- a/rudderstack/integrations/destinations/destination_linkedin_insight_tag_test.go
+++ b/rudderstack/integrations/destinations/destination_linkedin_insight_tag_test.go
@@ -33,8 +33,24 @@ func TestDestinationResourceLinkedinInsightTag(t *testing.T) {
 				event_filtering {
 					whitelist = ["one", "two", "three"]
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
 				}
 			`,
 			APIUpdate: `
@@ -58,11 +74,53 @@ func TestDestinationResourceLinkedinInsightTag(t *testing.T) {
 						"eventName": "three"
 					}
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					]
 				}
 			}			

--- a/rudderstack/integrations/destinations/destination_marketo.go
+++ b/rudderstack/integrations/destinations/destination_marketo.go
@@ -27,16 +27,16 @@ func init() {
 		c.Simple("connectionMode.shopify", "connection_mode.0.shopify", c.SkipZeroValue),
 		c.Simple("connectionMode.cloud", "connection_mode.0.cloud", c.SkipZeroValue),
 		c.Simple("connectionMode.warehouse", "connection_mode.0.warehouse", c.SkipZeroValue),
-		c.ArrayWithObjects("rudderEventsMapping", "rudder_events_mapping", map[string]string{
+		c.ArrayWithObjects("rudderEventsMapping", "rudder_events_mapping", map[string]interface{}{
 			"event":             "event",
 			"marketoPrimarykey": "marketo_primarykey",
 			"marketoActivityId": "marketo_activity_id",
 		}),
-		c.ArrayWithObjects("leadTraitMapping", "lead_trait_mapping", map[string]string{
+		c.ArrayWithObjects("leadTraitMapping", "lead_trait_mapping", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),
-		c.ArrayWithObjects("customActivityPropertyMap", "custom_activity_property_map", map[string]string{
+		c.ArrayWithObjects("customActivityPropertyMap", "custom_activity_property_map", map[string]interface{}{
 			"from": "from",
 			"to":   "to",
 		}),

--- a/rudderstack/integrations/destinations/destination_marketo_test.go
+++ b/rudderstack/integrations/destinations/destination_marketo_test.go
@@ -61,18 +61,74 @@ func TestDestinationResourceMarketo(t *testing.T) {
 					web = "cloud"
 					ios = "cloud"
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -104,61 +160,223 @@ func TestDestinationResourceMarketo(t *testing.T) {
 					"web": "cloud",
 					"ios": "cloud"
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_mixpanel_test.go
+++ b/rudderstack/integrations/destinations/destination_mixpanel_test.go
@@ -50,18 +50,74 @@ func TestDestinationResourceMixpanel(t *testing.T) {
 					whitelist = ["one", "two", "three"]
 				}
 		
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 				use_new_mapping = true
 			`,
@@ -143,61 +199,223 @@ func TestDestinationResourceMixpanel(t *testing.T) {
 						"eventName": "three"
 					}
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				},
 				"useNewMapping": true

--- a/rudderstack/integrations/destinations/destination_postgres.go
+++ b/rudderstack/integrations/destinations/destination_postgres.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloud_source", "shopify"}
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloudSource", "shopify"}
 	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
 
 	properties := []c.ConfigProperty{

--- a/rudderstack/integrations/destinations/destination_postgres_test.go
+++ b/rudderstack/integrations/destinations/destination_postgres_test.go
@@ -39,18 +39,74 @@ func TestDestinationResourcePostgres(t *testing.T) {
 				ssl_mode = "verify-ca"
 				sync_frequency = "60"
 				use_rudder_storage = true
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					cloud_source = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					cloud_source = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -62,61 +118,223 @@ func TestDestinationResourcePostgres(t *testing.T) {
 				"sslMode": "verify-ca",
 				"syncFrequency": "60",
 				"useRudderStorage": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
-					"cloud_source": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+					"cloudSource": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud_source"
+								},
+								{
+									"consent": "two_cloud_source"
+								},
+								{
+									"consent": "three_cloud_source"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_qualtrics_test.go
+++ b/rudderstack/integrations/destinations/destination_qualtrics_test.go
@@ -36,10 +36,34 @@ func TestDestinationResourceQualtrics(t *testing.T) {
 				event_filtering {
 					blacklist = [ "one", "two", "three" ]
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -52,21 +76,87 @@ func TestDestinationResourceQualtrics(t *testing.T) {
 					{"eventName": "three"}
 				],
 				"useNativeSDK":{"ios":true},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					]
 				},
 				"enableGenericPageTitle":{"web":true}

--- a/rudderstack/integrations/destinations/destination_redis_test.go
+++ b/rudderstack/integrations/destinations/destination_redis_test.go
@@ -29,18 +29,74 @@ func TestDestinationResourceRedis(t *testing.T) {
 				database      = "..."
 				ca_certificate = "..."
 				skip_verify   = true
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -52,61 +108,223 @@ func TestDestinationResourceRedis(t *testing.T) {
 				"database": "...",
 				"caCertificate": "...",
 				"skipVerify": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_redshift.go
+++ b/rudderstack/integrations/destinations/destination_redshift.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloud_source", "shopify"}
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloudSource", "shopify"}
 	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
 
 	properties := []c.ConfigProperty{

--- a/rudderstack/integrations/destinations/destination_redshift_test.go
+++ b/rudderstack/integrations/destinations/destination_redshift_test.go
@@ -55,18 +55,74 @@ func TestDestinationResourceRedshift(t *testing.T) {
 					access_key_id = "some-access-key-id"
 					access_key = "some-access-key"
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					cloud_source = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					cloud_source = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 				`,
 			APIUpdate: `{
@@ -87,61 +143,223 @@ func TestDestinationResourceRedshift(t *testing.T) {
 					"excludeWindowStartTime": "11:00",
 					"excludeWindowEndTime": "12:00"	
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
-					"cloud_source": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+					"cloudSource": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud_source"
+								},
+								{
+									"consent": "two_cloud_source"
+								},
+								{
+									"consent": "three_cloud_source"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_s3_datalake.go
+++ b/rudderstack/integrations/destinations/destination_s3_datalake.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloud_source", "shopify"}
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloudSource", "shopify"}
 	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
 
 	properties := []c.ConfigProperty{

--- a/rudderstack/integrations/destinations/destination_s3_datalake_test.go
+++ b/rudderstack/integrations/destinations/destination_s3_datalake_test.go
@@ -39,18 +39,74 @@ func TestDestinationResourceS3Datalake(t *testing.T) {
 					frequency = "30"
 					start_at  = "10:00"
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					cloud_source = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					cloud_source = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -64,61 +120,223 @@ func TestDestinationResourceS3Datalake(t *testing.T) {
 				"region": "region",
 				"syncFrequency": "30",
 				"syncStartAt": "10:00",
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
-					"cloud_source": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+					"cloudSource": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud_source"
+								},
+								{
+									"consent": "two_cloud_source"
+								},
+								{
+									"consent": "three_cloud_source"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_s3_test.go
+++ b/rudderstack/integrations/destinations/destination_s3_test.go
@@ -24,18 +24,74 @@ func TestDestinationResourceS3(t *testing.T) {
 				access_key    = "..."
 			
 				enable_sse    = true
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -44,61 +100,223 @@ func TestDestinationResourceS3(t *testing.T) {
 				"accessKeyID": "...",
 				"accessKey": "...",
 				"enableSSE": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_salesforce_test.go
+++ b/rudderstack/integrations/destinations/destination_salesforce_test.go
@@ -27,18 +27,74 @@ func TestDestinationResourceSalesforce(t *testing.T) {
 				initial_access_token = "token"
 				map_properties = true
 				use_contact_id = true
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -47,61 +103,223 @@ func TestDestinationResourceSalesforce(t *testing.T) {
 				"initialAccessToken": "token",
 				"useContactId": true,
 				"mapProperties": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_sentry_test.go
+++ b/rudderstack/integrations/destinations/destination_sentry_test.go
@@ -39,8 +39,24 @@ func TestDestinationResourceSentry(t *testing.T) {
 				  whitelist = ["one", "two", "three"]
 				}
 
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
 				}
 			`,
 			APIUpdate: `{
@@ -79,11 +95,53 @@ func TestDestinationResourceSentry(t *testing.T) {
 					{ "eventName": "two" },
 					{ "eventName": "three" }
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_slack.go
+++ b/rudderstack/integrations/destinations/destination_slack.go
@@ -13,12 +13,12 @@ func init() {
 	properties := []c.ConfigProperty{
 		c.Simple("webhookUrl", "webhook_url"),
 		c.Simple("identifyTemplate", "identify_template", c.SkipZeroValue),
-		c.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]string{
+		c.ArrayWithObjects("eventChannelSettings", "event_channel_settings", map[string]interface{}{
 			"eventName":    "name",
 			"eventChannel": "channel",
 			"eventRegex":   "regex",
 		}),
-		c.ArrayWithObjects("eventTemplateSettings", "event_template_settings", map[string]string{
+		c.ArrayWithObjects("eventTemplateSettings", "event_template_settings", map[string]interface{}{
 			"eventName":     "name",
 			"eventTemplate": "template",
 			"eventRegex":    "regex",

--- a/rudderstack/integrations/destinations/destination_slack_test.go
+++ b/rudderstack/integrations/destinations/destination_slack_test.go
@@ -37,18 +37,74 @@ func TestDestinationResourceSlack(t *testing.T) {
 				]
 			  
 				whitelisted_trait_settings = ["one", "two", "three"]
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -73,61 +129,223 @@ func TestDestinationResourceSlack(t *testing.T) {
 					{ "trait": "two" },
 					{ "trait": "three" }
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_snowflake.go
+++ b/rudderstack/integrations/destinations/destination_snowflake.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloud_source", "shopify"}
+	supportedSourceTypes := []string{"web", "android", "ios", "unity", "reactnative", "flutter", "cordova", "amp", "cloud", "cloudSource", "shopify"}
 	commonProperties, commonSchema := GetCommonConfigMeta(supportedSourceTypes)
 
 	properties := []c.ConfigProperty{

--- a/rudderstack/integrations/destinations/destination_snowflake_test.go
+++ b/rudderstack/integrations/destinations/destination_snowflake_test.go
@@ -54,18 +54,74 @@ func TestDestinationResourceSnowflake(t *testing.T) {
 					access_key = "example-access-key"
 					enable_sse = true
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					cloud_source = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					cloud_source = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud_source", "two_cloud_source", "three_cloud_source"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -91,61 +147,223 @@ func TestDestinationResourceSnowflake(t *testing.T) {
         		"accessKeyID": "example-access-key-id",
         		"accessKey": "example-access-key",
         		"enableSSE": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
-					"cloud_source": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+					"cloudSource": [
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud_source"
+								},
+								{
+									"consent": "two_cloud_source"
+								},
+								{
+									"consent": "three_cloud_source"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_statsig_test.go
+++ b/rudderstack/integrations/destinations/destination_statsig_test.go
@@ -32,18 +32,74 @@ func TestDestinationResourceStatSig(t *testing.T) {
 				 amp = "cloud"
 				 react_native = "cloud"
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -54,61 +110,223 @@ func TestDestinationResourceStatSig(t *testing.T) {
 					"amp": "cloud",
 					"reactnative": "cloud"
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_vwo_test.go
+++ b/rudderstack/integrations/destinations/destination_vwo_test.go
@@ -35,8 +35,24 @@ func TestDestinationResourceVWO(t *testing.T) {
 				event_filtering {
 					whitelist = ["one", "two", "three"]
 				}
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
 				}
 			`,
 			APIUpdate: `{
@@ -61,11 +77,53 @@ func TestDestinationResourceVWO(t *testing.T) {
 				"useNativeSDK": {
 				  "web": true
 				},
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_webhook_test.go
+++ b/rudderstack/integrations/destinations/destination_webhook_test.go
@@ -31,18 +31,74 @@ func TestDestinationResourceWebhook(t *testing.T) {
 						to   = "b2"
 					}
 				]
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -58,61 +114,223 @@ func TestDestinationResourceWebhook(t *testing.T) {
 						"to": "b2"
 					}
 				],
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/integrations/destinations/destination_zendesk_test.go
+++ b/rudderstack/integrations/destinations/destination_zendesk_test.go
@@ -29,18 +29,74 @@ func TestDestinationResourceZendesk(t *testing.T) {
 				send_group_calls_without_user_id = true
 				remove_users_from_organization   = true
 				search_by_external_id = true
-				onetrust_cookie_categories {
-					web = ["one", "two", "three"]
-					android = ["one", "two", "three"]
-					ios = ["one", "two", "three"]
-					unity = ["one", "two", "three"]
-					reactnative = ["one", "two", "three"]
-					flutter = ["one", "two", "three"]
-					cordova = ["one", "two", "three"]
-					amp = ["one", "two", "three"]
-					cloud = ["one", "two", "three"]
-					warehouse = ["one", "two", "three"]
-					shopify = ["one", "two", "three"]
+				consent_management {
+					web = [
+						{
+							provider = "oneTrust"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "ketch"
+							consents = ["one_web", "two_web", "three_web"]
+							resolution_strategy = ""
+						},
+						{
+							provider = "custom"
+							resolution_strategy = "and"
+							consents = ["one_web", "two_web", "three_web"]
+						}
+					]
+					android = [{
+						provider = "ketch"
+						consents = ["one_android", "two_android", "three_android"]
+						resolution_strategy = ""
+					}]
+					ios = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_ios", "two_ios", "three_ios"]
+					}]
+					unity = [{
+						provider = "custom"
+						resolution_strategy = "or"
+						consents = ["one_unity", "two_unity", "three_unity"]
+					}]
+					reactnative = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_reactnative", "two_reactnative", "three_reactnative"]
+					}]
+					flutter = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_flutter", "two_flutter", "three_flutter"]
+					}]
+					cordova = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cordova", "two_cordova", "three_cordova"]
+					}]
+					amp = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_amp", "two_amp", "three_amp"]
+					}]
+					cloud = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_cloud", "two_cloud", "three_cloud"]
+					}]
+					warehouse = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_warehouse", "two_warehouse", "three_warehouse"]
+					}]
+					shopify = [{
+						provider = "custom"
+						resolution_strategy = "and"
+						consents = ["one_shopify", "two_shopify", "three_shopify"]
+					}]
 				}
 			`,
 			APIUpdate: `{
@@ -51,61 +107,223 @@ func TestDestinationResourceZendesk(t *testing.T) {
 				"sendGroupCallsWithoutUserId": true,
 				"removeUsersFromOrganization": true,
 				"searchByExternalId": true,
-				"oneTrustCookieCategories": {
+				"consentManagement": {
 					"web": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "oneTrust",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						},
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_web"
+								},
+								{
+									"consent": "two_web"
+								},
+								{
+									"consent": "three_web"
+								}
+							]
+						}
 					],
 					"android": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "ketch",
+							"resolutionStrategy": "",
+							"consents": [
+								{
+									"consent": "one_android"
+								},
+								{
+									"consent": "two_android"
+								},
+								{
+									"consent": "three_android"
+								}
+							]
+						}
 					],
 					"ios": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_ios"
+								},
+								{
+									"consent": "two_ios"
+								},
+								{
+									"consent": "three_ios"
+								}
+							]
+						}
 					],
 					"unity": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "or",
+							"consents": [
+								{
+									"consent": "one_unity"
+								},
+								{
+									"consent": "two_unity"
+								},
+								{
+									"consent": "three_unity"
+								}
+							]
+						}
 					],
 					"reactnative": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_reactnative"
+								},
+								{
+									"consent": "two_reactnative"
+								},
+								{
+									"consent": "three_reactnative"
+								}
+							]
+						}
 					],
 					"flutter": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_flutter"
+								},
+								{
+									"consent": "two_flutter"
+								},
+								{
+									"consent": "three_flutter"
+								}
+							]
+						}
 					],
 					"cordova": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cordova"
+								},
+								{
+									"consent": "two_cordova"
+								},
+								{
+									"consent": "three_cordova"
+								}
+							]
+						}
 					],
 					"amp": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_amp"
+								},
+								{
+									"consent": "two_amp"
+								},
+								{
+									"consent": "three_amp"
+								}
+							]
+						}
 					],
 					"cloud": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_cloud"
+								},
+								{
+									"consent": "two_cloud"
+								},
+								{
+									"consent": "three_cloud"
+								}
+							]
+						}
 					],
 					"warehouse": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_warehouse"
+								},
+								{
+									"consent": "two_warehouse"
+								},
+								{
+									"consent": "three_warehouse"
+								}
+							]
+						}
 					],
 					"shopify": [
-						{ "oneTrustCookieCategory": "one" },
-						{ "oneTrustCookieCategory": "two" },
-						{ "oneTrustCookieCategory": "three" }
+						{
+							"provider": "custom",
+							"resolutionStrategy": "and",
+							"consents": [
+								{
+									"consent": "one_shopify"
+								},
+								{
+									"consent": "two_shopify"
+								},
+								{
+									"consent": "three_shopify"
+								}
+							]
+						}
 					]
 				}
 			}`,

--- a/rudderstack/provider.go
+++ b/rudderstack/provider.go
@@ -74,7 +74,7 @@ func configureClient(ctx context.Context, d *schema.ResourceData) (*Client, diag
 	accessToken := d.Get("access_token").(string)
 	client, err := NewAPIClient(accessToken,
 		client.WithBaseURL(apiUrl),
-		client.WithUserAgent("terraform-provider-rudderstack/2.0.0"))
+		client.WithUserAgent("terraform-provider-rudderstack/3.0.0"))
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,6 +13,9 @@ The RudderStack Terraform Provider allows you to access your RudderStack control
 
 {{tffile "examples/main.tf"}}
 
+> **:warning: Breaking Change**
+> 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the examples in the destinations` resource guide.
 
 > **:warning: Breaking Change**
 > 

--- a/templates/resources/destination_LINKEDIN_INSIGHT_TAG.md.tmpl
+++ b/templates/resources/destination_LINKEDIN_INSIGHT_TAG.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/linkedin-in
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_active_campaign.md.tmpl
+++ b/templates/resources/destination_active_campaign.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/marketing/activecampaign
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_adobe_analytics.md.tmpl
+++ b/templates/resources/destination_adobe_analytics.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/adobe-analy
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_amplitude.md.tmpl
+++ b/templates/resources/destination_amplitude.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/analytics/amplitude
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 1.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_bigquery.md.tmpl
+++ b/templates/resources/destination_bigquery.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/data-warehouse-integrations/google-bigquery
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_braze.md.tmpl
+++ b/templates/resources/destination_braze.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_customerio.md.tmpl
+++ b/templates/resources/destination_customerio.md.tmpl
@@ -15,6 +15,10 @@ https://www.rudderstack.com/docs/stream-sources/customerio
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_facebook_pixel.md.tmpl
+++ b/templates/resources/destination_facebook_pixel.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/advertising/fb-pixel
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_gcs.md.tmpl
+++ b/templates/resources/destination_gcs.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/warehouse-destinations/gcs-datalak
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_google_ads.md.tmpl
+++ b/templates/resources/destination_google_ads.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/advertising/g-ads-gtag
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_google_analytics.md.tmpl
+++ b/templates/resources/destination_google_analytics.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/analytics/google-analytics-ga
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_google_analytics4.md.tmpl
+++ b/templates/resources/destination_google_analytics4.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/analytics/google-analytics-4/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 1.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_google_sheets.md.tmpl
+++ b/templates/resources/destination_google_sheets.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/google-shee
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_google_tag_manager.md.tmpl
+++ b/templates/resources/destination_google_tag_manager.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/tag-managers/google-tag-manager/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 1.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_intercom.md.tmpl
+++ b/templates/resources/destination_intercom.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/intercom/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_iterable.md.tmpl
+++ b/templates/resources/destination_iterable.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/iterable/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_kafka.md.tmpl
+++ b/templates/resources/destination_kafka.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/kafka/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_kinesis.md.tmpl
+++ b/templates/resources/destination_kinesis.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/amazon-kine
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_marketo.md.tmpl
+++ b/templates/resources/destination_marketo.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/marketo/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_mixpanel.md.tmpl
+++ b/templates/resources/destination_mixpanel.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 1.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_postgres.md.tmpl
+++ b/templates/resources/destination_postgres.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/warehouse-destinations/postgresql/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 1.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_qualtrics.md.tmpl
+++ b/templates/resources/destination_qualtrics.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/qualtrics/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_redis.md.tmpl
+++ b/templates/resources/destination_redis.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/storage-platforms/redis
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_redshift.md.tmpl
+++ b/templates/resources/destination_redshift.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/reverse-etl/amazon-redshift
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_s3.md.tmpl
+++ b/templates/resources/destination_s3.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/storage-platforms/amazon-s3
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_s3_datalake.md.tmpl
+++ b/templates/resources/destination_s3_datalake.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/data-warehouse-integrations/s3-datalake
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_salesforce.md.tmpl
+++ b/templates/resources/destination_salesforce.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/salesforce/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_sentry.md.tmpl
+++ b/templates/resources/destination_sentry.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/error-reporting/sentry
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_slack.md.tmpl
+++ b/templates/resources/destination_slack.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/business-messaging/slack
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_snowflake.md.tmpl
+++ b/templates/resources/destination_snowflake.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/warehouse-destinations/snowflake/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_statsig.md.tmpl
+++ b/templates/resources/destination_statsig.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/streaming-destinations/statsig/
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_vwo.md.tmpl
+++ b/templates/resources/destination_vwo.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/testing-and-personalization/vwo-be
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_webhook.md.tmpl
+++ b/templates/resources/destination_webhook.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/webhooks
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/destination_zendesk.md.tmpl
+++ b/templates/resources/destination_zendesk.md.tmpl
@@ -16,6 +16,10 @@ https://www.rudderstack.com/docs/destinations/crm/zendesk
 
 > **:warning: Breaking Change**
 > 
+> Note that from the provider versions 3.0.0 and above, `onetrust_cookie_categories` property is replaced with `consent_management` that supports multiple consent management providers. Please refer to the example above.
+
+> **:warning: Breaking Change**
+> 
 > Note that from the provider versions 2.0.0 and above, the schema of `onetrust_cookie_categories` property has been changed. Please refer to the example above.
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Description of the change

Added Generic Consent Management (GCM) fields to all the destinations.


## Linear Link

https://linear.app/rudderstack/issue/SDK-746/add-new-generic-consent-fields-for-all-destinations-in-terraform-files

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
