### PR TITLE
chore(ci): workflow cleanup (SEC-284)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Disables Go module cache restore in release workflow.

Ref: SEC-284