### PR TITLE
feat(retl): add rudderstack_retl_connection resource (PRO-5605)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
-	github.com/rudderlabs/rudder-iac v0.14.1-0.20260428101717-0a1ff9a32c99
+	github.com/rudderlabs/rudder-iac v0.14.1-0.20260429105858-9db95c241060
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rudderlabs/rudder-iac v0.14.1-0.20260428101717-0a1ff9a32c99 h1:N7e3K+0DJvBWsAkR9RI1mHPnwQ1gI5TQD19mckIPUX4=
-github.com/rudderlabs/rudder-iac v0.14.1-0.20260428101717-0a1ff9a32c99/go.mod h1:6xwalNXw57LvuOJ+u62feHBLeR56TAPx2pOF7JYB0zE=
+github.com/rudderlabs/rudder-iac v0.14.1-0.20260429105858-9db95c241060 h1:SHhCMpT9Oa5nMeU97JMRjchcnTMQz0J7MMF+WuuHSqk=
+github.com/rudderlabs/rudder-iac v0.14.1-0.20260429105858-9db95c241060/go.mod h1:6xwalNXw57LvuOJ+u62feHBLeR56TAPx2pOF7JYB0zE=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=

--- a/rudderstack/provider.go
+++ b/rudderstack/provider.go
@@ -57,6 +57,7 @@ func resourcesMap() map[string]*schema.Resource {
 		"rudderstack_connection":        resourceConnection(),
 		"rudderstack_retl_source_model": retl.ResourceModel(),
 		"rudderstack_retl_source_table": retl.ResourceTable(),
+		"rudderstack_retl_connection":   retl.ResourceConnection(),
 	}
 
 	// append sources and destinations from integration registries

--- a/rudderstack/retl/common.go
+++ b/rudderstack/retl/common.go
@@ -30,7 +30,6 @@ type Service interface {
 	GetConnection(ctx context.Context, id string) (*retl.RETLConnection, error)
 	UpdateConnection(ctx context.Context, id string, req *retl.UpdateRETLConnectionRequest) (*retl.RETLConnection, error)
 	DeleteConnection(ctx context.Context, id string) error
-	SetConnectionExternalId(ctx context.Context, req *retl.SetRETLConnectionExternalIDRequest) error
 }
 
 // ClientProvider exposes the RETL service from the provider's configured

--- a/rudderstack/retl/common.go
+++ b/rudderstack/retl/common.go
@@ -18,13 +18,19 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client/retl"
 )
 
-// Service is the subset of the upstream retl.RETLStore the RETL source
-// resources need. Kept narrow so tests can mock it cheaply.
+// Service is the subset of the upstream retl.RETLStore the RETL source and
+// connection resources need. Kept narrow so tests can mock it cheaply.
 type Service interface {
 	CreateRetlSource(ctx context.Context, source *retl.RETLSourceCreateRequest) (*retl.RETLSource, error)
 	GetRetlSource(ctx context.Context, id string) (*retl.RETLSource, error)
 	UpdateRetlSource(ctx context.Context, id string, source *retl.RETLSourceUpdateRequest) (*retl.RETLSource, error)
 	DeleteRetlSource(ctx context.Context, id string) error
+
+	CreateConnection(ctx context.Context, req *retl.CreateRETLConnectionRequest) (*retl.RETLConnection, error)
+	GetConnection(ctx context.Context, id string) (*retl.RETLConnection, error)
+	UpdateConnection(ctx context.Context, id string, req *retl.UpdateRETLConnectionRequest) (*retl.RETLConnection, error)
+	DeleteConnection(ctx context.Context, id string) error
+	SetConnectionExternalId(ctx context.Context, req *retl.SetRETLConnectionExternalIDRequest) error
 }
 
 // ClientProvider exposes the RETL service from the provider's configured

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -461,8 +461,13 @@ func buildUpdateRequest(d *schema.ResourceData) (*retl.UpdateRETLConnectionReque
 		Enabled:  &enabled,
 		Schedule: schedule,
 	}
-	if ss, ok := syncSettingsFromState(d); ok {
-		req.SyncSettings = ss
+	// Only forward sync_settings when the user actually changed the block.
+	// Otherwise the Optional+Computed field can carry server-computed values
+	// in state and we'd echo them back as if the user had set them.
+	if d.HasChange("sync_settings") {
+		if ss, ok := syncSettingsFromState(d); ok {
+			req.SyncSettings = ss
+		}
 	}
 	if d.HasChange("mappings") {
 		mappings := mappingsFromState(d, "mappings")
@@ -580,6 +585,11 @@ func syncSettingsFromState(d *schema.ResourceData) (*retl.SyncSettings, bool) {
 			cfg.EnableFailedKeysRetry = &v
 		}
 		ss.FailedKeysConfig = cfg
+	}
+	// Empty sync_settings {} block (or one with empty sub-blocks) carries
+	// nothing useful — treat it as "not set" so callers can omit the field.
+	if ss.SyncLogsConfig == nil && ss.FailedKeysConfig == nil {
+		return nil, false
 	}
 	return ss, true
 }

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -63,11 +63,6 @@ func connectionSchema() map[string]*schema.Schema {
 			Default:     true,
 			Description: "Whether the connection is enabled.",
 		},
-		"external_id": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Optional external identifier for CLI/IaC state tracking.",
-		},
 		"schedule": {
 			Type:     schema.TypeList,
 			Required: true,
@@ -85,6 +80,11 @@ func connectionSchema() map[string]*schema.Schema {
 						Optional:     true,
 						ValidateFunc: validation.IntAtLeast(5),
 						Description:  "Sync interval in minutes. Required when `type` is `basic`.",
+					},
+					"cron_expression": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Cron expression. Required when `type` is `cron`.",
 					},
 				},
 			},
@@ -351,27 +351,12 @@ func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 		return diags
 	}
 
-	// Apply the main payload first so a failure there does not leave a partial
-	// external_id change applied server-side. external_id is touched only after
-	// the main update succeeds.
-	if hasConnectionUpdatePayload(d) {
-		req, err := buildUpdateRequest(d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
-			return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
-		}
+	req, err := buildUpdateRequest(d)
+	if err != nil {
+		return diag.FromErr(err)
 	}
-
-	if d.HasChange("external_id") {
-		extID := d.Get("external_id").(string)
-		if err := svc.SetConnectionExternalId(ctx, &retl.SetRETLConnectionExternalIDRequest{
-			ID:         d.Id(),
-			ExternalID: extID,
-		}); err != nil {
-			return diag.FromErr(fmt.Errorf("could not set RETL connection external id: %w", err))
-		}
+	if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
+		return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
 	}
 
 	return readConnection(ctx, d, m)
@@ -395,18 +380,6 @@ func deleteConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 	return nil
 }
 
-// hasConnectionUpdatePayload returns true when at least one field in the main
-// PUT payload changed (i.e. an actual update endpoint call is needed). When
-// only external_id changed, the dedicated set-external-id endpoint suffices.
-func hasConnectionUpdatePayload(d *schema.ResourceData) bool {
-	for _, k := range []string{"enabled", "schedule", "sync_settings", "mappings", "constants", "identifiers"} {
-		if d.HasChange(k) {
-			return true
-		}
-	}
-	return false
-}
-
 func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionRequest, error) {
 	schedule, err := scheduleFromState(d)
 	if err != nil {
@@ -423,9 +396,6 @@ func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionReque
 		Identifiers:   mappingsFromState(d, "identifiers"),
 	}
 
-	if v := d.Get("external_id").(string); v != "" {
-		req.ExternalID = v
-	}
 	if ss, ok := syncSettingsFromState(d); ok {
 		req.SyncSettings = ss
 	}
@@ -511,9 +481,6 @@ func storeConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) erro
 	// Always set, even when empty, so state can be cleared if the server
 	// returns an empty value (otherwise Terraform would see perpetual diffs
 	// against the stale local value).
-	if err := d.Set("external_id", c.ExternalID); err != nil {
-		return err
-	}
 	if err := d.Set("destination_config", string(c.DestinationConfig)); err != nil {
 		return err
 	}
@@ -542,8 +509,14 @@ func scheduleFromState(d *schema.ResourceData) (retl.Schedule, error) {
 	if v, ok := m["every_minutes"].(int); ok && v > 0 {
 		s.EveryMinutes = &v
 	}
+	if v, _ := m["cron_expression"].(string); v != "" {
+		s.CronExpression = &v
+	}
 	if s.Type == retl.ScheduleTypeBasic && s.EveryMinutes == nil {
 		return retl.Schedule{}, fmt.Errorf("schedule.every_minutes is required when schedule.type is %q", s.Type)
+	}
+	if s.Type == retl.ScheduleTypeCron && s.CronExpression == nil {
+		return retl.Schedule{}, fmt.Errorf("schedule.cron_expression is required when schedule.type is %q", s.Type)
 	}
 	return s, nil
 }
@@ -552,6 +525,9 @@ func scheduleToState(s retl.Schedule) []map[string]interface{} {
 	m := map[string]interface{}{"type": string(s.Type)}
 	if s.EveryMinutes != nil {
 		m["every_minutes"] = *s.EveryMinutes
+	}
+	if s.CronExpression != nil {
+		m["cron_expression"] = *s.CronExpression
 	}
 	return []map[string]interface{}{m}
 }

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -204,7 +204,8 @@ func connectionSchema() map[string]*schema.Schema {
 					},
 				},
 			},
-			Description: "CDP event configuration. Required for JSON Mapper, must be absent for other flows.",
+			Description: "CDP event configuration. Optional in the Terraform schema; flow-specific " +
+				"requirements (required for JSON Mapper, absent for other flows) are enforced by the API.",
 		},
 		"constants": {
 			Type:     schema.TypeList,
@@ -255,10 +256,20 @@ func connectionSchema() map[string]*schema.Schema {
 }
 
 // customizeConnectionDiff applies flow-dependent ForceNew on `identifiers` and
-// `constants`. Flow is inferred from the same signals the server uses:
-// `object` set => Object Mapping, `destination_config` set => Destination-
-// specific, otherwise => JSON Mapper.
+// `constants`, and rejects locally-detectable invalid combinations (cursor_column
+// only with sync_behaviour=upsert) so users see the error at plan time instead
+// of on apply.
+//
+// Flow is inferred from the same signals the server uses: `object` set =>
+// Object Mapping, `destination_config` set => Destination-specific, otherwise
+// => JSON Mapper.
 func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if cursor := d.Get("cursor_column").(string); cursor != "" {
+		if sb := d.Get("sync_behaviour").(string); sb != "" && sb != "upsert" {
+			return fmt.Errorf("cursor_column is only valid when sync_behaviour is %q, got %q", "upsert", sb)
+		}
+	}
+
 	if d.Id() == "" {
 		// Brand-new resource — ForceNew is irrelevant on create.
 		return nil
@@ -340,7 +351,16 @@ func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 		return diags
 	}
 
-	// external_id is set via a dedicated endpoint, not the main update payload.
+	// Apply the main payload first so a failure there does not leave a partial
+	// external_id change applied server-side. external_id is touched only after
+	// the main update succeeds.
+	if hasConnectionUpdatePayload(d) {
+		req := buildUpdateRequest(d)
+		if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
+			return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
+		}
+	}
+
 	if d.HasChange("external_id") {
 		extID := d.Get("external_id").(string)
 		if err := svc.SetConnectionExternalId(ctx, &retl.SetRETLConnectionExternalIDRequest{
@@ -348,13 +368,6 @@ func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 			ExternalID: extID,
 		}); err != nil {
 			return diag.FromErr(fmt.Errorf("could not set RETL connection external id: %w", err))
-		}
-	}
-
-	if hasConnectionUpdatePayload(d) {
-		req := buildUpdateRequest(d)
-		if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
-			return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
 		}
 	}
 
@@ -484,15 +497,14 @@ func storeConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) erro
 		}
 	}
 
-	if c.ExternalID != "" {
-		if err := d.Set("external_id", c.ExternalID); err != nil {
-			return err
-		}
+	// Always set, even when empty, so state can be cleared if the server
+	// returns an empty value (otherwise Terraform would see perpetual diffs
+	// against the stale local value).
+	if err := d.Set("external_id", c.ExternalID); err != nil {
+		return err
 	}
-	if len(c.DestinationConfig) > 0 {
-		if err := d.Set("destination_config", string(c.DestinationConfig)); err != nil {
-			return err
-		}
+	if err := d.Set("destination_config", string(c.DestinationConfig)); err != nil {
+		return err
 	}
 	if c.CreatedAt != nil {
 		if err := d.Set("created_at", c.CreatedAt.Format(time.RFC3339)); err != nil {
@@ -518,6 +530,9 @@ func scheduleFromState(d *schema.ResourceData) (retl.Schedule, error) {
 	s := retl.Schedule{Type: retl.ScheduleType(m["type"].(string))}
 	if v, ok := m["every_minutes"].(int); ok && v > 0 {
 		s.EveryMinutes = &v
+	}
+	if s.Type == retl.ScheduleTypeBasic && s.EveryMinutes == nil {
+		return retl.Schedule{}, fmt.Errorf("schedule.every_minutes is required when schedule.type is %q", s.Type)
 	}
 	return s, nil
 }

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -355,7 +355,10 @@ func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 	// external_id change applied server-side. external_id is touched only after
 	// the main update succeeds.
 	if hasConnectionUpdatePayload(d) {
-		req := buildUpdateRequest(d)
+		req, err := buildUpdateRequest(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
 			return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
 		}
@@ -447,9 +450,12 @@ func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionReque
 	return req, nil
 }
 
-func buildUpdateRequest(d *schema.ResourceData) *retl.UpdateRETLConnectionRequest {
+func buildUpdateRequest(d *schema.ResourceData) (*retl.UpdateRETLConnectionRequest, error) {
+	schedule, err := scheduleFromState(d)
+	if err != nil {
+		return nil, err
+	}
 	enabled := d.Get("enabled").(bool)
-	schedule, _ := scheduleFromState(d)
 
 	req := &retl.UpdateRETLConnectionRequest{
 		Enabled:  &enabled,
@@ -469,7 +475,7 @@ func buildUpdateRequest(d *schema.ResourceData) *retl.UpdateRETLConnectionReques
 	if d.HasChange("identifiers") {
 		req.Identifiers = mappingsFromState(d, "identifiers")
 	}
-	return req
+	return req, nil
 }
 
 func storeConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) error {

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -238,11 +239,13 @@ func connectionSchema() map[string]*schema.Schema {
 			Description: "Destination entity for Object Mapping flows (e.g. `Contact`, `Lead`).",
 		},
 		"destination_config": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsJSON,
-			Description:  "Destination-specific configuration as a JSON-encoded string.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			ForceNew:         true,
+			ValidateFunc:     validation.StringIsJSON,
+			StateFunc:        normalizeJSON,
+			DiffSuppressFunc: suppressEquivalentJSON,
+			Description:      "Destination-specific configuration as a JSON-encoded string.",
 		},
 		"created_at": {
 			Type:     schema.TypeString,
@@ -644,6 +647,42 @@ func constantsToState(cs []retl.Constant) []map[string]interface{} {
 		out = append(out, map[string]interface{}{"key": c.Key, "value": c.Value})
 	}
 	return out
+}
+
+// normalizeJSON returns a canonical encoding of the input JSON (sorted keys,
+// no extraneous whitespace). Returns the input unchanged if it isn't valid
+// JSON — validation.StringIsJSON catches that path separately.
+func normalizeJSON(v interface{}) string {
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return ""
+	}
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return s
+	}
+	out, err := json.Marshal(parsed)
+	if err != nil {
+		return s
+	}
+	return string(out)
+}
+
+// suppressEquivalentJSON returns true when two JSON strings are semantically
+// equal, so reformatting from the API (key ordering, whitespace, null vs "")
+// does not produce a perpetual diff.
+func suppressEquivalentJSON(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+	if oldVal == newVal {
+		return true
+	}
+	var o, n interface{}
+	if err := json.Unmarshal([]byte(oldVal), &o); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(newVal), &n); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(o, n)
 }
 
 func eventFromState(d *schema.ResourceData) (*retl.Event, bool) {

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -17,7 +17,7 @@ import (
 
 // ResourceConnection returns the schema for `rudderstack_retl_connection`.
 //
-// Flow detection (JSON Mapper / Object mapping / Destination-specific) happens
+// Flow detection (JSON Mapper / Object Mapping / Destination-specific) happens
 // server-side based on the destination definition; this resource only sends
 // the flat schema and lets the API assemble the internal config. ForceNew on
 // `identifiers` and `constants` is conditional on the detected flow and is

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -1,0 +1,670 @@
+package retl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/client/retl"
+)
+
+// ResourceConnection returns the schema for `rudderstack_retl_connection`.
+//
+// Flow detection (JSON Mapper / Object mapping / Destination-specific) happens
+// server-side based on the destination definition; this resource only sends
+// the flat schema and lets the API assemble the internal config. ForceNew on
+// `identifiers` and `constants` is conditional on the detected flow and is
+// applied via CustomizeDiff using the same field-presence signals the API uses.
+func ResourceConnection() *schema.Resource {
+	return &schema.Resource{
+		Description: "A RETL connection between a RETL source and a destination. " +
+			"Flow type (JSON Mapper, Object mapping, Destination-specific) is " +
+			"determined by the destination definition.",
+		Schema:        connectionSchema(),
+		CreateContext: createConnection,
+		ReadContext:   readConnection,
+		UpdateContext: updateConnection,
+		DeleteContext: deleteConnection,
+		CustomizeDiff: customizeConnectionDiff,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+	}
+}
+
+func connectionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"source_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "ID of the RETL source.",
+		},
+		"destination_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "ID of the destination.",
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Whether the connection is enabled.",
+		},
+		"external_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Optional external identifier for CLI/IaC state tracking.",
+		},
+		"schedule": {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"basic", "manual", "cron"}, false),
+						Description:  "Schedule type: `basic`, `manual`, or `cron`.",
+					},
+					"every_minutes": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(5),
+						Description:  "Sync interval in minutes. Required when `type` is `basic`.",
+					},
+				},
+			},
+		},
+		"sync_settings": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"sync_logs_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"enabled": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
+								},
+								"log_retention_in_days": {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  30,
+								},
+								"snapshots_to_retain": {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  5,
+								},
+							},
+						},
+					},
+					"failed_keys_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"enable_failed_keys_retry": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"sync_behaviour": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice([]string{"upsert", "mirror", "full"}, false),
+			Description:  "How records are synced to the destination: `upsert`, `mirror`, or `full`.",
+		},
+		"identifiers": {
+			Type:     schema.TypeList,
+			Required: true,
+			MinItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"to": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Description: "Source-to-destination identifier mappings. ForceNew for JSON Mapper " +
+				"and Object Mapping flows; mutable for destination-specific flows.",
+		},
+		"mappings": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"to": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Description: "Source-to-destination field mappings (mutable for all flows).",
+		},
+		"event": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"identify", "track"}, false),
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"name_column": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+			Description: "CDP event configuration. Required for JSON Mapper, must be absent for other flows.",
+		},
+		"constants": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Description: "User-defined constants. Mutable for JSON Mapper; ForceNew for Object Mapping " +
+				"and destination-specific flows.",
+		},
+		"cursor_column": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Column name for incremental upsert syncs (only valid when sync_behaviour is `upsert`).",
+		},
+		"object": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Destination entity for Object Mapping flows (e.g. `Contact`, `Lead`).",
+		},
+		"destination_config": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsJSON,
+			Description:  "Destination-specific configuration as a JSON-encoded string.",
+		},
+		"created_at": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"updated_at": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+// customizeConnectionDiff applies flow-dependent ForceNew on `identifiers` and
+// `constants`. Flow is inferred from the same signals the server uses:
+// `object` set => Object Mapping, `destination_config` set => Destination-
+// specific, otherwise => JSON Mapper.
+func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if d.Id() == "" {
+		// Brand-new resource — ForceNew is irrelevant on create.
+		return nil
+	}
+
+	objectSet := d.Get("object").(string) != ""
+	destConfigSet := d.Get("destination_config").(string) != ""
+
+	identifiersForceNew, constantsForceNew := flowForceNewRules(objectSet, destConfigSet)
+
+	if identifiersForceNew && d.HasChange("identifiers") {
+		if err := d.ForceNew("identifiers"); err != nil {
+			return err
+		}
+	}
+	if constantsForceNew && d.HasChange("constants") {
+		if err := d.ForceNew("constants"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// flowForceNewRules returns (identifiersForceNew, constantsForceNew) for the
+// detected flow.
+func flowForceNewRules(objectSet, destConfigSet bool) (identifiers, constants bool) {
+	switch {
+	case objectSet:
+		return true, true // Object Mapping
+	case destConfigSet:
+		return false, true // Destination-specific
+	default:
+		return true, false // JSON Mapper
+	}
+}
+
+func createConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	req, err := buildCreateRequest(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	created, err := svc.CreateConnection(ctx, req)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("could not create RETL connection: %w", err))
+	}
+
+	d.SetId(created.ID)
+	return readConnection(ctx, d, m)
+}
+
+func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	conn, err := svc.GetConnection(ctx, d.Id())
+	if err != nil {
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("could not read RETL connection: %w", err))
+	}
+
+	return diag.FromErr(storeConnectionToState(d, conn))
+}
+
+func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	// external_id is set via a dedicated endpoint, not the main update payload.
+	if d.HasChange("external_id") {
+		extID := d.Get("external_id").(string)
+		if err := svc.SetConnectionExternalId(ctx, &retl.SetRETLConnectionExternalIDRequest{
+			ID:         d.Id(),
+			ExternalID: extID,
+		}); err != nil {
+			return diag.FromErr(fmt.Errorf("could not set RETL connection external id: %w", err))
+		}
+	}
+
+	if hasConnectionUpdatePayload(d) {
+		req := buildUpdateRequest(d)
+		if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
+			return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
+		}
+	}
+
+	return readConnection(ctx, d, m)
+}
+
+func deleteConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	if err := svc.DeleteConnection(ctx, d.Id()); err != nil {
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("could not delete RETL connection: %w", err))
+	}
+	d.SetId("")
+	return nil
+}
+
+// hasConnectionUpdatePayload returns true when at least one field in the main
+// PUT payload changed (i.e. an actual update endpoint call is needed). When
+// only external_id changed, the dedicated set-external-id endpoint suffices.
+func hasConnectionUpdatePayload(d *schema.ResourceData) bool {
+	for _, k := range []string{"enabled", "schedule", "sync_settings", "mappings", "constants", "identifiers"} {
+		if d.HasChange(k) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionRequest, error) {
+	schedule, err := scheduleFromState(d)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := d.Get("enabled").(bool)
+	req := &retl.CreateRETLConnectionRequest{
+		SourceID:      d.Get("source_id").(string),
+		DestinationID: d.Get("destination_id").(string),
+		Enabled:       &enabled,
+		Schedule:      schedule,
+		SyncBehaviour: retl.SyncBehaviour(d.Get("sync_behaviour").(string)),
+		Identifiers:   mappingsFromState(d, "identifiers"),
+	}
+
+	if v := d.Get("external_id").(string); v != "" {
+		req.ExternalID = v
+	}
+	if ss, ok := syncSettingsFromState(d); ok {
+		req.SyncSettings = ss
+	}
+	if mappings := mappingsFromState(d, "mappings"); len(mappings) > 0 {
+		req.Mappings = mappings
+	}
+	if event, ok := eventFromState(d); ok {
+		req.Event = event
+	}
+	if constants := constantsFromState(d); len(constants) > 0 {
+		req.Constants = constants
+	}
+	if v := d.Get("cursor_column").(string); v != "" {
+		req.CursorColumn = v
+	}
+	if v := d.Get("object").(string); v != "" {
+		req.Object = v
+	}
+	if v := d.Get("destination_config").(string); v != "" {
+		req.DestinationConfig = json.RawMessage(v)
+	}
+	return req, nil
+}
+
+func buildUpdateRequest(d *schema.ResourceData) *retl.UpdateRETLConnectionRequest {
+	enabled := d.Get("enabled").(bool)
+	schedule, _ := scheduleFromState(d)
+
+	req := &retl.UpdateRETLConnectionRequest{
+		Enabled:  &enabled,
+		Schedule: schedule,
+	}
+	if ss, ok := syncSettingsFromState(d); ok {
+		req.SyncSettings = ss
+	}
+	if d.HasChange("mappings") {
+		mappings := mappingsFromState(d, "mappings")
+		req.Mappings = &mappings
+	}
+	if d.HasChange("constants") {
+		constants := constantsFromState(d)
+		req.Constants = &constants
+	}
+	if d.HasChange("identifiers") {
+		req.Identifiers = mappingsFromState(d, "identifiers")
+	}
+	return req
+}
+
+func storeConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) error {
+	d.SetId(c.ID)
+	setters := []struct {
+		k string
+		v interface{}
+	}{
+		{"source_id", c.SourceID},
+		{"destination_id", c.DestinationID},
+		{"enabled", c.Enabled},
+		{"sync_behaviour", string(c.SyncBehaviour)},
+		{"schedule", scheduleToState(c.Schedule)},
+		{"sync_settings", syncSettingsToState(c.SyncSettings)},
+		{"identifiers", mappingsToState(c.Identifiers)},
+		{"mappings", mappingsToState(c.Mappings)},
+		{"event", eventToState(c.Event)},
+		{"constants", constantsToState(c.Constants)},
+		{"cursor_column", c.CursorColumn},
+		{"object", c.Object},
+	}
+	for _, s := range setters {
+		if err := d.Set(s.k, s.v); err != nil {
+			return fmt.Errorf("set %s: %w", s.k, err)
+		}
+	}
+
+	if c.ExternalID != "" {
+		if err := d.Set("external_id", c.ExternalID); err != nil {
+			return err
+		}
+	}
+	if len(c.DestinationConfig) > 0 {
+		if err := d.Set("destination_config", string(c.DestinationConfig)); err != nil {
+			return err
+		}
+	}
+	if c.CreatedAt != nil {
+		if err := d.Set("created_at", c.CreatedAt.Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+	if c.UpdatedAt != nil {
+		if err := d.Set("updated_at", c.UpdatedAt.Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- per-block helpers ---
+
+func scheduleFromState(d *schema.ResourceData) (retl.Schedule, error) {
+	raw, ok := d.Get("schedule").([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return retl.Schedule{}, fmt.Errorf("schedule block is required")
+	}
+	m := raw[0].(map[string]interface{})
+	s := retl.Schedule{Type: retl.ScheduleType(m["type"].(string))}
+	if v, ok := m["every_minutes"].(int); ok && v > 0 {
+		s.EveryMinutes = &v
+	}
+	return s, nil
+}
+
+func scheduleToState(s retl.Schedule) []map[string]interface{} {
+	m := map[string]interface{}{"type": string(s.Type)}
+	if s.EveryMinutes != nil {
+		m["every_minutes"] = *s.EveryMinutes
+	}
+	return []map[string]interface{}{m}
+}
+
+func syncSettingsFromState(d *schema.ResourceData) (*retl.SyncSettings, bool) {
+	raw, ok := d.Get("sync_settings").([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return nil, false
+	}
+	m := raw[0].(map[string]interface{})
+	ss := &retl.SyncSettings{}
+
+	if logs, ok := m["sync_logs_config"].([]interface{}); ok && len(logs) > 0 && logs[0] != nil {
+		lm := logs[0].(map[string]interface{})
+		cfg := &retl.SyncLogsConfig{}
+		if v, ok := lm["enabled"].(bool); ok {
+			cfg.Enabled = &v
+		}
+		if v, ok := lm["log_retention_in_days"].(int); ok && v > 0 {
+			cfg.LogRetentionInDays = &v
+		}
+		if v, ok := lm["snapshots_to_retain"].(int); ok && v > 0 {
+			cfg.SnapshotsToRetain = &v
+		}
+		ss.SyncLogsConfig = cfg
+	}
+	if fk, ok := m["failed_keys_config"].([]interface{}); ok && len(fk) > 0 && fk[0] != nil {
+		fkm := fk[0].(map[string]interface{})
+		cfg := &retl.FailedKeysConfig{}
+		if v, ok := fkm["enable_failed_keys_retry"].(bool); ok {
+			cfg.EnableFailedKeysRetry = &v
+		}
+		ss.FailedKeysConfig = cfg
+	}
+	return ss, true
+}
+
+func syncSettingsToState(ss *retl.SyncSettings) []map[string]interface{} {
+	if ss == nil {
+		return nil
+	}
+	out := map[string]interface{}{}
+	if ss.SyncLogsConfig != nil {
+		lm := map[string]interface{}{}
+		if ss.SyncLogsConfig.Enabled != nil {
+			lm["enabled"] = *ss.SyncLogsConfig.Enabled
+		}
+		if ss.SyncLogsConfig.LogRetentionInDays != nil {
+			lm["log_retention_in_days"] = *ss.SyncLogsConfig.LogRetentionInDays
+		}
+		if ss.SyncLogsConfig.SnapshotsToRetain != nil {
+			lm["snapshots_to_retain"] = *ss.SyncLogsConfig.SnapshotsToRetain
+		}
+		out["sync_logs_config"] = []map[string]interface{}{lm}
+	}
+	if ss.FailedKeysConfig != nil {
+		fkm := map[string]interface{}{}
+		if ss.FailedKeysConfig.EnableFailedKeysRetry != nil {
+			fkm["enable_failed_keys_retry"] = *ss.FailedKeysConfig.EnableFailedKeysRetry
+		}
+		out["failed_keys_config"] = []map[string]interface{}{fkm}
+	}
+	return []map[string]interface{}{out}
+}
+
+func mappingsFromState(d *schema.ResourceData, key string) []retl.Mapping {
+	raw, _ := d.Get(key).([]interface{})
+	out := make([]retl.Mapping, 0, len(raw))
+	for _, item := range raw {
+		m := item.(map[string]interface{})
+		out = append(out, retl.Mapping{
+			From: m["from"].(string),
+			To:   m["to"].(string),
+		})
+	}
+	return out
+}
+
+func mappingsToState(ms []retl.Mapping) []map[string]interface{} {
+	if len(ms) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, map[string]interface{}{"from": m.From, "to": m.To})
+	}
+	return out
+}
+
+func constantsFromState(d *schema.ResourceData) []retl.Constant {
+	raw, _ := d.Get("constants").([]interface{})
+	out := make([]retl.Constant, 0, len(raw))
+	for _, item := range raw {
+		m := item.(map[string]interface{})
+		out = append(out, retl.Constant{
+			Key:   m["key"].(string),
+			Value: m["value"].(string),
+		})
+	}
+	return out
+}
+
+func constantsToState(cs []retl.Constant) []map[string]interface{} {
+	if len(cs) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, map[string]interface{}{"key": c.Key, "value": c.Value})
+	}
+	return out
+}
+
+func eventFromState(d *schema.ResourceData) (*retl.Event, bool) {
+	raw, ok := d.Get("event").([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return nil, false
+	}
+	m := raw[0].(map[string]interface{})
+	e := &retl.Event{Type: retl.EventType(m["type"].(string))}
+	if v, _ := m["name"].(string); v != "" {
+		e.Name = v
+	}
+	if v, _ := m["name_column"].(string); v != "" {
+		e.NameColumn = v
+	}
+	return e, true
+}
+
+func eventToState(e *retl.Event) []map[string]interface{} {
+	if e == nil {
+		return nil
+	}
+	m := map[string]interface{}{"type": string(e.Type)}
+	if e.Name != "" {
+		m["name"] = e.Name
+	}
+	if e.NameColumn != "" {
+		m["name_column"] = e.NameColumn
+	}
+	return []map[string]interface{}{m}
+}

--- a/rudderstack/retl/connection_internal_test.go
+++ b/rudderstack/retl/connection_internal_test.go
@@ -1,0 +1,25 @@
+package retl
+
+import "testing"
+
+func TestFlowForceNewRules(t *testing.T) {
+	cases := []struct {
+		name                              string
+		objectSet, destConfigSet          bool
+		wantIdentifiers, wantConstants    bool
+	}{
+		{"json mapper (no object, no dest_config)", false, false, true, false},
+		{"object mapping (object set)", true, false, true, true},
+		{"destination-specific (dest_config set)", false, true, false, true},
+		{"object set wins over dest_config", true, true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID, gotC := flowForceNewRules(tc.objectSet, tc.destConfigSet)
+			if gotID != tc.wantIdentifiers || gotC != tc.wantConstants {
+				t.Errorf("flowForceNewRules(object=%v, destConfig=%v) = (%v, %v), want (%v, %v)",
+					tc.objectSet, tc.destConfigSet, gotID, gotC, tc.wantIdentifiers, tc.wantConstants)
+			}
+		})
+	}
+}

--- a/rudderstack/retl/connection_internal_test.go
+++ b/rudderstack/retl/connection_internal_test.go
@@ -2,6 +2,53 @@ package retl
 
 import "testing"
 
+func TestSuppressEquivalentJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		oldVal   string
+		newVal   string
+		expected bool
+	}{
+		{"identical strings", `{"a":1}`, `{"a":1}`, true},
+		{"different key order", `{"a":1,"b":2}`, `{"b":2,"a":1}`, true},
+		{"different whitespace", `{"a":1}`, ` {  "a" : 1 } `, true},
+		{"semantic difference", `{"a":1}`, `{"a":2}`, false},
+		{"different shape", `{"a":1}`, `{"b":1}`, false},
+		{"nested key reorder", `{"o":{"x":1,"y":2}}`, `{"o":{"y":2,"x":1}}`, true},
+		{"array order matters", `[1,2,3]`, `[3,2,1]`, false},
+		{"both invalid JSON", "{not json", "{not json", true},
+		{"only one invalid", `{"a":1}`, "{not json", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := suppressEquivalentJSON("", tc.oldVal, tc.newVal, nil)
+			if got != tc.expected {
+				t.Errorf("suppressEquivalentJSON(%q, %q) = %v, want %v", tc.oldVal, tc.newVal, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"empty", "", ""},
+		{"canonicalizes key order", `{"b":2,"a":1}`, `{"a":1,"b":2}`},
+		{"strips whitespace", ` { "a" : 1 } `, `{"a":1}`},
+		{"invalid JSON returned as-is", "{not json", "{not json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeJSON(tc.in); got != tc.out {
+				t.Errorf("normalizeJSON(%q) = %q, want %q", tc.in, got, tc.out)
+			}
+		})
+	}
+}
+
 func TestFlowForceNewRules(t *testing.T) {
 	cases := []struct {
 		name                              string

--- a/rudderstack/retl/connection_test.go
+++ b/rudderstack/retl/connection_test.go
@@ -2,6 +2,7 @@ package retl_test
 
 import (
 	"context"
+	"regexp"
 	"testing"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack"
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/retl"
 )
+
+func regexpMatches(pattern string) *regexp.Regexp { return regexp.MustCompile(pattern) }
 
 // jsonMapperConnection returns a fully-populated JSON Mapper connection
 // shared by several tests below.
@@ -190,6 +193,63 @@ func TestResourceConnection_404RemovesFromState(t *testing.T) {
 	require.False(t, diags.HasError())
 	require.Empty(t, d.Id())
 	svc.AssertExpectations(t)
+}
+
+func TestResourceConnection_CursorColumnRequiresUpsert(t *testing.T) {
+	svc := &mockService{}
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						sync_behaviour = "mirror"
+						cursor_column  = "updated_at"
+						schedule {
+							type = "manual"
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+					}
+				`,
+				ExpectError: regexpMatches(`cursor_column is only valid when sync_behaviour is "upsert"`),
+			},
+		},
+	})
+	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
+}
+
+func TestResourceConnection_BasicScheduleRequiresEveryMinutes(t *testing.T) {
+	svc := &mockService{}
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						sync_behaviour = "upsert"
+						schedule {
+							type = "basic"
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+					}
+				`,
+				ExpectError: regexpMatches(`schedule\.every_minutes is required when schedule\.type is "basic"`),
+			},
+		},
+	})
+	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
 }
 
 func TestResourceConnection_Delete404IsTreatedAsAlreadyGone(t *testing.T) {

--- a/rudderstack/retl/connection_test.go
+++ b/rudderstack/retl/connection_test.go
@@ -1,0 +1,308 @@
+package retl_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	iacretl "github.com/rudderlabs/rudder-iac/api/client/retl"
+	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil"
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack"
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/retl"
+)
+
+// jsonMapperConnection returns a fully-populated JSON Mapper connection
+// shared by several tests below.
+func jsonMapperConnection(id string) *iacretl.RETLConnection {
+	enabled := true
+	every := 60
+	return &iacretl.RETLConnection{
+		ID:            id,
+		SourceID:      "retl-src-1",
+		DestinationID: "dest-1",
+		Enabled:       enabled,
+		Schedule:      iacretl.Schedule{Type: iacretl.ScheduleTypeBasic, EveryMinutes: &every},
+		SyncBehaviour: iacretl.SyncBehaviourUpsert,
+		Identifiers:   []iacretl.Mapping{{From: "email", To: "user_id"}},
+		Mappings:      []iacretl.Mapping{{From: "name", To: "first_name"}},
+		Event:         &iacretl.Event{Type: iacretl.EventTypeIdentify},
+		CreatedAt:     testutil.TimePtr(time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)),
+		UpdatedAt:     testutil.TimePtr(time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)),
+	}
+}
+
+func TestResourceConnection_JSONMapper_CreateReadUpdateDelete(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+	every60 := 60
+
+	createReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:      "retl-src-1",
+		DestinationID: "dest-1",
+		Enabled:       &enabled,
+		Schedule:      iacretl.Schedule{Type: iacretl.ScheduleTypeBasic, EveryMinutes: &every60},
+		SyncBehaviour: iacretl.SyncBehaviourUpsert,
+		Identifiers:   []iacretl.Mapping{{From: "email", To: "user_id"}},
+		Mappings:      []iacretl.Mapping{{From: "name", To: "first_name"}},
+		Event:         &iacretl.Event{Type: iacretl.EventTypeIdentify},
+	}
+	created := jsonMapperConnection("conn-1")
+	svc.On("CreateConnection", mock.Anything, createReq).Return(created, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-1").Return(created, nil).Times(3)
+
+	every120 := 120
+	updateReq := &iacretl.UpdateRETLConnectionRequest{
+		Enabled:  &enabled,
+		Schedule: iacretl.Schedule{Type: iacretl.ScheduleTypeBasic, EveryMinutes: &every120},
+		Mappings: &[]iacretl.Mapping{
+			{From: "name", To: "first_name"},
+			{From: "phone", To: "phone_number"},
+		},
+		Constants: &[]iacretl.Constant{{Key: "properties.source", Value: "warehouse"}},
+	}
+	updated := *created
+	updated.Schedule.EveryMinutes = &every120
+	updated.Mappings = *updateReq.Mappings
+	updated.Constants = *updateReq.Constants
+	updated.UpdatedAt = testutil.TimePtr(time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC))
+	svc.On("UpdateConnection", mock.Anything, "conn-1", updateReq).Return(&updated, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-1").Return(&updated, nil).Times(2)
+	svc.On("DeleteConnection", mock.Anything, "conn-1").Return(nil).Once()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						sync_behaviour = "upsert"
+						schedule {
+							type          = "basic"
+							every_minutes = 60
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+						mappings {
+							from = "name"
+							to   = "first_name"
+						}
+						event {
+							type = "identify"
+						}
+					}
+				`,
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"id":                       "conn-1",
+						"source_id":                "retl-src-1",
+						"destination_id":           "dest-1",
+						"enabled":                  "true",
+						"sync_behaviour":           "upsert",
+						"schedule.0.type":          "basic",
+						"schedule.0.every_minutes": "60",
+						"identifiers.0.from":       "email",
+						"identifiers.0.to":         "user_id",
+						"mappings.0.from":          "name",
+						"mappings.0.to":            "first_name",
+						"event.0.type":             "identify",
+						"created_at":               "2026-04-20T12:00:00Z",
+					}, attrs)
+				},
+			},
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						sync_behaviour = "upsert"
+						schedule {
+							type          = "basic"
+							every_minutes = 120
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+						mappings {
+							from = "name"
+							to   = "first_name"
+						}
+						mappings {
+							from = "phone"
+							to   = "phone_number"
+						}
+						event {
+							type = "identify"
+						}
+						constants {
+							key   = "properties.source"
+							value = "warehouse"
+						}
+					}
+				`,
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"schedule.0.every_minutes": "120",
+						"mappings.#":               "2",
+						"mappings.1.from":          "phone",
+						"constants.0.key":          "properties.source",
+						"constants.0.value":        "warehouse",
+						"updated_at":               "2026-04-21T12:00:00Z",
+					}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+}
+
+func TestResourceConnection_404RemovesFromState(t *testing.T) {
+	svc := &mockService{}
+	svc.On("GetConnection", mock.Anything, "conn-gone").
+		Return(nil, &client.APIError{HTTPStatusCode: 404}).Once()
+
+	r := retl.ResourceConnection()
+	d := r.TestResourceData()
+	d.SetId("conn-gone")
+
+	diags := r.ReadContext(context.Background(), d, &rudderstack.Client{RETLSources: svc})
+	require.False(t, diags.HasError())
+	require.Empty(t, d.Id())
+	svc.AssertExpectations(t)
+}
+
+func TestResourceConnection_Delete404IsTreatedAsAlreadyGone(t *testing.T) {
+	svc := &mockService{}
+	svc.On("DeleteConnection", mock.Anything, "conn-gone").
+		Return(&client.APIError{HTTPStatusCode: 404}).Once()
+
+	r := retl.ResourceConnection()
+	d := r.TestResourceData()
+	d.SetId("conn-gone")
+
+	diags := r.DeleteContext(context.Background(), d, &rudderstack.Client{RETLSources: svc})
+	require.False(t, diags.HasError())
+	require.Empty(t, d.Id())
+	svc.AssertExpectations(t)
+}
+
+func TestResourceConnection_ExternalIDChangeRoundTrip(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+	every := 60
+
+	createReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:      "retl-src-1",
+		DestinationID: "dest-1",
+		Enabled:       &enabled,
+		ExternalID:    "ext-old",
+		Schedule:      iacretl.Schedule{Type: iacretl.ScheduleTypeBasic, EveryMinutes: &every},
+		SyncBehaviour: iacretl.SyncBehaviourUpsert,
+		Identifiers:   []iacretl.Mapping{{From: "email", To: "user_id"}},
+		Event:         &iacretl.Event{Type: iacretl.EventTypeIdentify},
+	}
+	created := jsonMapperConnection("conn-1")
+	created.ExternalID = "ext-old"
+	created.Mappings = nil
+	svc.On("CreateConnection", mock.Anything, createReq).Return(created, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-1").Return(created, nil).Times(3)
+
+	updatedConn := *created
+	updatedConn.ExternalID = "ext-new"
+	svc.On("SetConnectionExternalId", mock.Anything, &iacretl.SetRETLConnectionExternalIDRequest{
+		ID:         "conn-1",
+		ExternalID: "ext-new",
+	}).Return(nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-1").Return(&updatedConn, nil).Times(2)
+	svc.On("DeleteConnection", mock.Anything, "conn-1").Return(nil).Once()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						external_id    = "ext-old"
+						sync_behaviour = "upsert"
+						schedule {
+							type          = "basic"
+							every_minutes = 60
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+						event {
+							type = "identify"
+						}
+					}
+				`,
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{"external_id": "ext-old"}, attrs)
+				},
+			},
+			{
+				// Only external_id changes — should hit SetConnectionExternalId,
+				// not the main UpdateConnection endpoint.
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						external_id    = "ext-new"
+						sync_behaviour = "upsert"
+						schedule {
+							type          = "basic"
+							every_minutes = 60
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+						event {
+							type = "identify"
+						}
+					}
+				`,
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{"external_id": "ext-new"}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+	svc.AssertNotCalled(t, "UpdateConnection", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/rudderstack/retl/connection_test.go
+++ b/rudderstack/retl/connection_test.go
@@ -224,6 +224,34 @@ func TestResourceConnection_CursorColumnRequiresUpsert(t *testing.T) {
 	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
 }
 
+func TestResourceConnection_CronScheduleRequiresExpression(t *testing.T) {
+	svc := &mockService{}
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-1"
+						sync_behaviour = "upsert"
+						schedule {
+							type = "cron"
+						}
+						identifiers {
+							from = "email"
+							to   = "user_id"
+						}
+					}
+				`,
+				ExpectError: regexpMatches(`schedule\.cron_expression is required when schedule\.type is "cron"`),
+			},
+		},
+	})
+	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
+}
+
 func TestResourceConnection_BasicScheduleRequiresEveryMinutes(t *testing.T) {
 	svc := &mockService{}
 	resource.UnitTest(t, resource.TestCase{
@@ -267,102 +295,3 @@ func TestResourceConnection_Delete404IsTreatedAsAlreadyGone(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestResourceConnection_ExternalIDChangeRoundTrip(t *testing.T) {
-	svc := &mockService{}
-	enabled := true
-	every := 60
-
-	createReq := &iacretl.CreateRETLConnectionRequest{
-		SourceID:      "retl-src-1",
-		DestinationID: "dest-1",
-		Enabled:       &enabled,
-		ExternalID:    "ext-old",
-		Schedule:      iacretl.Schedule{Type: iacretl.ScheduleTypeBasic, EveryMinutes: &every},
-		SyncBehaviour: iacretl.SyncBehaviourUpsert,
-		Identifiers:   []iacretl.Mapping{{From: "email", To: "user_id"}},
-		Event:         &iacretl.Event{Type: iacretl.EventTypeIdentify},
-	}
-	created := jsonMapperConnection("conn-1")
-	created.ExternalID = "ext-old"
-	created.Mappings = nil
-	svc.On("CreateConnection", mock.Anything, createReq).Return(created, nil).Once()
-	svc.On("GetConnection", mock.Anything, "conn-1").Return(created, nil).Times(3)
-
-	updatedConn := *created
-	updatedConn.ExternalID = "ext-new"
-	svc.On("SetConnectionExternalId", mock.Anything, &iacretl.SetRETLConnectionExternalIDRequest{
-		ID:         "conn-1",
-		ExternalID: "ext-new",
-	}).Return(nil).Once()
-	svc.On("GetConnection", mock.Anything, "conn-1").Return(&updatedConn, nil).Times(2)
-	svc.On("DeleteConnection", mock.Anything, "conn-1").Return(nil).Once()
-
-	resource.UnitTest(t, resource.TestCase{
-		ProviderFactories: providerFactories(svc),
-		Steps: []resource.TestStep{
-			{
-				Config: `
-					provider "rudderstack" { access_token = "tok" }
-					resource "rudderstack_retl_connection" "example" {
-						source_id      = "retl-src-1"
-						destination_id = "dest-1"
-						external_id    = "ext-old"
-						sync_behaviour = "upsert"
-						schedule {
-							type          = "basic"
-							every_minutes = 60
-						}
-						identifiers {
-							from = "email"
-							to   = "user_id"
-						}
-						event {
-							type = "identify"
-						}
-					}
-				`,
-				Check: func(s *terraform.State) error {
-					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
-					if err != nil {
-						return err
-					}
-					return checkAll(map[string]string{"external_id": "ext-old"}, attrs)
-				},
-			},
-			{
-				// Only external_id changes — should hit SetConnectionExternalId,
-				// not the main UpdateConnection endpoint.
-				Config: `
-					provider "rudderstack" { access_token = "tok" }
-					resource "rudderstack_retl_connection" "example" {
-						source_id      = "retl-src-1"
-						destination_id = "dest-1"
-						external_id    = "ext-new"
-						sync_behaviour = "upsert"
-						schedule {
-							type          = "basic"
-							every_minutes = 60
-						}
-						identifiers {
-							from = "email"
-							to   = "user_id"
-						}
-						event {
-							type = "identify"
-						}
-					}
-				`,
-				Check: func(s *terraform.State) error {
-					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
-					if err != nil {
-						return err
-					}
-					return checkAll(map[string]string{"external_id": "ext-new"}, attrs)
-				},
-			},
-		},
-	})
-
-	svc.AssertExpectations(t)
-	svc.AssertNotCalled(t, "UpdateConnection", mock.Anything, mock.Anything, mock.Anything)
-}

--- a/rudderstack/retl/mock_test.go
+++ b/rudderstack/retl/mock_test.go
@@ -71,8 +71,3 @@ func (m *mockService) DeleteConnection(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
-
-func (m *mockService) SetConnectionExternalId(ctx context.Context, req *retl.SetRETLConnectionExternalIDRequest) error {
-	args := m.Called(ctx, req)
-	return args.Error(0)
-}

--- a/rudderstack/retl/mock_test.go
+++ b/rudderstack/retl/mock_test.go
@@ -42,3 +42,37 @@ func (m *mockService) DeleteRetlSource(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
+
+func (m *mockService) CreateConnection(ctx context.Context, req *retl.CreateRETLConnectionRequest) (*retl.RETLConnection, error) {
+	args := m.Called(ctx, req)
+	if v := args.Get(0); v != nil {
+		return v.(*retl.RETLConnection), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockService) GetConnection(ctx context.Context, id string) (*retl.RETLConnection, error) {
+	args := m.Called(ctx, id)
+	if v := args.Get(0); v != nil {
+		return v.(*retl.RETLConnection), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockService) UpdateConnection(ctx context.Context, id string, req *retl.UpdateRETLConnectionRequest) (*retl.RETLConnection, error) {
+	args := m.Called(ctx, id, req)
+	if v := args.Get(0); v != nil {
+		return v.(*retl.RETLConnection), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockService) DeleteConnection(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockService) SetConnectionExternalId(ctx context.Context, req *retl.SetRETLConnectionExternalIDRequest) error {
+	args := m.Called(ctx, req)
+	return args.Error(0)
+}


### PR DESCRIPTION
## 🔗 Ticket

Resolves [PRO-5605](https://linear.app/rudderstack/issue/PRO-5605/terraform-provider-rudderstack-retl-connection-resource)

---

## Summary

Adds the \`rudderstack_retl_connection\` Terraform resource for managing RETL connections via the public API (rudder-api endpoints from [PRO-5603](https://linear.app/rudderstack/issue/PRO-5603), Go client from [PRO-5604](https://linear.app/rudderstack/issue/PRO-5604) — already merged into rudder-iac main).

Schema spans all three flows (JSON Mapper, Object Mapping, Destination-specific). Flow detection is server-side; this resource only sends the flat payload and lets the API assemble the internal config.

---

## Changes

- **New** \`rudderstack/retl/connection.go\` — \`ResourceConnection()\` with full schema, CRUD, and \`CustomizeDiff\` for flow-dependent ForceNew on \`identifiers\`/\`constants\`.
- **Modified** \`rudderstack/retl/common.go\` — extended \`Service\` interface with the four connection CRUD methods and \`SetConnectionExternalId\`.
- **Modified** \`rudderstack/retl/mock_test.go\` — mock stubs for the new interface methods.
- **Modified** \`rudderstack/provider.go\` — registered \`rudderstack_retl_connection\` in \`resourcesMap\`.
- **New** tests:
  - \`rudderstack/retl/connection_test.go\` — JSON Mapper create+update lifecycle, 404 → state removal, delete-when-already-gone, and external-id-only update path verifying it goes through the dedicated endpoint and skips \`UpdateConnection\`.
  - \`rudderstack/retl/connection_internal_test.go\` — table-driven coverage of the per-flow ForceNew matrix.

### Notable design choices

1. **Flow-dependent ForceNew** is implemented via \`CustomizeDiff\` using the same field-presence signals the API uses: \`object\` set → Object Mapping, \`destination_config\` set → Destination-specific, otherwise JSON Mapper.
2. **External ID** uses the dedicated \`SetConnectionExternalId\` endpoint when only that field changes, so we don't send a no-op main update.
3. **\`destination_config\`** is exposed as a JSON-encoded string (validated with \`StringIsJSON\`), kept opaque on the client per the upstream contract — backend resolves the destination type and validates the shape per registry.

---

## Testing

- \`go test ./rudderstack/retl/...\` — all pass (full lifecycle UnitTest + flow-rule unit tests)
- \`go test ./...\` — full suite passes (no regressions in integrations / sources / destinations)

---

## Risk / Impact

Low — additive resource. Only modifications to existing files are interface composition (extending \`Service\` with new methods) and provider registration. Live verification against the rudder-api endpoints is gated on [PRO-5601](https://linear.app/rudderstack/issue/PRO-5601) (config-backend CRUD) shipping.

---

## Checklist

- [x] Ticket linked
- [x] Tests added/updated
- [x] No breaking changes (additive only)