### PR TITLE
feat: support for partition config fields in bigquery destination

### DIFF
--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -103,6 +103,9 @@ resource "rudderstack_destination_bigquery" "example" {
       # exclude_window_start_time = "11:00"
       # exclude_window_end_time   = "12:00"
     }
+
+    # partition_column = "_PARTITIONTIME"
+    # partition_type   = "day"
   }
 }
 ```
@@ -148,6 +151,8 @@ Optional:
 - `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `location` (String) Enter the GCP region of your project dataset.
 - `namespace` (String) Enter the schema name where RudderStack will create all the tables. If not specified, RudderStack will set this to the source name by default.
+- `partition_column` (String) Column to use for partitioning
+- `partition_type` (String) Partition type
 - `prefix` (String) If specified, RudderStack creates a folder in the bucket with this prefix and loads all the data in it.
 - `skip_tracks_table` (Boolean) If enabled, RudderStack will skip sending the event data to the tracks table.
 - `skip_users_table` (Boolean) If enabled, RudderStack will skip sending the event data to the users table.

--- a/examples/destination_bigquery.tf
+++ b/examples/destination_bigquery.tf
@@ -88,5 +88,8 @@ resource "rudderstack_destination_bigquery" "example" {
       # exclude_window_start_time = "11:00"
       # exclude_window_end_time   = "12:00"
     }
+
+    # partition_column = "_PARTITIONTIME"
+    # partition_type   = "day"
   }
 }

--- a/rudderstack/integrations/destinations/destination_bigquery.go
+++ b/rudderstack/integrations/destinations/destination_bigquery.go
@@ -20,6 +20,8 @@ func init() {
 		c.Simple("skipTracksTable", "skip_tracks_table"),
 		c.Simple("skipViews", "skip_views"),
 		c.Simple("skipUsersTable", "skip_users_table"),
+		c.Simple("partitionColumn", "partition_column"),
+		c.Simple("partitionType", "partition_type"),
 		c.Simple("syncFrequency", "sync.0.frequency"),
 		c.Simple("syncStartAt", "sync.0.start_at", c.SkipZeroValue),
 		c.Simple("excludeWindow.excludeWindowStartTime", "sync.0.exclude_window_start_time", c.SkipZeroValue),
@@ -120,6 +122,20 @@ func init() {
 			Optional:    true,
 			Default:     true,
 			Description: "If enabled, RudderStack will skip sending the event data to the users table.",
+		},
+		"partition_column": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          "_PARTITIONTIME",
+			Description:      "Column to use for partitioning",
+			ValidateDiagFunc: c.StringMatchesRegexp("^(\\_PARTITIONTIME|loaded_at|received_at|timestamp|sent_at|original_timestamp)$"),
+		},
+		"partition_type": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          "day",
+			Description:      "Partition type",
+			ValidateDiagFunc: c.StringMatchesRegexp("^(hour|day)$"),
 		},
 	}
 

--- a/rudderstack/integrations/destinations/destination_bigquery_test.go
+++ b/rudderstack/integrations/destinations/destination_bigquery_test.go
@@ -14,6 +14,8 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 				project     = "project"
 				bucket_name = "bucket"
 				credentials = "..."
+				partition_column = "loaded_at"
+				partition_type = "hour"
 						
 				sync {
 					frequency = "30"
@@ -26,6 +28,8 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 				"skipTracksTable": false,
 				"skipViews": false,
 				"skipUsersTable": true,
+				"partitionColumn": "loaded_at",
+				"partitionType": "hour",
 				"syncFrequency": "30"
 			}`,
 			TerraformUpdate: `
@@ -122,6 +126,8 @@ func TestDestinationResourceBigQuery(t *testing.T) {
 				"skipTracksTable": true,
 				"skipViews": false,
 				"skipUsersTable": false,
+				"partitionColumn": "_PARTITIONTIME",
+				"partitionType": "day",
 				"location": "us-east1",
 				"prefix": "prefix",
 				"namespace": "namespace",


### PR DESCRIPTION
## Description of the change

This PR adds two new fields in BQ destination - `partition_type` and `partition_column`

## Notion Link

> Notion Link

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
