### PR TITLE
fix: import script will not fail if a single resource cannot be imported

### DIFF
--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -134,10 +134,16 @@ func GenerateTerraform(sources []client.Source, destinations []client.Destinatio
 }
 
 // generateSource generates a source resource block from an API source object and a terraform source type and ConfigMeta.
-func generateSource(source client.Source, terraformType string, cm *configs.ConfigMeta) (*hclwrite.Block, error) {
+func generateSource(source client.Source, terraformType string, cm *configs.ConfigMeta) (block *hclwrite.Block, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while generating source block: %v", r)
+		}
+	}()
+
 	resourceType := sourceType(terraformType)
 	resourceName := sourceName(source)
-	block := hclwrite.NewBlock("resource", []string{resourceType, resourceName})
+	block = hclwrite.NewBlock("resource", []string{resourceType, resourceName})
 
 	body := block.Body()
 	body.SetAttributeValue("name", cty.StringVal(source.Name))


### PR DESCRIPTION
## Description of the change

This PR fixes a problem where import script does not output anything if the block for a single resource cannot be generated, due to unknown errors. With this change, the block is skipped and an error is logged in the console.

## Notion Link

> Notion Link

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
