### PR TITLE
chore(test): add E2E acceptance tests for customerio_audience destination and 29 event stream sources

### DIFF
--- a/rudderstack/integrations/destinations/destination_customerio_audience_test.go
+++ b/rudderstack/integrations/destinations/destination_customerio_audience_test.go
@@ -3,26 +3,26 @@ package destinations_test
 import (
 	"testing"
 
+	acc "github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil/acc"
 	cmt "github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil/cm"
 	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
 
-func TestDestinationResourceCustomerioAudience(t *testing.T) {
-	cmt.AssertDestination(t, "customerio_audience", []c.TestConfig{
-		{
-			TerraformCreate: `
+var customerioAudienceTestConfigs = []c.TestConfig{
+	{
+		TerraformCreate: `
 				site_id     = "site-id-1"
 				api_key     = "api-key-1"
 				app_api_key = "app-api-key-1"
 				region      = "US"
 			`,
-			APICreate: `{
+		APICreate: `{
 				"siteId":    "site-id-1",
 				"apiKey":    "api-key-1",
 				"appApiKey": "app-api-key-1",
 				"region":    "US"
 			}`,
-			TerraformUpdate: `
+		TerraformUpdate: `
 				site_id     = "site-id-1"
 				api_key     = "api-key-1"
 				app_api_key = "app-api-key-1"
@@ -38,7 +38,7 @@ func TestDestinationResourceCustomerioAudience(t *testing.T) {
 					}]
 				}
 			`,
-			APIUpdate: `{
+		APIUpdate: `{
 				"siteId":    "site-id-1",
 				"apiKey":    "api-key-1",
 				"appApiKey": "app-api-key-1",
@@ -60,6 +60,13 @@ func TestDestinationResourceCustomerioAudience(t *testing.T) {
 					]
 				}
 			}`,
-		},
-	})
+	},
+}
+
+func TestDestinationResourceCustomerioAudience(t *testing.T) {
+	cmt.AssertDestination(t, "customerio_audience", customerioAudienceTestConfigs)
+}
+
+func TestAccDestinationCustomerioAudience(t *testing.T) {
+	acc.AccAssertDestination(t, "customerio_audience", customerioAudienceTestConfigs)
 }

--- a/rudderstack/integrations/sources/sources_test.go
+++ b/rudderstack/integrations/sources/sources_test.go
@@ -295,3 +295,119 @@ func TestAccSourceAdjust(t *testing.T) {
 func TestAccSourceRust(t *testing.T) {
 	acc.AccAssertSource(t, "rust", emptyTestConfigs)
 }
+
+func TestAccSourceAMP(t *testing.T) {
+	acc.AccAssertSource(t, "amp", emptyTestConfigs)
+}
+
+func TestAccSourceAndroidKotlin(t *testing.T) {
+	acc.AccAssertSource(t, "android_kotlin", emptyTestConfigs)
+}
+
+func TestAccSourceIOSSwift(t *testing.T) {
+	acc.AccAssertSource(t, "ios_swift", emptyTestConfigs)
+}
+
+func TestAccSourceUnity(t *testing.T) {
+	acc.AccAssertSource(t, "unity", emptyTestConfigs)
+}
+
+func TestAccSourceAppcenter(t *testing.T) {
+	acc.AccAssertSource(t, "appcenter", emptyTestConfigs)
+}
+
+func TestAccSourceAppsflyer(t *testing.T) {
+	acc.AccAssertSource(t, "appsflyer", emptyTestConfigs)
+}
+
+func TestAccSourceAuth0(t *testing.T) {
+	acc.AccAssertSource(t, "auth0", emptyTestConfigs)
+}
+
+func TestAccSourceCanny(t *testing.T) {
+	acc.AccAssertSource(t, "canny", emptyTestConfigs)
+}
+
+func TestAccSourceCloseCRM(t *testing.T) {
+	acc.AccAssertSource(t, "close_crm", emptyTestConfigs)
+}
+
+func TestAccSourceCordial(t *testing.T) {
+	acc.AccAssertSource(t, "cordial", emptyTestConfigs)
+}
+
+func TestAccSourceExtole(t *testing.T) {
+	acc.AccAssertSource(t, "extole", emptyTestConfigs)
+}
+
+func TestAccSourceFormsort(t *testing.T) {
+	acc.AccAssertSource(t, "formsort", emptyTestConfigs)
+}
+
+func TestAccSourceGainsightPX(t *testing.T) {
+	acc.AccAssertSource(t, "gainsightpx", emptyTestConfigs)
+}
+
+func TestAccSourceIterable(t *testing.T) {
+	acc.AccAssertSource(t, "iterable", emptyTestConfigs)
+}
+
+func TestAccSourceLooker(t *testing.T) {
+	acc.AccAssertSource(t, "looker", emptyTestConfigs)
+}
+
+func TestAccSourceMailjet(t *testing.T) {
+	acc.AccAssertSource(t, "mailjet", emptyTestConfigs)
+}
+
+func TestAccSourceMailmodo(t *testing.T) {
+	acc.AccAssertSource(t, "mailmodo", emptyTestConfigs)
+}
+
+func TestAccSourceMoEngage(t *testing.T) {
+	acc.AccAssertSource(t, "moengage", emptyTestConfigs)
+}
+
+func TestAccSourceMonday(t *testing.T) {
+	acc.AccAssertSource(t, "monday", emptyTestConfigs)
+}
+
+func TestAccSourceOlark(t *testing.T) {
+	acc.AccAssertSource(t, "olark", emptyTestConfigs)
+}
+
+func TestAccSourceOrtto(t *testing.T) {
+	acc.AccAssertSource(t, "ortto", emptyTestConfigs)
+}
+
+func TestAccSourcePagerDuty(t *testing.T) {
+	acc.AccAssertSource(t, "pagerduty", emptyTestConfigs)
+}
+
+func TestAccSourcePipedream(t *testing.T) {
+	acc.AccAssertSource(t, "pipedream", emptyTestConfigs)
+}
+
+func TestAccSourceRefiner(t *testing.T) {
+	acc.AccAssertSource(t, "refiner", emptyTestConfigs)
+}
+
+func TestAccSourceRevenuecat(t *testing.T) {
+	acc.AccAssertSource(t, "revenuecat", emptyTestConfigs)
+}
+
+func TestAccSourceSatisMeter(t *testing.T) {
+	acc.AccAssertSource(t, "satismeter", emptyTestConfigs)
+}
+
+func TestAccSourceSegment(t *testing.T) {
+	acc.AccAssertSource(t, "segment", emptyTestConfigs)
+}
+
+func TestAccSourceSIGNL4(t *testing.T) {
+	acc.AccAssertSource(t, "signl4", emptyTestConfigs)
+}
+
+func TestAccSourceSlack(t *testing.T) {
+	acc.AccAssertSource(t, "slack", emptyTestConfigs)
+}


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

## Description of the change

- Extract customerio_audience configs to package-level var and add TestAccDestinationCustomerioAudience
- Add TestAcc* functions for 29 sources missing acceptance tests: amp, android_kotlin, ios_swift, unity, appcenter, appsflyer, auth0, canny, close_crm, cordial, extole, formsort, gainsightpx, iterable, looker, mailjet, mailmodo, moengage, monday, olark, ortto, pagerduty, pipedream, refiner, revenuecat, satismeter, segment, signl4, slack

## What is the related Linear task?

Resolves XXX-XXX

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
