### PR TITLE
fix: generating terraform script during import properly handles empty lists

### DIFF
--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -81,14 +81,14 @@ func GenerateTerraform(sources []client.Source, destinations []client.Destinatio
 		if cm != nil {
 			b, err := generateSource(src, terraformType, cm)
 			if err != nil {
-				return nil, err
+				logger.Printf("could not generate resource block for source '%s': %v", src.ID, err)
+			} else {
+				body.AppendBlock(b)
+				body.AppendNewline()
+				generatedSourceEntries[src.ID] = &sourceEntry{terraformType: terraformType, source: src}
 			}
-
-			body.AppendBlock(b)
-			body.AppendNewline()
-			generatedSourceEntries[src.ID] = &sourceEntry{terraformType: terraformType, source: src}
 		} else {
-			logger.Printf("could not generate resource block for source '%s':  type '%s' is not supported", src.ID, src.Type)
+			logger.Printf("could not generate resource block for source '%s': type '%s' is not supported", src.ID, src.Type)
 		}
 	}
 
@@ -100,14 +100,14 @@ func GenerateTerraform(sources []client.Source, destinations []client.Destinatio
 		if cm != nil {
 			b, err := generateDestination(dst, terraformType, cm)
 			if err != nil {
-				return nil, err
+				logger.Printf("could not generate resource block for destination '%s': %v", dst.ID, err)
+			} else {
+				body.AppendBlock(b)
+				body.AppendNewline()
+				generatedDestinationEntries[dst.ID] = &destinationEntry{terraformType: terraformType, destination: dst}
 			}
-
-			body.AppendBlock(b)
-			body.AppendNewline()
-			generatedDestinationEntries[dst.ID] = &destinationEntry{terraformType: terraformType, destination: dst}
 		} else {
-			logger.Printf("could not generate resource block for destination '%s':  type '%s' is not supported", dst.ID, dst.Type)
+			logger.Printf("could not generate resource block for destination '%s': type '%s' is not supported", dst.ID, dst.Type)
 		}
 	}
 
@@ -134,10 +134,16 @@ func GenerateTerraform(sources []client.Source, destinations []client.Destinatio
 }
 
 // generateSource generates a source resource block from an API source object and a terraform source type and ConfigMeta.
-func generateSource(source client.Source, terraformType string, cm *configs.ConfigMeta) (*hclwrite.Block, error) {
+func generateSource(source client.Source, terraformType string, cm *configs.ConfigMeta) (block *hclwrite.Block, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while generating source block: %v", r)
+		}
+	}()
+
 	resourceType := sourceType(terraformType)
 	resourceName := sourceName(source)
-	block := hclwrite.NewBlock("resource", []string{resourceType, resourceName})
+	block = hclwrite.NewBlock("resource", []string{resourceType, resourceName})
 
 	body := block.Body()
 	body.SetAttributeValue("name", cty.StringVal(source.Name))
@@ -162,10 +168,16 @@ func sourceName(source client.Source) string {
 }
 
 // generateDestination generates a destination resource block from an API destination object and a terraform destination type and ConfigMeta.
-func generateDestination(destination client.Destination, terraformType string, cm *configs.ConfigMeta) (*hclwrite.Block, error) {
+func generateDestination(destination client.Destination, terraformType string, cm *configs.ConfigMeta) (block *hclwrite.Block, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while generating destination block: %v", r)
+		}
+	}()
+
 	resourceType := destinationType(terraformType)
 	resourceName := destinationName(destination)
-	block := hclwrite.NewBlock("resource", []string{resourceType, resourceName})
+	block = hclwrite.NewBlock("resource", []string{resourceType, resourceName})
 
 	body := block.Body()
 	body.SetAttributeValue("name", cty.StringVal(destination.Name))

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -283,6 +283,11 @@ func ctyValue(x interface{}) cty.Value {
 		for _, i := range v {
 			values = append(values, ctyValue(i))
 		}
+		if len(values) == 0 {
+			// ListVal cannot be used with an empty list, so we return an ListValEmpty.
+			// The type of the list is not important because the generated code will have an empty list.
+			return cty.ListValEmpty(cty.String)
+		}
 		return cty.ListVal(values)
 
 	case map[string]interface{}:

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -127,7 +127,8 @@ func TestGeneratorTerraform(t *testing.T) {
 				  { "eventName": "two" },
 				  { "eventName": "three" }
 				],
-				"eventFilteringOption": "blacklistedEvents"
+				"eventFilteringOption": "blacklistedEvents",
+				"blacklistPiiProperties": [],	
 			}`),
 		},
 		{
@@ -177,9 +178,10 @@ resource "rudderstack_destination_redshift" "dst_id-redshift" {
 resource "rudderstack_destination_facebook_pixel" "dst_id-facebook-pixel" {
   name = "name-facebook-pixel"
   config {
-    access_token        = "facebook access token"
-    advanced_mapping    = true
-    category_to_content = [{ from = "from", to = "to" }]
+    access_token             = "facebook access token"
+    advanced_mapping         = true
+    blacklist_pii_properties = []
+    category_to_content      = [{ from = "from", to = "to" }]
     consent_management {
       web = [{ consents = ["one_web", "two_web", "three_web"], provider = "oneTrust", resolution_strategy = "" }, { consents = ["one_web", "two_web", "three_web"], provider = "ketch", resolution_strategy = "" }, { consents = ["one_web", "two_web", "three_web"], provider = "custom", resolution_strategy = "and" }]
     }


### PR DESCRIPTION
## Description of the change

This fixes a problem in the tool that generates terraform scripts during import, where fields in configuration might be empty arrays.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
