### PR TITLE
feat: support for new config fields in bigquery

### DIFF
--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -146,6 +146,9 @@ Optional:
 - `location` (String) Enter the GCP region of your project dataset.
 - `namespace` (String) Enter the schema name where RudderStack will create all the tables. If not specified, RudderStack will set this to the source name by default.
 - `prefix` (String) If specified, RudderStack creates a folder in the bucket with this prefix and loads all the data in it.
+- `skip_tracks_table` (Boolean) If enabled, RudderStack will skip sending the event data to the tracks table.
+- `skip_users_table` (Boolean) If enabled, RudderStack will skip sending the event data to the users table.
+- `skip_views` (Boolean) If enabled, RudderStack will skip creating views.
 
 <a id="nestedblock--config--sync"></a>
 ### Nested Schema for `config.sync`

--- a/rudderstack/integrations/destinations/destination_bigquery.go
+++ b/rudderstack/integrations/destinations/destination_bigquery.go
@@ -17,6 +17,9 @@ func init() {
 		c.Simple("prefix", "prefix", c.SkipZeroValue),
 		c.Simple("namespace", "namespace", c.SkipZeroValue),
 		c.Simple("credentials", "credentials"),
+		c.Simple("skipTracksTable", "skip_tracks_table"),
+		c.Simple("skipViews", "skip_views"),
+		c.Simple("skipUsersTable", "skip_users_table"),
 		c.Simple("syncFrequency", "sync.0.frequency"),
 		c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
 		c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
@@ -99,6 +102,24 @@ func init() {
 					},
 				},
 			},
+		},
+		"skip_tracks_table": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "If enabled, RudderStack will skip sending the event data to the tracks table.",
+		},
+		"skip_views": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "If enabled, RudderStack will skip creating views.",
+		},
+		"skip_users_table": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "If enabled, RudderStack will skip sending the event data to the users table.",
 		},
 	}
 

--- a/rudderstack/integrations/destinations/destination_bigquery_test.go
+++ b/rudderstack/integrations/destinations/destination_bigquery_test.go
@@ -23,6 +23,9 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 				"project": "project",
 				"bucketName": "bucket",
 				"credentials": "...",
+				"skipTracksTable": false,
+				"skipViews": false,
+				"skipUsersTable": true,
 				"syncFrequency": "30"
 			}`,
 			TerraformUpdate: `
@@ -33,6 +36,8 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 				location  = "us-east1"
 				prefix    = "prefix"
 				namespace = "namespace"
+				skip_tracks_table = true
+				skip_users_table = false
 			
 				sync {
 					frequency				  = "30"
@@ -114,6 +119,9 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 				"project": "project",
 				"bucketName": "bucket",
 				"credentials": "...",
+				"skipTracksTable": true,
+				"skipViews": false,
+				"skipUsersTable": false,
 				"location": "us-east1",
 				"prefix": "prefix",
 				"namespace": "namespace",


### PR DESCRIPTION
## Description of the change

This PR adds support for three new fields in bigquery destination
1. skipUsersTable
2. skipTracksTable
3. skipViews

## Notion Link

> Notion Link

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
