### PR TITLE
chore: add gh permissions and update gh actions to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
+
+permissions:
+  contents: write  # Required to create releases and upload assets
+  id-token: write  # Required for OIDC token generation if needed by GoReleaser
+
 on:
   push:
     tags:
@@ -20,13 +25,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -40,7 +45,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.0.0
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Description of the change

This pull request updates the GitHub Actions workflow for releases, focusing on improving security and keeping dependencies up to date. The most important changes are grouped below:

**Security & Permissions**

* Added explicit `permissions` for `contents: write` and `id-token: write` to the workflow, which are required for creating releases and uploading assets, and for OIDC token generation if needed by GoReleaser.

**Dependency Updates**

* Updated `actions/checkout` from version 3 to version 5 to use the latest stable release for source code checkout.
* Updated `actions/setup-go` from version 3 to version 5 to ensure the workflow uses the latest Go setup action.
* Upgraded `goreleaser/goreleaser-action` from version 3.0.0 to version 6 for improved compatibility and features.

Resolves INT-4104

## Notion Link

> Notion Link

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
