### PR TITLE
fix: s3 datalake destination created with roleBasedAuth false even when iamRoleARN is configured

### DIFF
--- a/rudderstack/configs/configproperty.go
+++ b/rudderstack/configs/configproperty.go
@@ -334,8 +334,8 @@ func discriminatorValue(apiKey string, values DiscriminatorValues) FromStateFunc
 				continue
 			}
 
-			// this is necessary to ignore empty state blocks
-			if r.IsArray() && len(r.Value().([]interface{})) == 0 {
+			// this is necessary to ignore empty state
+			if SkipZeroValue(r.Value()) {
 				continue
 			}
 

--- a/rudderstack/configs/configproperty.go
+++ b/rudderstack/configs/configproperty.go
@@ -334,9 +334,16 @@ func discriminatorValue(apiKey string, values DiscriminatorValues) FromStateFunc
 				continue
 			}
 
-			// this is necessary to ignore empty state
-			if SkipZeroValue(r.Value()) {
-				continue
+			// this is necessary to ignore empty state blocks
+			switch r.Type {
+			case gjson.JSON:
+				if r.IsArray() && len(r.Value().([]interface{})) == 0 {
+					continue
+				}
+			case gjson.String:
+				if r.Value() == "" {
+					continue
+				}
 			}
 
 			return sjson.Set(config, apiKey, v)

--- a/rudderstack/integrations/destinations/destination_s3_datalake.go
+++ b/rudderstack/integrations/destinations/destination_s3_datalake.go
@@ -18,9 +18,9 @@ func init() {
 		c.Simple("accessKey", "access_key", c.SkipZeroValue),
 		c.Simple("iamRoleARN", "role_based_authentication.0.i_am_role_arn", c.SkipZeroValue),
 		c.Discriminator("roleBasedAuth", c.DiscriminatorValues{
-			"role_based_authentication": true,
 			"access_key":                false,
 			"access_key_id":             false,
+			"role_based_authentication": true,
 		}),
 		c.Simple("enableSSE", "enable_sse", c.SkipZeroValue),
 		c.Simple("useGlue", "use_glue"),


### PR DESCRIPTION
## Description of the change

**BUG** - https://linear.app/rudderstack/issue/WAR-949/s3-datalake-terraform-race-condition

**FIX**
When computing the value of `roleBasedAuth` using `c.Discriminator`, ignore empty strings. This will ensure that it will ignore empty `access_key`/`access_key_id` fields 

## Notion Link

> Notion Link

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
