### PR TITLE
ci: pre-install terraform to fix text file busy race in plan-only tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -115,6 +115,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269ef065 # v3.1.2
+        with:
+          terraform_wrapper: false
+
       - name: Run plan-only validation
         env:
           TF_ACC: "1"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -116,7 +116,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269ef065 # v3.1.2
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_wrapper: false
 


### PR DESCRIPTION

🔒 Scanned for secrets using gitleaks 8.30.1

## Description of the change

Without a pre-installed terraform binary, terraform-plugin-sdk downloads it at test startup via hc-install. Running multiple packages in parallel causes concurrent writes to the same binary while another process tries to exec it, producing ETXTBSY on Linux.

Adding hashicorp/setup-terraform before the test step ensures fs.AnyVersion finds terraform on PATH and skips the download, eliminating the race. terraform_wrapper: false is required so terraform-exec version detection works.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## What is the related Linear task?

Resolves XXX-XXX

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
