### PR TITLE
chore: re-install Terraform to bypass expired hc-install PGP key

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -151,6 +151,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
+
       - name: Run E2E CRUD test
         env:
           TF_ACC: "1"
@@ -186,6 +191,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
+
       - name: Run E2E source CRUD tests
         env:
           TF_ACC: "1"
@@ -218,6 +228,11 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
 
       - name: Run E2E connection CRUD tests
         env:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -23,5 +23,9 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
       - name: Run tests
         run: make test-ci


### PR DESCRIPTION
## Description of the change

Pre-installs Terraform in all CI jobs that exercise the Terraform plugin SDK test harness, so the harness does not attempt to download Terraform via `hc-install` at runtime.

`hc-install` currently fails with `unable to verify checksums signature: openpgp: key expired` because HashiCorp's release-signing PGP key has expired. Using `hashicorp/setup-terraform` with `terraform_wrapper: false` provides a pre-installed binary on `PATH`, which the SDK harness picks up and skips the download step entirely.

Jobs updated:
- `unit-tests` (`test-ci.yml`) — was failing on `main` and all PRs
- `e2e-crud`, `e2e-source-crud`, `e2e-conn-crud` (`e2e-tests.yml`) — would have hit the same path once their tests were triggered

The `plan-only` job already had this step (added in #225) and served as the template.

## What is the related Linear task?

N/A — CI hotfix

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation