### PR TITLE
chore(retl): introduce Customer.io Audience support in RETL connections

### DIFF
--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -103,6 +103,13 @@ func GenerateImportScript(
 		if len(cnxn.DestinationConfig) > 0 && destinationTerraformTypes[cnxn.DestinationID] != "customerio_audience" {
 			continue
 		}
+		// For customerio_audience, mirror the HCL generator's hard-skip when
+		// the typed block can't be decoded.
+		if destinationTerraformTypes[cnxn.DestinationID] == "customerio_audience" && len(cnxn.DestinationConfig) > 0 {
+			if _, err := customerIOAudienceConfigBlock(cnxn.DestinationConfig); err != nil {
+				continue
+			}
+		}
 		lines = append(lines, fmt.Sprintf(`terraform import "rudderstack_retl_connection.%s" "%s"`, retlConnectionName(cnxn), cnxn.ID))
 	}
 
@@ -215,6 +222,15 @@ func GenerateTerraform(
 		if len(cnxn.DestinationConfig) > 0 && dst.terraformType != "customerio_audience" {
 			logger.Printf("skipping RETL connection '%s': destination-specific flow for '%s' is not supported", cnxn.ID, dst.terraformType)
 			continue
+		}
+		// For customerio_audience, the typed block is mandatory: emitting the
+		// connection without it would produce HCL that can't roundtrip on
+		// import. Skip the whole connection if decoding fails.
+		if dst.terraformType == "customerio_audience" && len(cnxn.DestinationConfig) > 0 {
+			if _, err := customerIOAudienceConfigBlock(cnxn.DestinationConfig); err != nil {
+				logger.Printf("skipping RETL connection '%s': cannot decode customerio_audience destinationConfig (%v)", cnxn.ID, err)
+				continue
+			}
 		}
 		b, err := generateRetlConnection(cnxn, src, dst)
 		if err != nil {
@@ -721,15 +737,17 @@ func generateRetlConnection(c retl.RETLConnection, src *retlSourceEntry, dst *de
 		body.SetAttributeValue("object", cty.StringVal(c.Object))
 	}
 	// The caller has already filtered out destination-specific flows that
-	// aren't Customer.io Audience, so any non-empty destinationConfig here
-	// belongs to a customerio_audience destination.
+	// aren't Customer.io Audience and pre-validated the typed block, so any
+	// non-empty destinationConfig here belongs to a customerio_audience
+	// destination and decodes cleanly. The error path is unreachable in
+	// normal flow; treat it as fail-fast so a future refactor that drops
+	// the pre-check can't silently emit unimportable HCL.
 	if len(c.DestinationConfig) > 0 {
 		b, err := customerIOAudienceConfigBlock(c.DestinationConfig)
 		if err != nil {
-			logger.Printf("RETL connection '%s': skipping customerio_audience_config (%v)", c.ID, err)
-		} else {
-			body.AppendBlock(b)
+			return nil, fmt.Errorf("decode customerio_audience destinationConfig: %w", err)
 		}
+		body.AppendBlock(b)
 	}
 
 	return block, nil

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -51,6 +51,7 @@ func GenerateImportScript(
 
 	foundSources := map[string]bool{}
 	foundDestinations := map[string]bool{}
+	destinationTerraformTypes := map[string]string{} // destination ID -> terraform type
 	foundRetlSources := map[string]bool{}
 
 	for _, src := range sources {
@@ -65,6 +66,7 @@ func GenerateImportScript(
 		t, cm := configMeta(destinationConfigs, dst.Type)
 		if cm != nil {
 			foundDestinations[dst.ID] = true
+			destinationTerraformTypes[dst.ID] = t
 			lines = append(lines, fmt.Sprintf(`terraform import "rudderstack_destination_%s.%s" "%s"`, t, destinationName(dst), dst.ID))
 		}
 	}
@@ -92,6 +94,12 @@ func GenerateImportScript(
 			continue
 		}
 		if !foundDestinations[cnxn.DestinationID] {
+			continue
+		}
+		// Skip unsupported destination-specific flows — these are skipped in
+		// the HCL generator too, so we mustn't emit an import line for a
+		// resource that doesn't exist.
+		if len(cnxn.DestinationConfig) > 0 && destinationTerraformTypes[cnxn.DestinationID] != "customerio_audience" {
 			continue
 		}
 		lines = append(lines, fmt.Sprintf(`terraform import "rudderstack_retl_connection.%s" "%s"`, retlConnectionName(cnxn), cnxn.ID))
@@ -197,6 +205,14 @@ func GenerateTerraform(
 		}
 		if !okd {
 			logger.Printf("could not generate resource block for RETL connection '%s': destination '%s' is not supported", cnxn.ID, cnxn.DestinationID)
+			continue
+		}
+		// Customer.io Audience is the only destination-specific flow this
+		// resource exposes as a typed block. Any other destination with a
+		// non-empty destinationConfig is a VDM-next flow we don't support —
+		// skip rather than emit a connection we can't represent.
+		if len(cnxn.DestinationConfig) > 0 && dst.terraformType != "customerio_audience" {
+			logger.Printf("skipping RETL connection '%s': destination-specific flow for '%s' is not supported", cnxn.ID, dst.terraformType)
 			continue
 		}
 		b, err := generateRetlConnection(cnxn, src, dst)
@@ -703,14 +719,15 @@ func generateRetlConnection(c retl.RETLConnection, src *retlSourceEntry, dst *de
 	if c.Object != "" {
 		body.SetAttributeValue("object", cty.StringVal(c.Object))
 	}
+	// The caller has already filtered out destination-specific flows that
+	// aren't Customer.io Audience, so any non-empty destinationConfig here
+	// belongs to a customerio_audience destination.
 	if len(c.DestinationConfig) > 0 {
-		tokens, err := destinationConfigJsonencodeTokens(c.DestinationConfig)
+		b, err := customerIOAudienceConfigBlock(c.DestinationConfig)
 		if err != nil {
-			// Log and omit the attribute — the rest of the connection is still
-			// usable. Don't fail the whole generation over an opaque blob.
-			logger.Printf("RETL connection '%s': skipping destination_config (%v)", c.ID, err)
+			logger.Printf("RETL connection '%s': skipping customerio_audience_config (%v)", c.ID, err)
 		} else {
-			body.SetAttributeRaw("destination_config", tokens)
+			body.AppendBlock(b)
 		}
 	}
 
@@ -780,45 +797,24 @@ func retlEventBlock(e *retl.Event) *hclwrite.Block {
 	return b
 }
 
-// destinationConfigJsonencodeTokens renders an opaque destinationConfig blob as
-// a `jsonencode({...})` call so the generated HCL stays readable. Returns an
-// error when the payload is JSON null, or when the top-level value isn't a
-// JSON object — both are valid JSON but neither produces useful HCL
-// (jsonencode(null) / jsonencode("foo") would round-trip the wrong shape
-// through the resource's destination_config string field). The caller is
-// expected to log the error and omit the attribute; the rest of the
-// connection block is still emitted.
-func destinationConfigJsonencodeTokens(raw json.RawMessage) (hclwrite.Tokens, error) {
-	var parsed interface{}
+// customerIOAudienceConfigBlock builds a `customerio_audience_config` block
+// from the connection's destinationConfig JSON. Returns an error if the JSON
+// is missing/invalid or audienceId is absent or not a number — the caller
+// logs and skips the block in that case.
+func customerIOAudienceConfigBlock(raw json.RawMessage) (*hclwrite.Block, error) {
+	var parsed map[string]interface{}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
 		return nil, fmt.Errorf("destinationConfig is not valid JSON: %w", err)
 	}
-	if parsed == nil {
-		return nil, fmt.Errorf("destinationConfig is JSON null")
-	}
-	m, ok := parsed.(map[string]interface{})
+	v, ok := parsed["audienceId"]
 	if !ok {
-		return nil, fmt.Errorf("destinationConfig top-level value is %T, expected JSON object", parsed)
+		return nil, fmt.Errorf("customerio_audience destinationConfig missing audienceId")
 	}
-	if len(m) == 0 {
-		// {} is technically a valid object, but emitting `jsonencode({})` is
-		// noise — the resource would set the field to a literal empty JSON
-		// string, which the schema's StateFunc already normalises away. Treat
-		// it the same as null and omit the attribute.
-		return nil, fmt.Errorf("destinationConfig is an empty object")
+	n, ok := v.(float64) // json.Unmarshal decodes numbers as float64
+	if !ok {
+		return nil, fmt.Errorf("customerio_audience audienceId is %T, expected number", v)
 	}
-	inner := hclwrite.TokensForValue(ctyValue(parsed))
-	// Suppress the leading whitespace hclwrite would otherwise insert before
-	// the opening brace of the inner value, so the output reads `jsonencode({`
-	// and not `jsonencode( {`.
-	if len(inner) > 0 {
-		inner[0].SpacesBefore = 0
-	}
-	out := hclwrite.Tokens{
-		&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("jsonencode")},
-		&hclwrite.Token{Type: hclsyntax.TokenOParen, Bytes: []byte("(")},
-	}
-	out = append(out, inner...)
-	out = append(out, &hclwrite.Token{Type: hclsyntax.TokenCParen, Bytes: []byte(")")})
-	return out, nil
+	b := hclwrite.NewBlock("customerio_audience_config", nil)
+	b.Body().SetAttributeValue("audience_id", cty.NumberIntVal(int64(n)))
+	return b, nil
 }

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -103,10 +103,15 @@ func GenerateImportScript(
 		if len(cnxn.DestinationConfig) > 0 && destinationTerraformTypes[cnxn.DestinationID] != "customerio_audience" {
 			continue
 		}
-		// customerio_audience connections import into the typed resource
-		// rudderstack_retl_connection_customerio_audience; mirror the HCL
-		// generator's hard-skip when the typed config can't be decoded.
-		if destinationTerraformTypes[cnxn.DestinationID] == "customerio_audience" && len(cnxn.DestinationConfig) > 0 {
+		// customerio_audience destinations always import into the typed
+		// resource rudderstack_retl_connection_customerio_audience. Hard-skip
+		// when destinationConfig is missing or undecodable so the import
+		// script never diverges from the HCL generator (the typed resource
+		// schema requires audience_id, so HCL without it would be invalid).
+		if destinationTerraformTypes[cnxn.DestinationID] == "customerio_audience" {
+			if len(cnxn.DestinationConfig) == 0 {
+				continue
+			}
 			if _, err := decodeCustomerIOAudienceID(cnxn.DestinationConfig); err != nil {
 				continue
 			}
@@ -226,10 +231,16 @@ func GenerateTerraform(
 			logger.Printf("skipping RETL connection '%s': destination-specific flow for '%s' is not supported", cnxn.ID, dst.terraformType)
 			continue
 		}
-		// For customerio_audience, the typed audience_id is mandatory: emitting
-		// the connection without it would produce HCL that can't roundtrip on
-		// import. Skip the whole connection if decoding fails.
-		if dst.terraformType == "customerio_audience" && len(cnxn.DestinationConfig) > 0 {
+		// For customerio_audience, audience_id is required by the typed
+		// schema. Emitting the resource without it would produce HCL that
+		// can't roundtrip on import, and emitting the generic resource for a
+		// typed destination would diverge from the import script. Hard-skip
+		// in both these cases so the two outputs stay aligned.
+		if dst.terraformType == "customerio_audience" {
+			if len(cnxn.DestinationConfig) == 0 {
+				logger.Printf("skipping RETL connection '%s': customerio_audience destination without destinationConfig (audience_id required)", cnxn.ID)
+				continue
+			}
 			if _, err := decodeCustomerIOAudienceID(cnxn.DestinationConfig); err != nil {
 				logger.Printf("skipping RETL connection '%s': cannot decode customerio_audience destinationConfig (%v)", cnxn.ID, err)
 				continue

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -103,12 +103,15 @@ func GenerateImportScript(
 		if len(cnxn.DestinationConfig) > 0 && destinationTerraformTypes[cnxn.DestinationID] != "customerio_audience" {
 			continue
 		}
-		// For customerio_audience, mirror the HCL generator's hard-skip when
-		// the typed block can't be decoded.
+		// customerio_audience connections import into the typed resource
+		// rudderstack_retl_connection_customerio_audience; mirror the HCL
+		// generator's hard-skip when the typed config can't be decoded.
 		if destinationTerraformTypes[cnxn.DestinationID] == "customerio_audience" && len(cnxn.DestinationConfig) > 0 {
-			if _, err := customerIOAudienceConfigBlock(cnxn.DestinationConfig); err != nil {
+			if _, err := decodeCustomerIOAudienceID(cnxn.DestinationConfig); err != nil {
 				continue
 			}
+			lines = append(lines, fmt.Sprintf(`terraform import "rudderstack_retl_connection_customerio_audience.%s" "%s"`, retlConnectionName(cnxn), cnxn.ID))
+			continue
 		}
 		lines = append(lines, fmt.Sprintf(`terraform import "rudderstack_retl_connection.%s" "%s"`, retlConnectionName(cnxn), cnxn.ID))
 	}
@@ -216,18 +219,18 @@ func GenerateTerraform(
 			continue
 		}
 		// Customer.io Audience is the only destination-specific flow this
-		// resource exposes as a typed block. Any other destination with a
-		// non-empty destinationConfig is a VDM-next flow we don't support —
-		// skip rather than emit a connection we can't represent.
+		// generator currently emits as a typed resource. Any other destination
+		// with a non-empty destinationConfig is a VDM-next flow we don't
+		// support — skip rather than emit a connection we can't represent.
 		if len(cnxn.DestinationConfig) > 0 && dst.terraformType != "customerio_audience" {
 			logger.Printf("skipping RETL connection '%s': destination-specific flow for '%s' is not supported", cnxn.ID, dst.terraformType)
 			continue
 		}
-		// For customerio_audience, the typed block is mandatory: emitting the
-		// connection without it would produce HCL that can't roundtrip on
+		// For customerio_audience, the typed audience_id is mandatory: emitting
+		// the connection without it would produce HCL that can't roundtrip on
 		// import. Skip the whole connection if decoding fails.
 		if dst.terraformType == "customerio_audience" && len(cnxn.DestinationConfig) > 0 {
-			if _, err := customerIOAudienceConfigBlock(cnxn.DestinationConfig); err != nil {
+			if _, err := decodeCustomerIOAudienceID(cnxn.DestinationConfig); err != nil {
 				logger.Printf("skipping RETL connection '%s': cannot decode customerio_audience destinationConfig (%v)", cnxn.ID, err)
 				continue
 			}
@@ -680,6 +683,16 @@ func generateRetlSource(s retl.RETLSource, terraformType string) (block *hclwrit
 // references (so terraform can manage the dependency graph), and the rest of
 // the flat API response is split back into the nested HCL blocks the resource
 // schema expects.
+//
+// For customerio_audience destinations the function emits the typed
+// `rudderstack_retl_connection_customerio_audience` resource with the
+// audience ID as a top-level attribute; all other destinations get the
+// generic `rudderstack_retl_connection`. The caller has already filtered
+// out unsupported destination-specific flows and pre-validated the typed
+// audience config, so any non-empty destinationConfig here belongs to a
+// customerio_audience destination and decodes cleanly. The error path on
+// decode is treated as fail-fast — defense-in-depth against a future
+// refactor that drops the pre-check.
 func generateRetlConnection(c retl.RETLConnection, src *retlSourceEntry, dst *destinationEntry) (block *hclwrite.Block, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -687,7 +700,11 @@ func generateRetlConnection(c retl.RETLConnection, src *retlSourceEntry, dst *de
 		}
 	}()
 
-	block = hclwrite.NewBlock("resource", []string{"rudderstack_retl_connection", retlConnectionName(c)})
+	resourceType := "rudderstack_retl_connection"
+	if dst.terraformType == "customerio_audience" {
+		resourceType = "rudderstack_retl_connection_customerio_audience"
+	}
+	block = hclwrite.NewBlock("resource", []string{resourceType, retlConnectionName(c)})
 	body := block.Body()
 
 	body.SetAttributeRaw("source_id", hclwrite.Tokens{
@@ -719,6 +736,20 @@ func generateRetlConnection(c retl.RETLConnection, src *retlSourceEntry, dst *de
 		body.AppendBlock(retlMappingBlock("mappings", m))
 	}
 
+	// Generic resource: event / constants / cursor_column / object apply.
+	// Typed customerio_audience resource: audience_id is the only flow-specific
+	// field; the rest don't apply.
+	if dst.terraformType == "customerio_audience" {
+		if len(c.DestinationConfig) > 0 {
+			id, err := decodeCustomerIOAudienceID(c.DestinationConfig)
+			if err != nil {
+				return nil, fmt.Errorf("decode customerio_audience destinationConfig: %w", err)
+			}
+			body.SetAttributeValue("audience_id", cty.NumberIntVal(id))
+		}
+		return block, nil
+	}
+
 	if c.Event != nil {
 		body.AppendBlock(retlEventBlock(c.Event))
 	}
@@ -736,20 +767,6 @@ func generateRetlConnection(c retl.RETLConnection, src *retlSourceEntry, dst *de
 	if c.Object != "" {
 		body.SetAttributeValue("object", cty.StringVal(c.Object))
 	}
-	// The caller has already filtered out destination-specific flows that
-	// aren't Customer.io Audience and pre-validated the typed block, so any
-	// non-empty destinationConfig here belongs to a customerio_audience
-	// destination and decodes cleanly. The error path is unreachable in
-	// normal flow; treat it as fail-fast so a future refactor that drops
-	// the pre-check can't silently emit unimportable HCL.
-	if len(c.DestinationConfig) > 0 {
-		b, err := customerIOAudienceConfigBlock(c.DestinationConfig)
-		if err != nil {
-			return nil, fmt.Errorf("decode customerio_audience destinationConfig: %w", err)
-		}
-		body.AppendBlock(b)
-	}
-
 	return block, nil
 }
 
@@ -816,27 +833,25 @@ func retlEventBlock(e *retl.Event) *hclwrite.Block {
 	return b
 }
 
-// customerIOAudienceConfigBlock builds a `customerio_audience_config` block
-// from the connection's destinationConfig JSON. Returns an error if the JSON
-// is missing/invalid or audienceId is absent or not a number — the caller
-// logs and skips the block in that case.
-func customerIOAudienceConfigBlock(raw json.RawMessage) (*hclwrite.Block, error) {
+// decodeCustomerIOAudienceID extracts the integer audienceId from a
+// customerio_audience destinationConfig JSON blob. Returns an error if the
+// payload is invalid, missing audienceId, or non-integer — the caller logs
+// and skips the connection in that case.
+func decodeCustomerIOAudienceID(raw json.RawMessage) (int64, error) {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return nil, fmt.Errorf("destinationConfig is not valid JSON: %w", err)
+		return 0, fmt.Errorf("destinationConfig is not valid JSON: %w", err)
 	}
 	v, ok := parsed["audienceId"]
 	if !ok {
-		return nil, fmt.Errorf("customerio_audience destinationConfig missing audienceId")
+		return 0, fmt.Errorf("customerio_audience destinationConfig missing audienceId")
 	}
 	n, ok := v.(float64) // json.Unmarshal decodes numbers as float64
 	if !ok {
-		return nil, fmt.Errorf("customerio_audience audienceId is %T, expected number", v)
+		return 0, fmt.Errorf("customerio_audience audienceId is %T, expected number", v)
 	}
 	if math.IsNaN(n) || math.IsInf(n, 0) || math.Trunc(n) != n {
-		return nil, fmt.Errorf("customerio_audience audienceId %v is not an integer", n)
+		return 0, fmt.Errorf("customerio_audience audienceId %v is not an integer", n)
 	}
-	b := hclwrite.NewBlock("customerio_audience_config", nil)
-	b.Body().SetAttributeValue("audience_id", cty.NumberIntVal(int64(n)))
-	return b, nil
+	return int64(n), nil
 }

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -813,6 +814,9 @@ func customerIOAudienceConfigBlock(raw json.RawMessage) (*hclwrite.Block, error)
 	n, ok := v.(float64) // json.Unmarshal decodes numbers as float64
 	if !ok {
 		return nil, fmt.Errorf("customerio_audience audienceId is %T, expected number", v)
+	}
+	if math.IsNaN(n) || math.IsInf(n, 0) || math.Trunc(n) != n {
+		return nil, fmt.Errorf("customerio_audience audienceId %v is not an integer", n)
 	}
 	b := hclwrite.NewBlock("customerio_audience_config", nil)
 	b.Body().SetAttributeValue("audience_id", cty.NumberIntVal(int64(n)))

--- a/cmd/generatetf/generator/generator_internal_test.go
+++ b/cmd/generatetf/generator/generator_internal_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 )
 
-func TestCustomerIOAudienceConfigBlock(t *testing.T) {
+func TestDecodeCustomerIOAudienceID(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      string
+		wantID  int64
 		wantErr bool
 	}{
-		{name: "valid int audienceId", in: `{"audienceId": 16}`, wantErr: false},
-		{name: "zero audienceId", in: `{"audienceId": 0}`, wantErr: false},
+		{name: "valid int audienceId", in: `{"audienceId": 16}`, wantID: 16},
+		{name: "zero audienceId", in: `{"audienceId": 0}`, wantID: 0},
 		{name: "missing audienceId", in: `{}`, wantErr: true},
 		{name: "string audienceId", in: `{"audienceId": "abc"}`, wantErr: true},
 		// Reject fractional audienceId — int64(42.5) would silently truncate.
@@ -21,15 +22,15 @@ func TestCustomerIOAudienceConfigBlock(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			b, err := customerIOAudienceConfigBlock(json.RawMessage(tc.in))
+			got, err := decodeCustomerIOAudienceID(json.RawMessage(tc.in))
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
 			}
 			if tc.wantErr {
 				return
 			}
-			if b == nil {
-				t.Fatal("expected non-nil block")
+			if got != tc.wantID {
+				t.Errorf("audienceId = %d, want %d", got, tc.wantID)
 			}
 		})
 	}

--- a/cmd/generatetf/generator/generator_internal_test.go
+++ b/cmd/generatetf/generator/generator_internal_test.go
@@ -1,0 +1,36 @@
+package generator
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCustomerIOAudienceConfigBlock(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "valid int audienceId", in: `{"audienceId": 16}`, wantErr: false},
+		{name: "zero audienceId", in: `{"audienceId": 0}`, wantErr: false},
+		{name: "missing audienceId", in: `{}`, wantErr: true},
+		{name: "string audienceId", in: `{"audienceId": "abc"}`, wantErr: true},
+		// Reject fractional audienceId — int64(42.5) would silently truncate.
+		{name: "fractional audienceId", in: `{"audienceId": 42.5}`, wantErr: true},
+		{name: "invalid JSON", in: `not json`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := customerIOAudienceConfigBlock(json.RawMessage(tc.in))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if b == nil {
+				t.Fatal("expected non-nil block")
+			}
+		})
+	}
+}

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -420,8 +420,8 @@ terraform import "rudderstack_connection.cnxn_id-connection-2" "id-connection-2"
 //   - one S3 table source (must be skipped — no _s3_table generator)
 //   - one source with an unsupported sourceType (must be skipped)
 //   - one JSON-Mapper connection wired to the model source + redshift destination
-//   - one destination-specific connection (with destination_config) wired to the
-//     table source + facebook-pixel destination
+//   - one unsupported destination-specific connection (Facebook Pixel — must be skipped)
+//   - one Customer.io Audience connection (typed customerio_audience_config block)
 //   - one connection whose RETL source is the unsupported one (must be skipped)
 //   - one connection whose destination doesn't exist in the generated set (must be skipped)
 func retlFixtures() ([]retl.RETLSource, []retl.RETLConnection) {
@@ -501,7 +501,9 @@ func retlFixtures() ([]retl.RETLSource, []retl.RETLConnection) {
 			CursorColumn: "updated_at",
 		},
 		{
-			ID:            "cnxn-ds-1",
+			// Facebook Pixel (destination-specific flow) — must be skipped:
+			// only Customer.io Audience is supported among destination-specific flows.
+			ID:            "cnxn-skip-unsupported-ds",
 			SourceID:      "src-table-1",
 			DestinationID: "id-facebook-pixel",
 			Enabled:       true,
@@ -514,6 +516,20 @@ func retlFixtures() ([]retl.RETLSource, []retl.RETLConnection) {
 				{From: "email_col", To: "EMAIL"},
 			},
 			DestinationConfig: json.RawMessage(`{"audienceId":"segment_abc123"}`),
+		},
+		{
+			// Customer.io Audience — destinationConfig must be emitted as the
+			// typed customerio_audience_config block, not jsonencode.
+			ID:            "cnxn-cio-1",
+			SourceID:      "src-model-1",
+			DestinationID: "id-cio-audience",
+			Enabled:       true,
+			Schedule:      retl.Schedule{Type: retl.ScheduleTypeManual},
+			SyncBehaviour: retl.SyncBehaviourMirror,
+			Identifiers: []retl.Mapping{
+				{From: "email", To: "email"},
+			},
+			DestinationConfig: json.RawMessage(`{"audienceId":42}`),
 		},
 		{
 			// Connection whose RETL source is the unsupported one — must be skipped.
@@ -553,6 +569,19 @@ func retlEventStreamingFixtures() ([]client.Source, []client.Destination) {
 				Name:   "name-facebook-pixel",
 				Type:   "FACEBOOK_PIXEL",
 				Config: json.RawMessage(`{}`),
+			},
+			{
+				ID:   "id-cio-audience",
+				Name: "name-cio-audience",
+				Type: "CUSTOMERIO_AUDIENCE",
+				// Minimal valid config for the destination_customerio_audience
+				// resource — generator only needs enough to emit *something*.
+				Config: json.RawMessage(`{
+					"siteId":    "site-1",
+					"apiKey":    "k",
+					"appApiKey": "ak",
+					"region":    "US"
+				}`),
 			},
 		}
 }
@@ -606,18 +635,20 @@ func TestGeneratorTerraform_RETL(t *testing.T) {
 	assert.Contains(t, output, `value = "rudderstack"`)
 	assert.Contains(t, output, `type = "identify"`)
 
-	// destination-specific connection: destination_config rendered as jsonencode(...)
-	assert.Contains(t, output, `resource "rudderstack_retl_connection" "retl_cnxn_cnxn-ds-1"`)
-	assert.Contains(t, output, `destination_id = rudderstack_destination_facebook_pixel.dst_id-facebook-pixel.id`)
-	// destination_config sits in its own attribute group after the blocks, so
-	// sync_behaviour is aligned with the top group (destination_id, 14 chars).
-	assert.Contains(t, output, `sync_behaviour = "mirror"`)
-	assert.Contains(t, output, `destination_config = jsonencode({`)
-	assert.Contains(t, output, `audienceId = "segment_abc123"`)
+	// Customer.io Audience connection: typed customerio_audience_config block.
+	assert.Contains(t, output, `resource "rudderstack_retl_connection" "retl_cnxn_cnxn-cio-1"`)
+	assert.Contains(t, output, `destination_id = rudderstack_destination_customerio_audience.dst_id-cio-audience.id`)
+	assert.Contains(t, output, `customerio_audience_config {`)
+	assert.Contains(t, output, `audience_id = 42`)
+	// Raw destination_config / jsonencode must not appear anywhere — the
+	// schema no longer supports it.
+	assert.NotContains(t, output, `destination_config`)
+	assert.NotContains(t, output, `jsonencode`)
 
 	// skipped connections aren't emitted
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-source`)
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-dest`)
+	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-unsupported-ds`)
 }
 
 func TestGeneratorImportScript_RETL(t *testing.T) {
@@ -631,59 +662,16 @@ func TestGeneratorImportScript_RETL(t *testing.T) {
 	expected := strings.Join([]string{
 		`terraform import "rudderstack_destination_redshift.dst_id-redshift" "id-redshift"`,
 		`terraform import "rudderstack_destination_facebook_pixel.dst_id-facebook-pixel" "id-facebook-pixel"`,
+		`terraform import "rudderstack_destination_customerio_audience.dst_id-cio-audience" "id-cio-audience"`,
 		`terraform import "rudderstack_retl_source_model.retl_src_src-model-1" "src-model-1"`,
 		`terraform import "rudderstack_retl_source_table.retl_src_src-table-1" "src-table-1"`,
 		`terraform import "rudderstack_retl_connection.retl_cnxn_cnxn-jm-1" "cnxn-jm-1"`,
-		`terraform import "rudderstack_retl_connection.retl_cnxn_cnxn-ds-1" "cnxn-ds-1"`,
+		`terraform import "rudderstack_retl_connection.retl_cnxn_cnxn-cio-1" "cnxn-cio-1"`,
 	}, "\n")
 
 	data, err := generator.GenerateImportScript(esSources, esDestinations, nil, retlSources, retlConnections)
 	require.NoError(t, err)
 	assert.Equal(t, expected, string(data))
-}
-
-// TestGeneratorTerraform_RETL_DestinationConfigEdgeCases verifies that
-// connections whose `destinationConfig` is JSON null or a non-object (string,
-// number, array) are still emitted but with the `destination_config` attribute
-// suppressed — the rest of the connection is usable. This guards the loose
-// API contract where the field is an opaque blob.
-func TestGeneratorTerraform_RETL_DestinationConfigEdgeCases(t *testing.T) {
-	_, esDestinations := retlEventStreamingFixtures()
-	retlSources := []retl.RETLSource{
-		{
-			ID: "src-1", Name: "src-1", IsEnabled: true,
-			SourceType: retl.ModelSourceType, SourceDefinitionName: "snowflake",
-			AccountID: "acc-1",
-			Config:    retl.RETLSQLModelConfig{PrimaryKey: "id", Sql: "SELECT 1"},
-		},
-	}
-	mkConn := func(id string, destCfg json.RawMessage) retl.RETLConnection {
-		return retl.RETLConnection{
-			ID: id, SourceID: "src-1", DestinationID: "id-redshift", Enabled: true,
-			Schedule:          retl.Schedule{Type: retl.ScheduleTypeManual},
-			SyncBehaviour:     retl.SyncBehaviourUpsert,
-			Identifiers:       []retl.Mapping{{From: "x", To: "y"}},
-			DestinationConfig: destCfg,
-		}
-	}
-	retlConnections := []retl.RETLConnection{
-		mkConn("cnxn-null", json.RawMessage(`null`)),
-		mkConn("cnxn-string", json.RawMessage(`"opaque-token"`)),
-		mkConn("cnxn-array", json.RawMessage(`[1,2,3]`)),
-		mkConn("cnxn-empty-obj", json.RawMessage(`{}`)),
-	}
-
-	data, err := generator.GenerateTerraform(nil, esDestinations, nil, retlSources, retlConnections)
-	require.NoError(t, err)
-	output := string(data)
-
-	// All four connection blocks should still be present, with their other fields intact.
-	assert.Contains(t, output, `"retl_cnxn_cnxn-null"`)
-	assert.Contains(t, output, `"retl_cnxn_cnxn-string"`)
-	assert.Contains(t, output, `"retl_cnxn_cnxn-array"`)
-	assert.Contains(t, output, `"retl_cnxn_cnxn-empty-obj"`)
-	// But destination_config must NOT have been emitted for any of them.
-	assert.NotContains(t, output, "destination_config")
 }
 
 // TestGeneratorTerraform_RETL_NilSourceConfig verifies that a RETL source with

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -562,6 +562,20 @@ func retlFixtures() ([]retl.RETLSource, []retl.RETLConnection) {
 			// audienceId is fractional — caught by the integrality check.
 			DestinationConfig: json.RawMessage(`{"audienceId":42.5}`),
 		},
+		{
+			// Customer.io Audience destination with NO destinationConfig at all
+			// — must be hard-skipped in both HCL and import-script outputs.
+			// Otherwise the HCL generator would emit a typed resource with no
+			// audience_id (schema-Required, so invalid HCL) and the import
+			// script would diverge by emitting a generic-resource import line.
+			ID:            "cnxn-skip-cio-empty-config",
+			SourceID:      "src-model-1",
+			DestinationID: "id-cio-audience",
+			Schedule:      retl.Schedule{Type: retl.ScheduleTypeManual},
+			SyncBehaviour: retl.SyncBehaviourMirror,
+			Identifiers:   []retl.Mapping{{From: "email", To: "email"}},
+			// DestinationConfig intentionally empty.
+		},
 	}
 	return sources, connections
 }
@@ -667,6 +681,7 @@ func TestGeneratorTerraform_RETL(t *testing.T) {
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-dest`)
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-unsupported-ds`)
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-cio-malformed`)
+	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-cio-empty-config`)
 }
 
 func TestGeneratorImportScript_RETL(t *testing.T) {

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -648,13 +648,17 @@ func TestGeneratorTerraform_RETL(t *testing.T) {
 	assert.Contains(t, output, `value = "rudderstack"`)
 	assert.Contains(t, output, `type = "identify"`)
 
-	// Customer.io Audience connection: typed customerio_audience_config block.
-	assert.Contains(t, output, `resource "rudderstack_retl_connection" "retl_cnxn_cnxn-cio-1"`)
+	// Customer.io Audience connection is emitted as the typed resource with
+	// audience_id as a top-level attribute.
+	assert.Contains(t, output, `resource "rudderstack_retl_connection_customerio_audience" "retl_cnxn_cnxn-cio-1"`)
 	assert.Contains(t, output, `destination_id = rudderstack_destination_customerio_audience.dst_id-cio-audience.id`)
-	assert.Contains(t, output, `customerio_audience_config {`)
 	assert.Contains(t, output, `audience_id = 42`)
-	// Raw destination_config / jsonencode must not appear anywhere — the
-	// schema no longer supports it.
+	// The customerio_audience connection must NOT be emitted as the generic
+	// resource — that would silently drop audience_id from the imported state.
+	assert.NotContains(t, output, `resource "rudderstack_retl_connection" "retl_cnxn_cnxn-cio-1"`)
+	// The legacy nested block and raw destination_config / jsonencode must not
+	// appear anywhere — the typed resource exposes audience_id at top level.
+	assert.NotContains(t, output, `customerio_audience_config {`)
 	assert.NotContains(t, output, `destination_config`)
 	assert.NotContains(t, output, `jsonencode`)
 
@@ -680,7 +684,7 @@ func TestGeneratorImportScript_RETL(t *testing.T) {
 		`terraform import "rudderstack_retl_source_model.retl_src_src-model-1" "src-model-1"`,
 		`terraform import "rudderstack_retl_source_table.retl_src_src-table-1" "src-table-1"`,
 		`terraform import "rudderstack_retl_connection.retl_cnxn_cnxn-jm-1" "cnxn-jm-1"`,
-		`terraform import "rudderstack_retl_connection.retl_cnxn_cnxn-cio-1" "cnxn-cio-1"`,
+		`terraform import "rudderstack_retl_connection_customerio_audience.retl_cnxn_cnxn-cio-1" "cnxn-cio-1"`,
 	}, "\n")
 
 	data, err := generator.GenerateImportScript(esSources, esDestinations, nil, retlSources, retlConnections)

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -549,6 +549,19 @@ func retlFixtures() ([]retl.RETLSource, []retl.RETLConnection) {
 			SyncBehaviour: retl.SyncBehaviourUpsert,
 			Identifiers:   []retl.Mapping{{From: "x", To: "y"}},
 		},
+		{
+			// Customer.io Audience destination with a malformed destinationConfig
+			// (missing audienceId) — must be hard-skipped rather than emitting an
+			// unimportable connection without the typed block.
+			ID:            "cnxn-skip-cio-malformed",
+			SourceID:      "src-model-1",
+			DestinationID: "id-cio-audience",
+			Schedule:      retl.Schedule{Type: retl.ScheduleTypeManual},
+			SyncBehaviour: retl.SyncBehaviourMirror,
+			Identifiers:   []retl.Mapping{{From: "email", To: "email"}},
+			// audienceId is fractional — caught by the integrality check.
+			DestinationConfig: json.RawMessage(`{"audienceId":42.5}`),
+		},
 	}
 	return sources, connections
 }
@@ -649,6 +662,7 @@ func TestGeneratorTerraform_RETL(t *testing.T) {
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-source`)
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-dest`)
 	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-unsupported-ds`)
+	assert.NotContains(t, output, `retl_cnxn_cnxn-skip-cio-malformed`)
 }
 
 func TestGeneratorImportScript_RETL(t *testing.T) {

--- a/examples/retl_connection.tf
+++ b/examples/retl_connection.tf
@@ -1,7 +1,8 @@
-# JSON Mapper flow — identifiers + per-field mappings, no `object`, no
-# `customerio_audience_config`. `basic` schedule runs every N minutes.
-# `constants` adds static key/value pairs to every synced row (mutable in
-# JSON Mapper; ForceNew in Object Mapping and destination-specific flows).
+# JSON Mapper flow — identifiers + per-field mappings, no `object`.
+# `basic` schedule runs every N minutes. `constants` adds static key/value
+# pairs to every synced row (mutable in JSON Mapper; ForceNew in Object
+# Mapping). Destination-specific flows (e.g. Customer.io Audience) have their
+# own typed resources — see retl_connection_customerio_audience.tf.
 resource "rudderstack_retl_connection" "table_to_webhook" {
   source_id      = rudderstack_retl_source_table.users.id
   destination_id = rudderstack_destination_webhook.example.id
@@ -226,36 +227,3 @@ resource "rudderstack_retl_connection" "track_to_webhook_named_column" {
   }
 }
 
-# Customer.io Audience flow — typed `customerio_audience_config` block carries
-# the destination-specific `audience_id`. ForceNew: changes recreate the
-# connection because the API does not accept `destinationConfig` on update.
-# `manual` schedule only runs when triggered explicitly.
-resource "rudderstack_retl_connection" "model_to_customerio_audience" {
-  source_id      = rudderstack_retl_source_model.users_revenue.id
-  destination_id = rudderstack_destination_customerio_audience.example.id
-  sync_behaviour = "mirror"
-
-  schedule {
-    type = "manual"
-  }
-
-  identifiers {
-    from = "email"
-    to   = "email"
-  }
-
-  customerio_audience_config {
-    audience_id = 16
-  }
-
-  sync_settings {
-    sync_logs_config {
-      enabled               = true
-      log_retention_in_days = 30
-      snapshots_to_retain   = 5
-    }
-    failed_keys_config {
-      enable_failed_keys_retry = false
-    }
-  }
-}

--- a/examples/retl_connection.tf
+++ b/examples/retl_connection.tf
@@ -1,0 +1,261 @@
+# JSON Mapper flow — identifiers + per-field mappings, no `object`, no
+# `customerio_audience_config`. `basic` schedule runs every N minutes.
+# `constants` adds static key/value pairs to every synced row (mutable in
+# JSON Mapper; ForceNew in Object Mapping and destination-specific flows).
+resource "rudderstack_retl_connection" "table_to_webhook" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_webhook.example.id
+  enabled        = true
+  sync_behaviour = "full"
+
+  schedule {
+    type          = "basic"
+    every_minutes = 60
+  }
+
+  event {
+    type = "identify"
+  }
+
+  identifiers {
+    from = "email"
+    to   = "user_id"
+  }
+
+  mappings {
+    from = "created_at"
+    to   = "traits.obj.created_at"
+  }
+
+  constants {
+    key   = "context.source"
+    value = "warehouse-users"
+  }
+
+  constants {
+    key   = "context.env"
+    value = "production"
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = false
+    }
+  }
+}
+
+# Object Mapping flow — `object` selects the destination-side object (e.g.
+# "customers" in Customer.io). `cron` schedule fires on a cron expression.
+resource "rudderstack_retl_connection" "table_to_customerio" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_customerio.example.id
+  enabled        = true
+  sync_behaviour = "upsert"
+  object         = "customers"
+
+  schedule {
+    type            = "cron"
+    cron_expression = "0 */6 * * *"
+  }
+
+  identifiers {
+    from = "email"
+    to   = "email"
+  }
+
+  mappings {
+    from = "user_id"
+    to   = "id"
+  }
+
+  mappings {
+    from = "created_at"
+    to   = "created_at"
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = false
+    }
+  }
+}
+
+# Incremental upsert — `cursor_column` makes each sync read only rows whose
+# cursor value is newer than the previous run. Only valid when
+# `sync_behaviour = "upsert"`. ForceNew: changes recreate the connection.
+resource "rudderstack_retl_connection" "table_to_webhook_incremental" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_webhook.example.id
+  enabled        = true
+  sync_behaviour = "upsert"
+  cursor_column  = "updated_at"
+
+  schedule {
+    type          = "basic"
+    every_minutes = 15
+  }
+
+  event {
+    type = "identify"
+  }
+
+  identifiers {
+    from = "user_id"
+    to   = "user_id"
+  }
+
+  mappings {
+    from = "email"
+    to   = "traits.email"
+  }
+
+  mappings {
+    from = "updated_at"
+    to   = "traits.updated_at"
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = true
+    }
+  }
+}
+
+# JSON Mapper with `track` events — each synced row becomes a track call with
+# a fixed event `name`. Use `name_column` instead if the event name should be
+# read from a column in the source.
+resource "rudderstack_retl_connection" "track_to_webhook" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_webhook.example.id
+  enabled        = true
+  sync_behaviour = "full"
+
+  schedule {
+    type = "manual"
+  }
+
+  event {
+    type = "track"
+    name = "user_synced"
+  }
+
+  identifiers {
+    from = "user_id"
+    to   = "userId"
+  }
+
+  mappings {
+    from = "email"
+    to   = "properties.email"
+  }
+
+  mappings {
+    from = "plan"
+    to   = "properties.plan"
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = false
+    }
+  }
+}
+
+# JSON Mapper with `track` events, dynamic event name — `name_column` reads
+# the event name from a column in the source row, so each row can emit a
+# different track event. Mutually exclusive with `name`.
+resource "rudderstack_retl_connection" "track_to_webhook_named_column" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_webhook.example.id
+  enabled        = true
+  sync_behaviour = "full"
+
+  schedule {
+    type = "manual"
+  }
+
+  event {
+    type        = "track"
+    name_column = "event_name"
+  }
+
+  identifiers {
+    from = "user_id"
+    to   = "userId"
+  }
+
+  mappings {
+    from = "email"
+    to   = "properties.email"
+  }
+
+  mappings {
+    from = "plan"
+    to   = "properties.plan"
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = false
+    }
+  }
+}
+
+# Customer.io Audience flow — typed `customerio_audience_config` block carries
+# the destination-specific `audience_id`. ForceNew: changes recreate the
+# connection because the API does not accept `destinationConfig` on update.
+# `manual` schedule only runs when triggered explicitly.
+resource "rudderstack_retl_connection" "model_to_customerio_audience" {
+  source_id      = rudderstack_retl_source_model.users_revenue.id
+  destination_id = rudderstack_destination_customerio_audience.example.id
+  sync_behaviour = "mirror"
+
+  schedule {
+    type = "manual"
+  }
+
+  identifiers {
+    from = "email"
+    to   = "email"
+  }
+
+  customerio_audience_config {
+    audience_id = 16
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = false
+    }
+  }
+}

--- a/examples/retl_connection_customerio_audience.tf
+++ b/examples/retl_connection_customerio_audience.tf
@@ -1,0 +1,31 @@
+# Customer.io Audience flow — destination-specific RETL connection scoped
+# to Customer.io Audience destinations. `audience_id` is a typed top-level
+# field (ForceNew because the Customer.io Audience API does not accept
+# destinationConfig changes on update — bumping audience_id recreates the
+# connection). `manual` schedule only runs when triggered explicitly.
+resource "rudderstack_retl_connection_customerio_audience" "model_to_customerio_audience" {
+  source_id      = rudderstack_retl_source_model.users_revenue.id
+  destination_id = rudderstack_destination_customerio_audience.example.id
+  sync_behaviour = "mirror"
+  audience_id    = 16
+
+  schedule {
+    type = "manual"
+  }
+
+  identifiers {
+    from = "email"
+    to   = "email"
+  }
+
+  sync_settings {
+    sync_logs_config {
+      enabled               = true
+      log_retention_in_days = 30
+      snapshots_to_retain   = 5
+    }
+    failed_keys_config {
+      enable_failed_keys_retry = false
+    }
+  }
+}

--- a/rudderstack/provider.go
+++ b/rudderstack/provider.go
@@ -54,10 +54,11 @@ func New() *schema.Provider {
 
 func resourcesMap() map[string]*schema.Resource {
 	resources := map[string]*schema.Resource{
-		"rudderstack_connection":        resourceConnection(),
-		"rudderstack_retl_source_model": retl.ResourceModel(),
-		"rudderstack_retl_source_table": retl.ResourceTable(),
-		"rudderstack_retl_connection":   retl.ResourceConnection(),
+		"rudderstack_connection":                            resourceConnection(),
+		"rudderstack_retl_source_model":                     retl.ResourceModel(),
+		"rudderstack_retl_source_table":                     retl.ResourceTable(),
+		"rudderstack_retl_connection":                       retl.ResourceConnection(),
+		"rudderstack_retl_connection_customerio_audience":   retl.ResourceConnectionCustomerIOAudience(),
 	}
 
 	// append sources and destinations from integration registries

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -248,9 +248,11 @@ func connectionSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"audience_id": {
-						Type:        schema.TypeInt,
-						Required:    true,
-						Description: "Customer.io audience ID.",
+						Type:         schema.TypeInt,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.IntAtLeast(1),
+						Description:  "Customer.io audience ID (positive integer).",
 					},
 				},
 			},

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -729,8 +730,12 @@ func customerIOAudienceToState(raw json.RawMessage) ([]map[string]interface{}, e
 	if !ok {
 		return nil, fmt.Errorf("destinationConfig audienceId is %T, expected number", v)
 	}
-	// int64(n) is exact for |n| < 2^53 (float64 mantissa). Customer.io audience
-	// IDs are well below that bound in practice.
+	if math.IsNaN(n) || math.IsInf(n, 0) || math.Trunc(n) != n {
+		return nil, fmt.Errorf("destinationConfig audienceId %v is not an integer", n)
+	}
+	// int(n) is exact for |n| < 2^53 (float64 mantissa). Customer.io audience
+	// IDs are well below that bound in practice; the integrality check above
+	// rejects fractional values like 42.5 that would otherwise truncate silently.
 	return []map[string]interface{}{{"audience_id": int(n)}}, nil
 }
 

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -16,21 +14,28 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client/retl"
 )
 
-// ResourceConnection returns the schema for `rudderstack_retl_connection`.
+// ResourceConnection returns the schema for `rudderstack_retl_connection` —
+// the generic resource covering JSON Mapper and Object Mapping flows.
 //
-// Flow detection (JSON Mapper / Object Mapping / Customer.io Audience) happens
-// server-side based on the destination definition; this resource only sends
-// the flat schema and lets the API assemble the internal config. ForceNew on
-// `identifiers` and `constants` is conditional on the detected flow and is
-// applied via CustomizeDiff using the same field-presence signals the API uses.
-// Customer.io Audience is the only destination-specific flow currently exposed
-// as a typed block; other destination-specific flows are not supported.
+// Flow detection (JSON Mapper vs Object Mapping) happens server-side from the
+// destination definition. This resource only sends the flat schema and lets
+// the API assemble the internal config. The `object` attribute distinguishes
+// Object Mapping (set) from JSON Mapper (absent).
+//
+// Destination-specific flows (Customer.io Audience etc.) are intentionally
+// out of scope here. Each destination-specific flow gets its own typed
+// resource (e.g. `rudderstack_retl_connection_customerio_audience`) that
+// exposes the destination's required fields as first-class schema attributes
+// instead of stuffing them into a generic destination_config blob. The
+// generic resource refuses to refresh a connection whose destinationConfig
+// has been populated by a destination-specific flow so users get a clear
+// signal at refresh time to switch to the typed resource.
 func ResourceConnection() *schema.Resource {
 	return &schema.Resource{
-		Description: "A RETL connection between a RETL source and a destination. " +
-			"Flow type (JSON Mapper, Object mapping, Customer.io Audience) is " +
-			"determined by the destination definition.",
-		Schema:        connectionSchema(),
+		Description: "A generic RETL connection between a RETL source and a destination, " +
+			"covering JSON Mapper and Object Mapping flows. Destination-specific flows " +
+			"(e.g. Customer.io Audience) have their own typed resources.",
+		Schema:        genericConnectionSchema(),
 		CreateContext: createConnection,
 		ReadContext:   readConnection,
 		UpdateContext: updateConnection,
@@ -42,148 +47,27 @@ func ResourceConnection() *schema.Resource {
 	}
 }
 
-func connectionSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"source_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
-			Description: "ID of the RETL source.",
-		},
-		"destination_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
-			Description: "ID of the destination.",
-		},
-		"enabled": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     true,
-			Description: "Whether the connection is enabled.",
-		},
-		"schedule": {
-			Type:     schema.TypeList,
-			Required: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"type": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validation.StringInSlice([]string{"basic", "manual", "cron"}, false),
-						Description:  "Schedule type: `basic`, `manual`, or `cron`.",
-					},
-					"every_minutes": {
-						Type:         schema.TypeInt,
-						Optional:     true,
-						ValidateFunc: validation.IntAtLeast(5),
-						Description:  "Sync interval in minutes. Required when `type` is `basic`.",
-					},
-					"cron_expression": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "Cron expression. Required when `type` is `cron`.",
-					},
-				},
-			},
-		},
-		"sync_settings": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"sync_logs_config": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						MaxItems: 1,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"enabled": {
-									Type:     schema.TypeBool,
-									Optional: true,
-									Default:  true,
-								},
-								"log_retention_in_days": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Default:  30,
-								},
-								"snapshots_to_retain": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Default:  5,
-								},
-							},
-						},
-					},
-					"failed_keys_config": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						MaxItems: 1,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"enable_failed_keys_retry": {
-									Type:     schema.TypeBool,
-									Optional: true,
-									Default:  true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"sync_behaviour": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringInSlice([]string{"upsert", "mirror", "full"}, false),
-			Description:  "How records are synced to the destination: `upsert`, `mirror`, or `full`.",
-		},
+// genericConnectionSchema composes the base RETL connection schema with the
+// generic-flow-only fields: `event` (JSON Mapper), `constants`, `cursor_column`,
+// `object` (Object Mapping). The base `identifiers` field is overridden to
+// add ForceNew because JSON Mapper and Object Mapping both treat identifier
+// changes as breaking. `constants` ForceNew is conditional on Object Mapping
+// and is applied in CustomizeDiff (Object Mapping = ForceNew; JSON Mapper =
+// mutable), so the schema declares it without ForceNew.
+func genericConnectionSchema() map[string]*schema.Schema {
+	return mergeSchemas(baseConnectionSchema(), map[string]*schema.Schema{
 		"identifiers": {
 			Type:     schema.TypeList,
 			Required: true,
+			ForceNew: true,
 			MinItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"from": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"to": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
+					"from": {Type: schema.TypeString, ForceNew: true, Required: true},
+					"to":   {Type: schema.TypeString, ForceNew: true, Required: true},
 				},
 			},
-			Description: "Source-to-destination identifier mappings. ForceNew for JSON Mapper " +
-				"and Object Mapping flows; mutable for destination-specific flows.",
-		},
-		"mappings": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"from": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"to": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-			Description: "Source-to-destination field mappings (mutable for all flows).",
+			Description: "Source-to-destination identifier mappings. ForceNew: changes recreate the connection.",
 		},
 		"event": {
 			Type:     schema.TypeList,
@@ -195,38 +79,26 @@ func connectionSchema() map[string]*schema.Schema {
 					"type": {
 						Type:         schema.TypeString,
 						Required:     true,
+						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice([]string{"identify", "track"}, false),
 					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name_column": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
+					"name":        {Type: schema.TypeString, Optional: true, ForceNew: true},
+					"name_column": {Type: schema.TypeString, Optional: true, ForceNew: true},
 				},
 			},
 			Description: "CDP event configuration. Optional in the Terraform schema; flow-specific " +
-				"requirements (required for JSON Mapper, absent for other flows) are enforced by the API.",
+				"requirements (required for JSON Mapper, absent for Object Mapping) are enforced by the API.",
 		},
 		"constants": {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"key": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
+					"key":   {Type: schema.TypeString, Required: true},
+					"value": {Type: schema.TypeString, Required: true},
 				},
 			},
-			Description: "User-defined constants. Mutable for JSON Mapper; ForceNew for Object Mapping " +
-				"and destination-specific flows.",
+			Description: "User-defined constants. Mutable for JSON Mapper; ForceNew for Object Mapping.",
 		},
 		"cursor_column": {
 			Type:        schema.TypeString,
@@ -240,43 +112,13 @@ func connectionSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Destination entity for Object Mapping flows (e.g. `Contact`, `Lead`).",
 		},
-		"customerio_audience_config": {
-			Type:     schema.TypeList,
-			Optional: true,
-			ForceNew: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"audience_id": {
-						Type:         schema.TypeInt,
-						Required:     true,
-						ForceNew:     true,
-						ValidateFunc: validation.IntAtLeast(1),
-						Description:  "Customer.io audience ID (positive integer).",
-					},
-				},
-			},
-			Description: "Typed configuration for Customer.io Audience destinations.",
-		},
-		"created_at": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"updated_at": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-	}
+	})
 }
 
-// customizeConnectionDiff applies flow-dependent ForceNew on `identifiers` and
-// `constants`, and rejects locally-detectable invalid combinations (cursor_column
-// only with sync_behaviour=upsert) so users see the error at plan time instead
-// of on apply.
-//
-// Flow is inferred from the same signals the server uses: `object` set =>
-// Object Mapping, `customerio_audience_config` set => Customer.io Audience
-// (destination-specific), otherwise => JSON Mapper.
+// customizeConnectionDiff applies the Object-Mapping-only `constants` ForceNew
+// and rejects locally-detectable invalid combinations (cursor_column only with
+// sync_behaviour=upsert) so users see the error at plan time instead of on
+// apply.
 func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	if cursor := d.Get("cursor_column").(string); cursor != "" {
 		if sb := d.Get("sync_behaviour").(string); sb != "" && sb != "upsert" {
@@ -289,35 +131,14 @@ func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interf
 		return nil
 	}
 
-	objectSet := d.Get("object").(string) != ""
-	destSpecific := hasCustomerIOAudienceConfig(d)
-
-	identifiersForceNew, constantsForceNew := flowForceNewRules(objectSet, destSpecific)
-
-	if identifiersForceNew && d.HasChange("identifiers") {
-		if err := d.ForceNew("identifiers"); err != nil {
-			return err
-		}
-	}
-	if constantsForceNew && d.HasChange("constants") {
+	// Object Mapping (object set) treats `constants` as immutable; JSON Mapper
+	// allows in-place updates.
+	if d.Get("object").(string) != "" && d.HasChange("constants") {
 		if err := d.ForceNew("constants"); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// flowForceNewRules returns (identifiersForceNew, constantsForceNew) for the
-// detected flow.
-func flowForceNewRules(objectSet, destSpecific bool) (identifiers, constants bool) {
-	switch {
-	case objectSet:
-		return true, true // Object Mapping
-	case destSpecific:
-		return false, true // Destination-specific (Customer.io Audience)
-	default:
-		return true, false // JSON Mapper
-	}
 }
 
 func createConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -356,7 +177,7 @@ func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		return diag.FromErr(fmt.Errorf("could not read RETL connection: %w", err))
 	}
 
-	return diag.FromErr(storeConnectionToState(d, conn))
+	return diag.FromErr(storeGenericConnectionToState(d, conn))
 }
 
 func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -376,6 +197,8 @@ func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 	return readConnection(ctx, d, m)
 }
 
+// deleteConnection deletes any RETL connection (by ID). Shared between the
+// generic and per-destination resources — delete has no flow-specific logic.
 func deleteConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	svc, diags := service(m)
 	if diags.HasError() {
@@ -395,26 +218,9 @@ func deleteConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionRequest, error) {
-	schedule, err := scheduleFromState(d)
-	if err != nil {
+	req := &retl.CreateRETLConnectionRequest{}
+	if err := applyBaseToCreateRequest(d, req); err != nil {
 		return nil, err
-	}
-
-	enabled := d.Get("enabled").(bool)
-	req := &retl.CreateRETLConnectionRequest{
-		SourceID:      d.Get("source_id").(string),
-		DestinationID: d.Get("destination_id").(string),
-		Enabled:       &enabled,
-		Schedule:      schedule,
-		SyncBehaviour: retl.SyncBehaviour(d.Get("sync_behaviour").(string)),
-		Identifiers:   mappingsFromState(d, "identifiers"),
-	}
-
-	if ss, ok := syncSettingsFromState(d); ok {
-		req.SyncSettings = ss
-	}
-	if mappings := mappingsFromState(d, "mappings"); len(mappings) > 0 {
-		req.Mappings = mappings
 	}
 	if event, ok := eventFromState(d); ok {
 		req.Event = event
@@ -428,318 +234,62 @@ func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionReque
 	if v := d.Get("object").(string); v != "" {
 		req.Object = v
 	}
-	if hasCustomerIOAudienceConfig(d) {
-		cfg, err := customerIOAudienceConfigJSON(d)
-		if err != nil {
-			return nil, err
-		}
-		req.DestinationConfig = cfg
-	}
 	return req, nil
 }
 
 func buildUpdateRequest(d *schema.ResourceData) (*retl.UpdateRETLConnectionRequest, error) {
-	schedule, err := scheduleFromState(d)
-	if err != nil {
+	req := &retl.UpdateRETLConnectionRequest{}
+	if err := applyBaseToUpdateRequest(d, req); err != nil {
 		return nil, err
-	}
-	enabled := d.Get("enabled").(bool)
-
-	req := &retl.UpdateRETLConnectionRequest{
-		Enabled:  &enabled,
-		Schedule: schedule,
-	}
-	// Only forward sync_settings when the user actually changed the block.
-	// Otherwise the Optional+Computed field can carry server-computed values
-	// in state and we'd echo them back as if the user had set them.
-	if d.HasChange("sync_settings") {
-		if ss, ok := syncSettingsFromState(d); ok {
-			req.SyncSettings = ss
-		}
-	}
-	if d.HasChange("mappings") {
-		mappings := mappingsFromState(d, "mappings")
-		req.Mappings = &mappings
 	}
 	if d.HasChange("constants") {
 		constants := constantsFromState(d)
 		req.Constants = &constants
 	}
-	if d.HasChange("identifiers") {
-		req.Identifiers = mappingsFromState(d, "identifiers")
-	}
 	return req, nil
 }
 
-func storeConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) error {
-	d.SetId(c.ID)
-	setters := []struct {
-		k string
-		v interface{}
-	}{
-		{"source_id", c.SourceID},
-		{"destination_id", c.DestinationID},
-		{"enabled", c.Enabled},
-		{"sync_behaviour", string(c.SyncBehaviour)},
-		{"schedule", scheduleToState(c.Schedule)},
-		{"sync_settings", syncSettingsToState(c.SyncSettings)},
-		{"identifiers", mappingsToState(c.Identifiers)},
-		{"mappings", mappingsToState(c.Mappings)},
-		{"event", eventToState(c.Event)},
-		{"constants", constantsToState(c.Constants)},
-		{"cursor_column", c.CursorColumn},
-		{"object", c.Object},
-	}
-	for _, s := range setters {
-		if err := d.Set(s.k, s.v); err != nil {
-			return fmt.Errorf("set %s: %w", s.k, err)
-		}
-	}
-
-	// The API returns destinationConfig as JSON for destination-specific flows.
-	// Customer.io Audience is the only typed flow we support; an unsupported
-	// destination-specific connection (imported from elsewhere) surfaces as a
-	// decode error so the user sees a clear "not supported" signal at refresh.
-	if len(c.DestinationConfig) > 0 {
-		typed, err := customerIOAudienceToState(c.DestinationConfig)
-		if err != nil {
-			return err
-		}
-		if err := d.Set("customerio_audience_config", typed); err != nil {
-			return err
-		}
-	} else if err := d.Set("customerio_audience_config", nil); err != nil {
+func storeGenericConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) error {
+	if err := storeBaseConnectionToState(d, c); err != nil {
 		return err
 	}
-	if c.CreatedAt != nil {
-		if err := d.Set("created_at", c.CreatedAt.Format(time.RFC3339)); err != nil {
-			return err
-		}
+	if err := d.Set("event", eventToState(c.Event)); err != nil {
+		return fmt.Errorf("set event: %w", err)
 	}
-	if c.UpdatedAt != nil {
-		if err := d.Set("updated_at", c.UpdatedAt.Format(time.RFC3339)); err != nil {
-			return err
+	if err := d.Set("constants", constantsToState(c.Constants)); err != nil {
+		return fmt.Errorf("set constants: %w", err)
+	}
+	if err := d.Set("cursor_column", c.CursorColumn); err != nil {
+		return fmt.Errorf("set cursor_column: %w", err)
+	}
+	if err := d.Set("object", c.Object); err != nil {
+		return fmt.Errorf("set object: %w", err)
+	}
+
+	// The API returns destinationConfig as a non-empty JSON payload only for
+	// destination-specific flows. The generic resource does not represent
+	// those — fail loudly at refresh so the user knows to switch resources
+	// rather than silently dropping config from state. JSON `null` is the
+	// server's way of saying "no destination-specific config" — treat it as a
+	// no-op.
+	if len(c.DestinationConfig) > 0 {
+		var parsed any
+		if err := json.Unmarshal(c.DestinationConfig, &parsed); err != nil {
+			return fmt.Errorf("decode destinationConfig: %w", err)
+		}
+		if parsed != nil {
+			return fmt.Errorf(
+				"connection has destination-specific configuration (destinationConfig=%s); "+
+					"the generic rudderstack_retl_connection resource does not represent destination-specific flows. "+
+					"Use a typed resource such as rudderstack_retl_connection_customerio_audience instead.",
+				c.DestinationConfig,
+			)
 		}
 	}
 	return nil
 }
 
-// --- per-block helpers ---
-
-func scheduleFromState(d *schema.ResourceData) (retl.Schedule, error) {
-	raw, ok := d.Get("schedule").([]interface{})
-	if !ok || len(raw) == 0 || raw[0] == nil {
-		return retl.Schedule{}, fmt.Errorf("schedule block is required")
-	}
-	m := raw[0].(map[string]interface{})
-	s := retl.Schedule{Type: retl.ScheduleType(m["type"].(string))}
-	if v, ok := m["every_minutes"].(int); ok && v > 0 {
-		s.EveryMinutes = &v
-	}
-	if v, _ := m["cron_expression"].(string); v != "" {
-		s.CronExpression = &v
-	}
-	if s.Type == retl.ScheduleTypeBasic && s.EveryMinutes == nil {
-		return retl.Schedule{}, fmt.Errorf("schedule.every_minutes is required when schedule.type is %q", s.Type)
-	}
-	if s.Type == retl.ScheduleTypeCron && s.CronExpression == nil {
-		return retl.Schedule{}, fmt.Errorf("schedule.cron_expression is required when schedule.type is %q", s.Type)
-	}
-	return s, nil
-}
-
-func scheduleToState(s retl.Schedule) []map[string]interface{} {
-	m := map[string]interface{}{"type": string(s.Type)}
-	if s.EveryMinutes != nil {
-		m["every_minutes"] = *s.EveryMinutes
-	}
-	if s.CronExpression != nil {
-		m["cron_expression"] = *s.CronExpression
-	}
-	return []map[string]interface{}{m}
-}
-
-func syncSettingsFromState(d *schema.ResourceData) (*retl.SyncSettings, bool) {
-	raw, ok := d.Get("sync_settings").([]interface{})
-	if !ok || len(raw) == 0 || raw[0] == nil {
-		return nil, false
-	}
-	m := raw[0].(map[string]interface{})
-	ss := &retl.SyncSettings{}
-
-	if logs, ok := m["sync_logs_config"].([]interface{}); ok && len(logs) > 0 && logs[0] != nil {
-		lm := logs[0].(map[string]interface{})
-		cfg := &retl.SyncLogsConfig{}
-		if v, ok := lm["enabled"].(bool); ok {
-			cfg.Enabled = &v
-		}
-		if v, ok := lm["log_retention_in_days"].(int); ok && v > 0 {
-			cfg.LogRetentionInDays = &v
-		}
-		if v, ok := lm["snapshots_to_retain"].(int); ok && v > 0 {
-			cfg.SnapshotsToRetain = &v
-		}
-		ss.SyncLogsConfig = cfg
-	}
-	if fk, ok := m["failed_keys_config"].([]interface{}); ok && len(fk) > 0 && fk[0] != nil {
-		fkm := fk[0].(map[string]interface{})
-		cfg := &retl.FailedKeysConfig{}
-		if v, ok := fkm["enable_failed_keys_retry"].(bool); ok {
-			cfg.EnableFailedKeysRetry = &v
-		}
-		ss.FailedKeysConfig = cfg
-	}
-	// Empty sync_settings {} block (or one with empty sub-blocks) carries
-	// nothing useful — treat it as "not set" so callers can omit the field.
-	if ss.SyncLogsConfig == nil && ss.FailedKeysConfig == nil {
-		return nil, false
-	}
-	return ss, true
-}
-
-func syncSettingsToState(ss *retl.SyncSettings) []map[string]interface{} {
-	if ss == nil {
-		return nil
-	}
-	out := map[string]interface{}{}
-	if ss.SyncLogsConfig != nil {
-		lm := map[string]interface{}{}
-		if ss.SyncLogsConfig.Enabled != nil {
-			lm["enabled"] = *ss.SyncLogsConfig.Enabled
-		}
-		if ss.SyncLogsConfig.LogRetentionInDays != nil {
-			lm["log_retention_in_days"] = *ss.SyncLogsConfig.LogRetentionInDays
-		}
-		if ss.SyncLogsConfig.SnapshotsToRetain != nil {
-			lm["snapshots_to_retain"] = *ss.SyncLogsConfig.SnapshotsToRetain
-		}
-		out["sync_logs_config"] = []map[string]interface{}{lm}
-	}
-	if ss.FailedKeysConfig != nil {
-		fkm := map[string]interface{}{}
-		if ss.FailedKeysConfig.EnableFailedKeysRetry != nil {
-			fkm["enable_failed_keys_retry"] = *ss.FailedKeysConfig.EnableFailedKeysRetry
-		}
-		out["failed_keys_config"] = []map[string]interface{}{fkm}
-	}
-	return []map[string]interface{}{out}
-}
-
-func mappingsFromState(d *schema.ResourceData, key string) []retl.Mapping {
-	raw, _ := d.Get(key).([]interface{})
-	out := make([]retl.Mapping, 0, len(raw))
-	for _, item := range raw {
-		m := item.(map[string]interface{})
-		out = append(out, retl.Mapping{
-			From: m["from"].(string),
-			To:   m["to"].(string),
-		})
-	}
-	return out
-}
-
-func mappingsToState(ms []retl.Mapping) []map[string]interface{} {
-	if len(ms) == 0 {
-		return nil
-	}
-	out := make([]map[string]interface{}, 0, len(ms))
-	for _, m := range ms {
-		out = append(out, map[string]interface{}{"from": m.From, "to": m.To})
-	}
-	return out
-}
-
-func constantsFromState(d *schema.ResourceData) []retl.Constant {
-	raw, _ := d.Get("constants").([]interface{})
-	out := make([]retl.Constant, 0, len(raw))
-	for _, item := range raw {
-		m := item.(map[string]interface{})
-		out = append(out, retl.Constant{
-			Key:   m["key"].(string),
-			Value: m["value"].(string),
-		})
-	}
-	return out
-}
-
-func constantsToState(cs []retl.Constant) []map[string]interface{} {
-	if len(cs) == 0 {
-		return nil
-	}
-	out := make([]map[string]interface{}, 0, len(cs))
-	for _, c := range cs {
-		out = append(out, map[string]interface{}{"key": c.Key, "value": c.Value})
-	}
-	return out
-}
-
-// hasCustomerIOAudienceConfig reports whether the `customerio_audience_config`
-// block is populated in state. Used both by flow detection in CustomizeDiff
-// and by the read path to decide where to route the server's destinationConfig.
-func hasCustomerIOAudienceConfig(d resourceGetter) bool {
-	raw, ok := d.Get("customerio_audience_config").([]interface{})
-	return ok && len(raw) > 0 && raw[0] != nil
-}
-
-// resourceGetter is the subset of *schema.ResourceData / *schema.ResourceDiff
-// used by helpers that need to read state without caring which one they got.
-type resourceGetter interface {
-	Get(string) interface{}
-}
-
-// customerIOAudienceConfigJSON packs the typed customerio_audience_config
-// block into the destinationConfig JSON shape the API expects.
-// Caller must check hasCustomerIOAudienceConfig(d) first.
-func customerIOAudienceConfigJSON(d *schema.ResourceData) (json.RawMessage, error) {
-	raw := d.Get("customerio_audience_config").([]interface{})
-	m := raw[0].(map[string]interface{})
-	audienceID, ok := m["audience_id"].(int)
-	if !ok {
-		// Defensive: schema declares audience_id as TypeInt so the SDK should
-		// always hand us an int. Surface the divergence loudly rather than
-		// silently POST `{"audienceId": 0}`.
-		return nil, fmt.Errorf("customerio_audience_config.audience_id has unexpected type %T", m["audience_id"])
-	}
-	out, err := json.Marshal(map[string]any{"audienceId": audienceID})
-	if err != nil {
-		return nil, fmt.Errorf("encode customerio_audience_config: %w", err)
-	}
-	return out, nil
-}
-
-// customerIOAudienceToState decodes a Customer.io Audience destinationConfig
-// JSON blob into the typed block shape expected by d.Set. Returns (nil, nil)
-// when the payload is JSON null — that's the server's way of saying "no
-// destination-specific config", not an error. Returns an error when the blob
-// is a non-null shape without a numeric `audienceId` — that signals an
-// unsupported destination-specific connection (e.g. imported from a
-// destination that isn't Customer.io Audience), which this resource does not
-// represent.
-func customerIOAudienceToState(raw json.RawMessage) ([]map[string]interface{}, error) {
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return nil, fmt.Errorf("decode customerio_audience destinationConfig: %w", err)
-	}
-	if parsed == nil {
-		// JSON `null` unmarshalls into a nil map — treat as "no typed block".
-		return nil, nil
-	}
-	v, ok := parsed["audienceId"]
-	if !ok {
-		return nil, fmt.Errorf("destinationConfig has no audienceId — only Customer.io Audience destination-specific connections are supported")
-	}
-	n, ok := v.(float64) // json.Unmarshal decodes JSON numbers as float64
-	if !ok {
-		return nil, fmt.Errorf("destinationConfig audienceId is %T, expected number", v)
-	}
-	if math.IsNaN(n) || math.IsInf(n, 0) || math.Trunc(n) != n {
-		return nil, fmt.Errorf("destinationConfig audienceId %v is not an integer", n)
-	}
-	// int(n) is exact for |n| < 2^53 (float64 mantissa). Customer.io audience
-	// IDs are well below that bound in practice; the integrality check above
-	// rejects fractional values like 42.5 that would otherwise truncate silently.
-	return []map[string]interface{}{{"audience_id": int(n)}}, nil
-}
+// --- per-block helpers specific to the generic resource ---
 
 func eventFromState(d *schema.ResourceData) (*retl.Event, bool) {
 	raw, ok := d.Get("event").([]interface{})
@@ -769,4 +319,28 @@ func eventToState(e *retl.Event) []map[string]interface{} {
 		m["name_column"] = e.NameColumn
 	}
 	return []map[string]interface{}{m}
+}
+
+func constantsFromState(d *schema.ResourceData) []retl.Constant {
+	raw, _ := d.Get("constants").([]interface{})
+	out := make([]retl.Constant, 0, len(raw))
+	for _, item := range raw {
+		m := item.(map[string]interface{})
+		out = append(out, retl.Constant{
+			Key:   m["key"].(string),
+			Value: m["value"].(string),
+		})
+	}
+	return out
+}
+
+func constantsToState(cs []retl.Constant) []map[string]interface{} {
+	if len(cs) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, map[string]interface{}{"key": c.Key, "value": c.Value})
+	}
+	return out
 }

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -18,15 +17,17 @@ import (
 
 // ResourceConnection returns the schema for `rudderstack_retl_connection`.
 //
-// Flow detection (JSON Mapper / Object Mapping / Destination-specific) happens
+// Flow detection (JSON Mapper / Object Mapping / Customer.io Audience) happens
 // server-side based on the destination definition; this resource only sends
 // the flat schema and lets the API assemble the internal config. ForceNew on
 // `identifiers` and `constants` is conditional on the detected flow and is
 // applied via CustomizeDiff using the same field-presence signals the API uses.
+// Customer.io Audience is the only destination-specific flow currently exposed
+// as a typed block; other destination-specific flows are not supported.
 func ResourceConnection() *schema.Resource {
 	return &schema.Resource{
 		Description: "A RETL connection between a RETL source and a destination. " +
-			"Flow type (JSON Mapper, Object mapping, Destination-specific) is " +
+			"Flow type (JSON Mapper, Object mapping, Customer.io Audience) is " +
 			"determined by the destination definition.",
 		Schema:        connectionSchema(),
 		CreateContext: createConnection,
@@ -238,14 +239,21 @@ func connectionSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Destination entity for Object Mapping flows (e.g. `Contact`, `Lead`).",
 		},
-		"destination_config": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ForceNew:         true,
-			ValidateFunc:     validation.StringIsJSON,
-			StateFunc:        normalizeJSON,
-			DiffSuppressFunc: suppressEquivalentJSON,
-			Description:      "Destination-specific configuration as a JSON-encoded string.",
+		"customerio_audience_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"audience_id": {
+						Type:        schema.TypeInt,
+						Required:    true,
+						Description: "Customer.io audience ID.",
+					},
+				},
+			},
+			Description: "Typed configuration for Customer.io Audience destinations.",
 		},
 		"created_at": {
 			Type:     schema.TypeString,
@@ -264,8 +272,8 @@ func connectionSchema() map[string]*schema.Schema {
 // of on apply.
 //
 // Flow is inferred from the same signals the server uses: `object` set =>
-// Object Mapping, `destination_config` set => Destination-specific, otherwise
-// => JSON Mapper.
+// Object Mapping, `customerio_audience_config` set => Customer.io Audience
+// (destination-specific), otherwise => JSON Mapper.
 func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	if cursor := d.Get("cursor_column").(string); cursor != "" {
 		if sb := d.Get("sync_behaviour").(string); sb != "" && sb != "upsert" {
@@ -279,9 +287,9 @@ func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interf
 	}
 
 	objectSet := d.Get("object").(string) != ""
-	destConfigSet := d.Get("destination_config").(string) != ""
+	destSpecific := hasCustomerIOAudienceConfig(d)
 
-	identifiersForceNew, constantsForceNew := flowForceNewRules(objectSet, destConfigSet)
+	identifiersForceNew, constantsForceNew := flowForceNewRules(objectSet, destSpecific)
 
 	if identifiersForceNew && d.HasChange("identifiers") {
 		if err := d.ForceNew("identifiers"); err != nil {
@@ -298,12 +306,12 @@ func customizeConnectionDiff(_ context.Context, d *schema.ResourceDiff, _ interf
 
 // flowForceNewRules returns (identifiersForceNew, constantsForceNew) for the
 // detected flow.
-func flowForceNewRules(objectSet, destConfigSet bool) (identifiers, constants bool) {
+func flowForceNewRules(objectSet, destSpecific bool) (identifiers, constants bool) {
 	switch {
 	case objectSet:
 		return true, true // Object Mapping
-	case destConfigSet:
-		return false, true // Destination-specific
+	case destSpecific:
+		return false, true // Destination-specific (Customer.io Audience)
 	default:
 		return true, false // JSON Mapper
 	}
@@ -417,8 +425,12 @@ func buildCreateRequest(d *schema.ResourceData) (*retl.CreateRETLConnectionReque
 	if v := d.Get("object").(string); v != "" {
 		req.Object = v
 	}
-	if v := d.Get("destination_config").(string); v != "" {
-		req.DestinationConfig = json.RawMessage(v)
+	if hasCustomerIOAudienceConfig(d) {
+		cfg, err := customerIOAudienceConfigJSON(d)
+		if err != nil {
+			return nil, err
+		}
+		req.DestinationConfig = cfg
 	}
 	return req, nil
 }
@@ -481,10 +493,19 @@ func storeConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) erro
 		}
 	}
 
-	// Always set, even when empty, so state can be cleared if the server
-	// returns an empty value (otherwise Terraform would see perpetual diffs
-	// against the stale local value).
-	if err := d.Set("destination_config", string(c.DestinationConfig)); err != nil {
+	// The API returns destinationConfig as JSON for destination-specific flows.
+	// Customer.io Audience is the only typed flow we support; an unsupported
+	// destination-specific connection (imported from elsewhere) surfaces as a
+	// decode error so the user sees a clear "not supported" signal at refresh.
+	if len(c.DestinationConfig) > 0 {
+		typed, err := customerIOAudienceToState(c.DestinationConfig)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("customerio_audience_config", typed); err != nil {
+			return err
+		}
+	} else if err := d.Set("customerio_audience_config", nil); err != nil {
 		return err
 	}
 	if c.CreatedAt != nil {
@@ -649,40 +670,68 @@ func constantsToState(cs []retl.Constant) []map[string]interface{} {
 	return out
 }
 
-// normalizeJSON returns a canonical encoding of the input JSON (sorted keys,
-// no extraneous whitespace). Returns the input unchanged if it isn't valid
-// JSON — validation.StringIsJSON catches that path separately.
-func normalizeJSON(v interface{}) string {
-	s, ok := v.(string)
-	if !ok || s == "" {
-		return ""
-	}
-	var parsed interface{}
-	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
-		return s
-	}
-	out, err := json.Marshal(parsed)
-	if err != nil {
-		return s
-	}
-	return string(out)
+// hasCustomerIOAudienceConfig reports whether the `customerio_audience_config`
+// block is populated in state. Used both by flow detection in CustomizeDiff
+// and by the read path to decide where to route the server's destinationConfig.
+func hasCustomerIOAudienceConfig(d resourceGetter) bool {
+	raw, ok := d.Get("customerio_audience_config").([]interface{})
+	return ok && len(raw) > 0 && raw[0] != nil
 }
 
-// suppressEquivalentJSON returns true when two JSON strings are semantically
-// equal, so reformatting from the API (key ordering, whitespace, null vs "")
-// does not produce a perpetual diff.
-func suppressEquivalentJSON(_, oldVal, newVal string, _ *schema.ResourceData) bool {
-	if oldVal == newVal {
-		return true
+// resourceGetter is the subset of *schema.ResourceData / *schema.ResourceDiff
+// used by helpers that need to read state without caring which one they got.
+type resourceGetter interface {
+	Get(string) interface{}
+}
+
+// customerIOAudienceConfigJSON packs the typed customerio_audience_config
+// block into the destinationConfig JSON shape the API expects.
+// Caller must check hasCustomerIOAudienceConfig(d) first.
+func customerIOAudienceConfigJSON(d *schema.ResourceData) (json.RawMessage, error) {
+	raw := d.Get("customerio_audience_config").([]interface{})
+	m := raw[0].(map[string]interface{})
+	audienceID, ok := m["audience_id"].(int)
+	if !ok {
+		// Defensive: schema declares audience_id as TypeInt so the SDK should
+		// always hand us an int. Surface the divergence loudly rather than
+		// silently POST `{"audienceId": 0}`.
+		return nil, fmt.Errorf("customerio_audience_config.audience_id has unexpected type %T", m["audience_id"])
 	}
-	var o, n interface{}
-	if err := json.Unmarshal([]byte(oldVal), &o); err != nil {
-		return false
+	out, err := json.Marshal(map[string]any{"audienceId": audienceID})
+	if err != nil {
+		return nil, fmt.Errorf("encode customerio_audience_config: %w", err)
 	}
-	if err := json.Unmarshal([]byte(newVal), &n); err != nil {
-		return false
+	return out, nil
+}
+
+// customerIOAudienceToState decodes a Customer.io Audience destinationConfig
+// JSON blob into the typed block shape expected by d.Set. Returns (nil, nil)
+// when the payload is JSON null — that's the server's way of saying "no
+// destination-specific config", not an error. Returns an error when the blob
+// is a non-null shape without a numeric `audienceId` — that signals an
+// unsupported destination-specific connection (e.g. imported from a
+// destination that isn't Customer.io Audience), which this resource does not
+// represent.
+func customerIOAudienceToState(raw json.RawMessage) ([]map[string]interface{}, error) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("decode customerio_audience destinationConfig: %w", err)
 	}
-	return reflect.DeepEqual(o, n)
+	if parsed == nil {
+		// JSON `null` unmarshalls into a nil map — treat as "no typed block".
+		return nil, nil
+	}
+	v, ok := parsed["audienceId"]
+	if !ok {
+		return nil, fmt.Errorf("destinationConfig has no audienceId — only Customer.io Audience destination-specific connections are supported")
+	}
+	n, ok := v.(float64) // json.Unmarshal decodes JSON numbers as float64
+	if !ok {
+		return nil, fmt.Errorf("destinationConfig audienceId is %T, expected number", v)
+	}
+	// int64(n) is exact for |n| < 2^53 (float64 mantissa). Customer.io audience
+	// IDs are well below that bound in practice.
+	return []map[string]interface{}{{"audience_id": int(n)}}, nil
 }
 
 func eventFromState(d *schema.ResourceData) (*retl.Event, bool) {

--- a/rudderstack/retl/connection.go
+++ b/rudderstack/retl/connection.go
@@ -49,26 +49,13 @@ func ResourceConnection() *schema.Resource {
 
 // genericConnectionSchema composes the base RETL connection schema with the
 // generic-flow-only fields: `event` (JSON Mapper), `constants`, `cursor_column`,
-// `object` (Object Mapping). The base `identifiers` field is overridden to
-// add ForceNew because JSON Mapper and Object Mapping both treat identifier
-// changes as breaking. `constants` ForceNew is conditional on Object Mapping
-// and is applied in CustomizeDiff (Object Mapping = ForceNew; JSON Mapper =
-// mutable), so the schema declares it without ForceNew.
+// `object` (Object Mapping). Identifiers ForceNew lives in the base schema
+// because every flow treats identifier changes as breaking.
+// `constants` ForceNew is conditional on Object Mapping and is applied in
+// CustomizeDiff (Object Mapping = ForceNew; JSON Mapper = mutable), so the
+// schema declares it without ForceNew.
 func genericConnectionSchema() map[string]*schema.Schema {
 	return mergeSchemas(baseConnectionSchema(), map[string]*schema.Schema{
-		"identifiers": {
-			Type:     schema.TypeList,
-			Required: true,
-			ForceNew: true,
-			MinItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"from": {Type: schema.TypeString, ForceNew: true, Required: true},
-					"to":   {Type: schema.TypeString, ForceNew: true, Required: true},
-				},
-			},
-			Description: "Source-to-destination identifier mappings. ForceNew: changes recreate the connection.",
-		},
 		"event": {
 			Type:     schema.TypeList,
 			Optional: true,
@@ -272,6 +259,10 @@ func storeGenericConnectionToState(d *schema.ResourceData, c *retl.RETLConnectio
 	// rather than silently dropping config from state. JSON `null` is the
 	// server's way of saying "no destination-specific config" — treat it as a
 	// no-op.
+	//
+	// The payload itself is not echoed into the error: destinationConfig can
+	// carry credentials for destination-specific flows we haven't yet typed
+	// (e.g. API keys), and Terraform diagnostics surface in CI logs.
 	if len(c.DestinationConfig) > 0 {
 		var parsed any
 		if err := json.Unmarshal(c.DestinationConfig, &parsed); err != nil {
@@ -279,10 +270,10 @@ func storeGenericConnectionToState(d *schema.ResourceData, c *retl.RETLConnectio
 		}
 		if parsed != nil {
 			return fmt.Errorf(
-				"connection has destination-specific configuration (destinationConfig=%s); "+
+				"connection %q has destination-specific configuration (destinationConfig is %d bytes); "+
 					"the generic rudderstack_retl_connection resource does not represent destination-specific flows. "+
 					"Use a typed resource such as rudderstack_retl_connection_customerio_audience instead.",
-				c.DestinationConfig,
+				c.ID, len(c.DestinationConfig),
 			)
 		}
 	}

--- a/rudderstack/retl/connection_base.go
+++ b/rudderstack/retl/connection_base.go
@@ -19,10 +19,10 @@ import (
 // rudderstack_retl_connection_customerio_audience) merges its own
 // destination-specific fields onto this base via mergeSchemas.
 //
-// Identifiers are declared here without ForceNew because whether identifiers
-// trigger a recreate depends on the destination flow — JSON Mapper / Object
-// Mapping treats them as immutable, destination-specific flows let them
-// change. Per-resource schemas tighten or relax this in their own mergeSchemas.
+// Identifiers are ForceNew at both the top level (catches list-size changes)
+// and the nested from/to attributes (catches in-place value mutations). This
+// applies uniformly across all flows — every RETL flow treats identifier
+// changes as breaking and requires a new connection.
 func baseConnectionSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"id": {
@@ -133,16 +133,19 @@ func baseConnectionSchema() map[string]*schema.Schema {
 		"identifiers": {
 			Type:     schema.TypeList,
 			Required: true,
+			ForceNew: true,
 			MinItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
+					// Nested ForceNew is required: the top-level ForceNew on a
+					// TypeList triggers replacement only on list-size changes
+					// (add/remove), not when an existing element's value
+					// mutates in place.
 					"from": {Type: schema.TypeString, Required: true, ForceNew: true},
 					"to":   {Type: schema.TypeString, Required: true, ForceNew: true},
 				},
 			},
-			Description: "Source-to-destination identifier mappings. Each per-flow resource " +
-				"decides whether changes recreate the connection (JSON Mapper / Object Mapping) " +
-				"or update in place (destination-specific flows).",
+			Description: "Source-to-destination identifier mappings. ForceNew: any change recreates the connection.",
 		},
 		"mappings": {
 			Type:     schema.TypeList,
@@ -230,9 +233,9 @@ func applyBaseToUpdateRequest(d *schema.ResourceData, req *retl.UpdateRETLConnec
 		mappings := mappingsFromState(d, "mappings")
 		req.Mappings = &mappings
 	}
-	if d.HasChange("identifiers") {
-		req.Identifiers = mappingsFromState(d, "identifiers")
-	}
+	// Identifiers are ForceNew across all flows (see baseConnectionSchema),
+	// so HasChange("identifiers") never fires on Update — terraform routes
+	// identifier changes through destroy + create instead.
 	return nil
 }
 

--- a/rudderstack/retl/connection_base.go
+++ b/rudderstack/retl/connection_base.go
@@ -1,0 +1,398 @@
+package retl
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/rudderlabs/rudder-iac/api/client/retl"
+)
+
+// baseConnectionSchema returns the fields shared by every
+// rudderstack_retl_connection_* resource: the universal source / destination /
+// schedule / sync fields, but NOT destination-flow-specific fields like
+// `event`, `cursor_column`, `object`, or `audience_id`. Each per-flow
+// resource (the generic JSON Mapper / Object Mapping resource and any typed
+// destination-scoped resource such as
+// rudderstack_retl_connection_customerio_audience) merges its own
+// destination-specific fields onto this base via mergeSchemas.
+//
+// Identifiers are declared here without ForceNew because whether identifiers
+// trigger a recreate depends on the destination flow — JSON Mapper / Object
+// Mapping treats them as immutable, destination-specific flows let them
+// change. Per-resource schemas tighten or relax this in their own mergeSchemas.
+func baseConnectionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"source_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "ID of the RETL source.",
+		},
+		"destination_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "ID of the destination.",
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Whether the connection is enabled.",
+		},
+		"schedule": {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"basic", "manual", "cron"}, false),
+						Description:  "Schedule type: `basic`, `manual`, or `cron`.",
+					},
+					"every_minutes": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(5),
+						Description:  "Sync interval in minutes. Required when `type` is `basic`.",
+					},
+					"cron_expression": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Cron expression. Required when `type` is `cron`.",
+					},
+				},
+			},
+		},
+		"sync_settings": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"sync_logs_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"enabled": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
+								},
+								"log_retention_in_days": {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  30,
+								},
+								"snapshots_to_retain": {
+									Type:     schema.TypeInt,
+									Optional: true,
+									Default:  5,
+								},
+							},
+						},
+					},
+					"failed_keys_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"enable_failed_keys_retry": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"sync_behaviour": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice([]string{"upsert", "mirror", "full"}, false),
+			Description:  "How records are synced to the destination: `upsert`, `mirror`, or `full`.",
+		},
+		"identifiers": {
+			Type:     schema.TypeList,
+			Required: true,
+			MinItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {Type: schema.TypeString, Required: true, ForceNew: true},
+					"to":   {Type: schema.TypeString, Required: true, ForceNew: true},
+				},
+			},
+			Description: "Source-to-destination identifier mappings. Each per-flow resource " +
+				"decides whether changes recreate the connection (JSON Mapper / Object Mapping) " +
+				"or update in place (destination-specific flows).",
+		},
+		"mappings": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"from": {Type: schema.TypeString, Required: true},
+					"to":   {Type: schema.TypeString, Required: true},
+				},
+			},
+			Description: "Source-to-destination field mappings (mutable).",
+		},
+		"created_at": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"updated_at": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+// mergeSchemas combines a base map with overrides. Overrides win on key
+// conflict — typed resources can replace a base field (e.g. tighten
+// `identifiers` to ForceNew, or relax an unsupported field).
+func mergeSchemas(base, override map[string]*schema.Schema) map[string]*schema.Schema {
+	out := make(map[string]*schema.Schema, len(base)+len(override))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range override {
+		out[k] = v
+	}
+	return out
+}
+
+// applyBaseToCreateRequest populates the universal fields of a
+// CreateRETLConnectionRequest from terraform state. Destination-flow-specific
+// fields (Event, Constants, CursorColumn, Object, DestinationConfig) are the
+// caller's responsibility.
+func applyBaseToCreateRequest(d *schema.ResourceData, req *retl.CreateRETLConnectionRequest) error {
+	schedule, err := scheduleFromState(d)
+	if err != nil {
+		return err
+	}
+	enabled := d.Get("enabled").(bool)
+	req.SourceID = d.Get("source_id").(string)
+	req.DestinationID = d.Get("destination_id").(string)
+	req.Enabled = &enabled
+	req.Schedule = schedule
+	req.SyncBehaviour = retl.SyncBehaviour(d.Get("sync_behaviour").(string))
+	req.Identifiers = mappingsFromState(d, "identifiers")
+
+	if ss, ok := syncSettingsFromState(d); ok {
+		req.SyncSettings = ss
+	}
+	if mappings := mappingsFromState(d, "mappings"); len(mappings) > 0 {
+		req.Mappings = mappings
+	}
+	return nil
+}
+
+// applyBaseToUpdateRequest populates the universal fields of an
+// UpdateRETLConnectionRequest from terraform state, respecting d.HasChange so
+// unchanged fields stay nil and don't get echoed back to the API.
+func applyBaseToUpdateRequest(d *schema.ResourceData, req *retl.UpdateRETLConnectionRequest) error {
+	schedule, err := scheduleFromState(d)
+	if err != nil {
+		return err
+	}
+	enabled := d.Get("enabled").(bool)
+	req.Enabled = &enabled
+	req.Schedule = schedule
+
+	// Only forward sync_settings when the user actually changed the block.
+	// Otherwise the Optional+Computed field can carry server-computed values
+	// in state and we'd echo them back as if the user had set them.
+	if d.HasChange("sync_settings") {
+		if ss, ok := syncSettingsFromState(d); ok {
+			req.SyncSettings = ss
+		}
+	}
+	if d.HasChange("mappings") {
+		mappings := mappingsFromState(d, "mappings")
+		req.Mappings = &mappings
+	}
+	if d.HasChange("identifiers") {
+		req.Identifiers = mappingsFromState(d, "identifiers")
+	}
+	return nil
+}
+
+// storeBaseConnectionToState writes the universal fields back to terraform
+// state. Destination-flow-specific fields (event, constants, cursor_column,
+// object, audience_id, ...) are written by the caller after this returns.
+func storeBaseConnectionToState(d *schema.ResourceData, c *retl.RETLConnection) error {
+	d.SetId(c.ID)
+	setters := []struct {
+		k string
+		v interface{}
+	}{
+		{"source_id", c.SourceID},
+		{"destination_id", c.DestinationID},
+		{"enabled", c.Enabled},
+		{"sync_behaviour", string(c.SyncBehaviour)},
+		{"schedule", scheduleToState(c.Schedule)},
+		{"sync_settings", syncSettingsToState(c.SyncSettings)},
+		{"identifiers", mappingsToState(c.Identifiers)},
+		{"mappings", mappingsToState(c.Mappings)},
+	}
+	for _, s := range setters {
+		if err := d.Set(s.k, s.v); err != nil {
+			return fmt.Errorf("set %s: %w", s.k, err)
+		}
+	}
+	if c.CreatedAt != nil {
+		if err := d.Set("created_at", c.CreatedAt.Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+	if c.UpdatedAt != nil {
+		if err := d.Set("updated_at", c.UpdatedAt.Format(time.RFC3339)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- per-block helpers (shared by all retl connection resources) ---
+
+func scheduleFromState(d *schema.ResourceData) (retl.Schedule, error) {
+	raw, ok := d.Get("schedule").([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return retl.Schedule{}, fmt.Errorf("schedule block is required")
+	}
+	m := raw[0].(map[string]interface{})
+	s := retl.Schedule{Type: retl.ScheduleType(m["type"].(string))}
+	if v, ok := m["every_minutes"].(int); ok && v > 0 {
+		s.EveryMinutes = &v
+	}
+	if v, _ := m["cron_expression"].(string); v != "" {
+		s.CronExpression = &v
+	}
+	if s.Type == retl.ScheduleTypeBasic && s.EveryMinutes == nil {
+		return retl.Schedule{}, fmt.Errorf("schedule.every_minutes is required when schedule.type is %q", s.Type)
+	}
+	if s.Type == retl.ScheduleTypeCron && s.CronExpression == nil {
+		return retl.Schedule{}, fmt.Errorf("schedule.cron_expression is required when schedule.type is %q", s.Type)
+	}
+	return s, nil
+}
+
+func scheduleToState(s retl.Schedule) []map[string]interface{} {
+	m := map[string]interface{}{"type": string(s.Type)}
+	if s.EveryMinutes != nil {
+		m["every_minutes"] = *s.EveryMinutes
+	}
+	if s.CronExpression != nil {
+		m["cron_expression"] = *s.CronExpression
+	}
+	return []map[string]interface{}{m}
+}
+
+func syncSettingsFromState(d *schema.ResourceData) (*retl.SyncSettings, bool) {
+	raw, ok := d.Get("sync_settings").([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return nil, false
+	}
+	m := raw[0].(map[string]interface{})
+	ss := &retl.SyncSettings{}
+
+	if logs, ok := m["sync_logs_config"].([]interface{}); ok && len(logs) > 0 && logs[0] != nil {
+		lm := logs[0].(map[string]interface{})
+		cfg := &retl.SyncLogsConfig{}
+		if v, ok := lm["enabled"].(bool); ok {
+			cfg.Enabled = &v
+		}
+		if v, ok := lm["log_retention_in_days"].(int); ok && v > 0 {
+			cfg.LogRetentionInDays = &v
+		}
+		if v, ok := lm["snapshots_to_retain"].(int); ok && v > 0 {
+			cfg.SnapshotsToRetain = &v
+		}
+		ss.SyncLogsConfig = cfg
+	}
+	if fk, ok := m["failed_keys_config"].([]interface{}); ok && len(fk) > 0 && fk[0] != nil {
+		fkm := fk[0].(map[string]interface{})
+		cfg := &retl.FailedKeysConfig{}
+		if v, ok := fkm["enable_failed_keys_retry"].(bool); ok {
+			cfg.EnableFailedKeysRetry = &v
+		}
+		ss.FailedKeysConfig = cfg
+	}
+	// Empty sync_settings {} block (or one with empty sub-blocks) carries
+	// nothing useful — treat it as "not set" so callers can omit the field.
+	if ss.SyncLogsConfig == nil && ss.FailedKeysConfig == nil {
+		return nil, false
+	}
+	return ss, true
+}
+
+func syncSettingsToState(ss *retl.SyncSettings) []map[string]interface{} {
+	if ss == nil {
+		return nil
+	}
+	out := map[string]interface{}{}
+	if ss.SyncLogsConfig != nil {
+		lm := map[string]interface{}{}
+		if ss.SyncLogsConfig.Enabled != nil {
+			lm["enabled"] = *ss.SyncLogsConfig.Enabled
+		}
+		if ss.SyncLogsConfig.LogRetentionInDays != nil {
+			lm["log_retention_in_days"] = *ss.SyncLogsConfig.LogRetentionInDays
+		}
+		if ss.SyncLogsConfig.SnapshotsToRetain != nil {
+			lm["snapshots_to_retain"] = *ss.SyncLogsConfig.SnapshotsToRetain
+		}
+		out["sync_logs_config"] = []map[string]interface{}{lm}
+	}
+	if ss.FailedKeysConfig != nil {
+		fkm := map[string]interface{}{}
+		if ss.FailedKeysConfig.EnableFailedKeysRetry != nil {
+			fkm["enable_failed_keys_retry"] = *ss.FailedKeysConfig.EnableFailedKeysRetry
+		}
+		out["failed_keys_config"] = []map[string]interface{}{fkm}
+	}
+	return []map[string]interface{}{out}
+}
+
+func mappingsFromState(d *schema.ResourceData, key string) []retl.Mapping {
+	raw, _ := d.Get(key).([]interface{})
+	out := make([]retl.Mapping, 0, len(raw))
+	for _, item := range raw {
+		m := item.(map[string]interface{})
+		out = append(out, retl.Mapping{
+			From: m["from"].(string),
+			To:   m["to"].(string),
+		})
+	}
+	return out
+}
+
+func mappingsToState(ms []retl.Mapping) []map[string]interface{} {
+	if len(ms) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, map[string]interface{}{"from": m.From, "to": m.To})
+	}
+	return out
+}

--- a/rudderstack/retl/connection_customerio_audience.go
+++ b/rudderstack/retl/connection_customerio_audience.go
@@ -1,0 +1,197 @@
+package retl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/client/retl"
+)
+
+// ResourceConnectionCustomerIOAudience returns the schema for
+// `rudderstack_retl_connection_customerio_audience` — a RETL connection
+// scoped to a Customer.io Audience destination.
+//
+// The audience ID is a first-class typed field. Internally it round-trips
+// through the API's untyped `destinationConfig` JSON as `{"audienceId": N}`
+// so the server-side flow detection still works, but Terraform users see and
+// validate an integer field rather than an opaque blob.
+//
+// Customer.io Audience is the first destination-specific RETL flow exposed
+// this way. Adding another typed destination follows the same pattern: a
+// new ResourceConnection<Destination> function composes
+// baseConnectionSchema() with the destination's required fields and adds a
+// small CRUD shim to pack/unpack destinationConfig.
+func ResourceConnectionCustomerIOAudience() *schema.Resource {
+	return &schema.Resource{
+		Description: "A RETL connection to a Customer.io Audience destination. " +
+			"Carries the audience ID as a typed top-level field; ForceNew because the " +
+			"Customer.io Audience API does not accept destinationConfig changes on update.",
+		Schema: mergeSchemas(baseConnectionSchema(), map[string]*schema.Schema{
+			"audience_id": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+				Description:  "Customer.io audience ID (positive integer).",
+			},
+		}),
+		CreateContext: createCustomerIOAudienceConnection,
+		ReadContext:   readCustomerIOAudienceConnection,
+		UpdateContext: updateCustomerIOAudienceConnection,
+		DeleteContext: deleteConnection,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+	}
+}
+
+func createCustomerIOAudienceConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	req := &retl.CreateRETLConnectionRequest{}
+	if err := applyBaseToCreateRequest(d, req); err != nil {
+		return diag.FromErr(err)
+	}
+	cfg, err := encodeCustomerIOAudienceConfig(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	req.DestinationConfig = cfg
+
+	created, err := svc.CreateConnection(ctx, req)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("could not create RETL connection: %w", err))
+	}
+	d.SetId(created.ID)
+	return readCustomerIOAudienceConnection(ctx, d, m)
+}
+
+func readCustomerIOAudienceConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	conn, err := svc.GetConnection(ctx, d.Id())
+	if err != nil {
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("could not read RETL connection: %w", err))
+	}
+
+	if err := storeBaseConnectionToState(d, conn); err != nil {
+		return diag.FromErr(err)
+	}
+	if len(conn.DestinationConfig) == 0 {
+		// No destinationConfig on a typed Customer.io Audience resource is a
+		// server-side inconsistency — clear the field so the next plan shows
+		// the gap rather than silently keeping a stale audience_id.
+		if err := d.Set("audience_id", 0); err != nil {
+			return diag.FromErr(fmt.Errorf("set audience_id: %w", err))
+		}
+		return nil
+	}
+	id, err := decodeCustomerIOAudienceID(conn.DestinationConfig)
+	if err != nil {
+		if errors.Is(err, errCustomerIOAudienceNullConfig) {
+			// JSON `null` carries the same "no typed config" meaning as an empty
+			// payload — clear the field for the same reason.
+			if err := d.Set("audience_id", 0); err != nil {
+				return diag.FromErr(fmt.Errorf("set audience_id: %w", err))
+			}
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+	if err := d.Set("audience_id", id); err != nil {
+		return diag.FromErr(fmt.Errorf("set audience_id: %w", err))
+	}
+	return nil
+}
+
+func updateCustomerIOAudienceConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	svc, diags := service(m)
+	if diags.HasError() {
+		return diags
+	}
+
+	// audience_id is ForceNew, so an Update never sees a change to it —
+	// applyBaseToUpdateRequest covers the rest.
+	req := &retl.UpdateRETLConnectionRequest{}
+	if err := applyBaseToUpdateRequest(d, req); err != nil {
+		return diag.FromErr(err)
+	}
+	if _, err := svc.UpdateConnection(ctx, d.Id(), req); err != nil {
+		return diag.FromErr(fmt.Errorf("could not update RETL connection: %w", err))
+	}
+	return readCustomerIOAudienceConnection(ctx, d, m)
+}
+
+// encodeCustomerIOAudienceConfig packs the top-level `audience_id` field
+// into the destinationConfig JSON shape the API expects.
+func encodeCustomerIOAudienceConfig(d *schema.ResourceData) (json.RawMessage, error) {
+	id, ok := d.Get("audience_id").(int)
+	if !ok {
+		// Defensive: schema declares audience_id as TypeInt so the SDK should
+		// always hand us an int. Surface the divergence loudly rather than
+		// silently POST `{"audienceId": 0}`.
+		return nil, fmt.Errorf("audience_id has unexpected type %T", d.Get("audience_id"))
+	}
+	out, err := json.Marshal(map[string]any{"audienceId": id})
+	if err != nil {
+		return nil, fmt.Errorf("encode customerio_audience destinationConfig: %w", err)
+	}
+	return out, nil
+}
+
+// errCustomerIOAudienceNullConfig signals that destinationConfig was the JSON
+// literal `null` — semantically "no destination-specific config", not a
+// malformed payload. Callers distinguish this from a hard decode error.
+var errCustomerIOAudienceNullConfig = errors.New("customerio_audience destinationConfig is null")
+
+// decodeCustomerIOAudienceID extracts the integer audienceId from a
+// destinationConfig JSON blob. Returns errCustomerIOAudienceNullConfig (a
+// soft signal) for JSON `null`. Returns a hard error when the payload is a
+// non-null shape without a numeric `audienceId` — that signals an
+// unsupported destination-specific connection (e.g. imported from a
+// destination that isn't Customer.io Audience), which this resource does
+// not represent.
+func decodeCustomerIOAudienceID(raw json.RawMessage) (int, error) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return 0, fmt.Errorf("decode customerio_audience destinationConfig: %w", err)
+	}
+	if parsed == nil {
+		// JSON `null` unmarshalls into a nil map — treat as "no typed config".
+		return 0, errCustomerIOAudienceNullConfig
+	}
+	v, ok := parsed["audienceId"]
+	if !ok {
+		return 0, fmt.Errorf("destinationConfig has no audienceId — only Customer.io Audience destination-specific connections are supported")
+	}
+	n, ok := v.(float64) // json.Unmarshal decodes JSON numbers as float64
+	if !ok {
+		return 0, fmt.Errorf("destinationConfig audienceId is %T, expected number", v)
+	}
+	if math.IsNaN(n) || math.IsInf(n, 0) || math.Trunc(n) != n {
+		return 0, fmt.Errorf("destinationConfig audienceId %v is not an integer", n)
+	}
+	// int(n) is exact for |n| < 2^53 (float64 mantissa). Customer.io audience
+	// IDs are well below that bound in practice; the integrality check above
+	// rejects fractional values like 42.5 that would otherwise truncate silently.
+	return int(n), nil
+}

--- a/rudderstack/retl/connection_customerio_audience_test.go
+++ b/rudderstack/retl/connection_customerio_audience_test.go
@@ -1,0 +1,248 @@
+package retl_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	iacretl "github.com/rudderlabs/rudder-iac/api/client/retl"
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack"
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/retl"
+)
+
+// The typed Customer.io Audience resource exposes audience_id as a top-level
+// integer; internally it round-trips through destinationConfig as
+// {"audienceId": N} so the API sees the same shape the generic resource used
+// to produce.
+func TestResourceConnectionCustomerIOAudience_CreateRead(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+
+	createReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	created := &iacretl.RETLConnection{
+		ID:                "conn-cio",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	svc.On("CreateConnection", mock.Anything, createReq).Return(created, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-cio").Return(created, nil).Times(2)
+	svc.On("DeleteConnection", mock.Anything, "conn-cio").Return(nil).Once()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection_customerio_audience" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-cio"
+						sync_behaviour = "mirror"
+						schedule { type = "manual" }
+						identifiers {
+							from = "email"
+							to   = "email"
+						}
+						audience_id = 42
+					}
+				`,
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection_customerio_audience.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"id":          "conn-cio",
+						"audience_id": "42",
+					}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+}
+
+// Changing `audience_id` must recreate the connection. The Customer.io
+// Audience API rejects destinationConfig changes on update, so audience_id
+// carries `ForceNew: true`. A new resource ID after the value change is the
+// proof — terraform would have called UpdateConnection (which we don't mock)
+// if ForceNew hadn't fired.
+func TestResourceConnectionCustomerIOAudience_AudienceIDIsForceNew(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+
+	firstReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	firstCreated := &iacretl.RETLConnection{
+		ID:                "conn-cio-1",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	secondReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":99}`),
+	}
+	secondCreated := &iacretl.RETLConnection{
+		ID:                "conn-cio-2",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":99}`),
+	}
+	svc.On("CreateConnection", mock.Anything, firstReq).Return(firstCreated, nil).Once()
+	svc.On("CreateConnection", mock.Anything, secondReq).Return(secondCreated, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-cio-1").Return(firstCreated, nil)
+	svc.On("GetConnection", mock.Anything, "conn-cio-2").Return(secondCreated, nil)
+	svc.On("DeleteConnection", mock.Anything, "conn-cio-1").Return(nil).Once()
+	svc.On("DeleteConnection", mock.Anything, "conn-cio-2").Return(nil).Once()
+
+	cfg := func(audienceID int) string {
+		return fmt.Sprintf(`
+			provider "rudderstack" { access_token = "tok" }
+			resource "rudderstack_retl_connection_customerio_audience" "example" {
+				source_id      = "retl-src-1"
+				destination_id = "dest-cio"
+				sync_behaviour = "mirror"
+				schedule { type = "manual" }
+				identifiers {
+					from = "email"
+					to   = "email"
+				}
+				audience_id = %d
+			}
+		`, audienceID)
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(42),
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection_customerio_audience.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"id":          "conn-cio-1",
+						"audience_id": "42",
+					}, attrs)
+				},
+			},
+			{
+				Config: cfg(99),
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection_customerio_audience.example")
+					if err != nil {
+						return err
+					}
+					// New ID proves the resource was destroyed and recreated
+					// rather than updated in place — i.e. ForceNew kicked in.
+					return checkAll(map[string]string{
+						"id":          "conn-cio-2",
+						"audience_id": "99",
+					}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+}
+
+// Customer.io audience IDs are always positive — plan-time validation must
+// reject values < 1 so users see a clear error in `terraform plan` rather
+// than a generic API rejection at apply time.
+func TestResourceConnectionCustomerIOAudience_RejectsNonPositiveID(t *testing.T) {
+	svc := &mockService{}
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection_customerio_audience" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-cio"
+						sync_behaviour = "mirror"
+						schedule { type = "manual" }
+						identifiers {
+							from = "email"
+							to   = "email"
+						}
+						audience_id = 0
+					}
+				`,
+				ExpectError: regexpMatches(`expected audience_id to be at least \(1\)`),
+			},
+		},
+	})
+	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
+}
+
+// Regression: a JSON-`null` destinationConfig in the API response must NOT
+// error on the typed resource. The read path treats `null` as "no typed
+// config" and clears audience_id from state instead of failing refresh.
+func TestResourceConnectionCustomerIOAudience_NullDestinationConfigOnRead(t *testing.T) {
+	svc := &mockService{}
+	conn := &iacretl.RETLConnection{
+		ID:                "conn-cio-null",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`null`),
+	}
+	svc.On("GetConnection", mock.Anything, "conn-cio-null").Return(conn, nil).Once()
+
+	r := retl.ResourceConnectionCustomerIOAudience()
+	d := r.TestResourceData()
+	d.SetId("conn-cio-null")
+
+	diags := r.ReadContext(context.Background(), d, &rudderstack.Client{RETLSources: svc})
+	require.False(t, diags.HasError(), "diags=%v", diags)
+	require.Equal(t, 0, d.Get("audience_id"))
+	svc.AssertExpectations(t)
+}

--- a/rudderstack/retl/connection_customerio_audience_test.go
+++ b/rudderstack/retl/connection_customerio_audience_test.go
@@ -220,6 +220,117 @@ func TestResourceConnectionCustomerIOAudience_RejectsNonPositiveID(t *testing.T)
 	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
 }
 
+// Identifier changes must recreate the typed resource (ForceNew is set at
+// both the top level and the nested from/to in baseConnectionSchema). A new
+// ID after the value change proves destroy + create — terraform would have
+// called UpdateConnection (which the mock does not register) if the schema
+// had allowed in-place updates.
+func TestResourceConnectionCustomerIOAudience_IdentifiersAreForceNew(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+
+	firstReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	firstCreated := &iacretl.RETLConnection{
+		ID:                "conn-cio-ids-1",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	secondReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "user_id", To: "external_id"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	secondCreated := &iacretl.RETLConnection{
+		ID:                "conn-cio-ids-2",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "user_id", To: "external_id"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	svc.On("CreateConnection", mock.Anything, firstReq).Return(firstCreated, nil).Once()
+	svc.On("CreateConnection", mock.Anything, secondReq).Return(secondCreated, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-cio-ids-1").Return(firstCreated, nil)
+	svc.On("GetConnection", mock.Anything, "conn-cio-ids-2").Return(secondCreated, nil)
+	svc.On("DeleteConnection", mock.Anything, "conn-cio-ids-1").Return(nil).Once()
+	svc.On("DeleteConnection", mock.Anything, "conn-cio-ids-2").Return(nil).Once()
+
+	cfg := func(from, to string) string {
+		return fmt.Sprintf(`
+			provider "rudderstack" { access_token = "tok" }
+			resource "rudderstack_retl_connection_customerio_audience" "example" {
+				source_id      = "retl-src-1"
+				destination_id = "dest-cio"
+				sync_behaviour = "mirror"
+				schedule { type = "manual" }
+				identifiers {
+					from = "%s"
+					to   = "%s"
+				}
+				audience_id = 42
+			}
+		`, from, to)
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg("email", "email"),
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection_customerio_audience.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"id":                 "conn-cio-ids-1",
+						"identifiers.0.from": "email",
+						"identifiers.0.to":   "email",
+					}, attrs)
+				},
+			},
+			{
+				Config: cfg("user_id", "external_id"),
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection_customerio_audience.example")
+					if err != nil {
+						return err
+					}
+					// New ID proves destroy + create — ForceNew fired. The
+					// mock also expects two distinct CreateConnection calls
+					// (one per identifier value).
+					return checkAll(map[string]string{
+						"id":                 "conn-cio-ids-2",
+						"identifiers.0.from": "user_id",
+						"identifiers.0.to":   "external_id",
+					}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+}
+
 // Regression: a JSON-`null` destinationConfig in the API response must NOT
 // error on the typed resource. The read path treats `null` as "no typed
 // config" and clears audience_id from state instead of failing refresh.

--- a/rudderstack/retl/connection_internal_test.go
+++ b/rudderstack/retl/connection_internal_test.go
@@ -2,25 +2,24 @@ package retl
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 )
 
-func TestCustomerIOAudienceToState(t *testing.T) {
+func TestDecodeCustomerIOAudienceID(t *testing.T) {
 	cases := []struct {
-		name      string
-		in        string
-		wantID    int
-		wantEmpty bool // expect (nil, nil) — typed block should be cleared
-		wantErr   bool
+		name    string
+		in      string
+		wantID  int
+		wantErr bool
+		wantNil bool // expect errCustomerIOAudienceNullConfig sentinel
 	}{
 		{name: "valid int audienceId", in: `{"audienceId": 7}`, wantID: 7},
-		{name: "zero audienceId", in: `{"audienceId": 0}`, wantID: 0},
 		{name: "extra fields are ignored", in: `{"audienceId": 9, "name": "x"}`, wantID: 9},
 		// JSON null is the server saying "no destination-specific config".
-		// Must NOT error — that would conflate a valid response with the
-		// "unsupported destination type" signal and break refresh on a real
-		// Customer.io Audience connection that ever received a null payload.
-		{name: "json null clears the typed block", in: `null`, wantEmpty: true},
+		// Must surface as the sentinel error so the caller can treat it as a
+		// soft signal (clear the field) rather than a malformed payload.
+		{name: "json null returns sentinel", in: `null`, wantNil: true},
 		{name: "missing audienceId is unsupported", in: `{}`, wantErr: true},
 		{name: "non-numeric audienceId is unsupported", in: `{"audienceId": "abc"}`, wantErr: true},
 		// Reject fractional audienceId — int(42.5) would silently truncate to 42.
@@ -29,46 +28,21 @@ func TestCustomerIOAudienceToState(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := customerIOAudienceToState(json.RawMessage(tc.in))
+			got, err := decodeCustomerIOAudienceID(json.RawMessage(tc.in))
+			if tc.wantNil {
+				if !errors.Is(err, errCustomerIOAudienceNullConfig) {
+					t.Fatalf("expected errCustomerIOAudienceNullConfig, got %v", err)
+				}
+				return
+			}
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
 			}
 			if tc.wantErr {
 				return
 			}
-			if tc.wantEmpty {
-				if got != nil {
-					t.Fatalf("expected nil typed block, got %v", got)
-				}
-				return
-			}
-			if len(got) != 1 {
-				t.Fatalf("expected 1 element, got %d", len(got))
-			}
-			if v, _ := got[0]["audience_id"].(int); v != tc.wantID {
-				t.Errorf("audience_id = %v, want %v", v, tc.wantID)
-			}
-		})
-	}
-}
-
-func TestFlowForceNewRules(t *testing.T) {
-	cases := []struct {
-		name                           string
-		objectSet, destSpecific        bool
-		wantIdentifiers, wantConstants bool
-	}{
-		{"json mapper (no object, no typed block)", false, false, true, false},
-		{"object mapping (object set)", true, false, true, true},
-		{"customerio_audience (typed block set)", false, true, false, true},
-		{"object set wins over typed block", true, true, true, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotID, gotC := flowForceNewRules(tc.objectSet, tc.destSpecific)
-			if gotID != tc.wantIdentifiers || gotC != tc.wantConstants {
-				t.Errorf("flowForceNewRules(object=%v, destSpecific=%v) = (%v, %v), want (%v, %v)",
-					tc.objectSet, tc.destSpecific, gotID, gotC, tc.wantIdentifiers, tc.wantConstants)
+			if got != tc.wantID {
+				t.Errorf("audience_id = %v, want %v", got, tc.wantID)
 			}
 		})
 	}

--- a/rudderstack/retl/connection_internal_test.go
+++ b/rudderstack/retl/connection_internal_test.go
@@ -1,49 +1,50 @@
 package retl
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
-func TestSuppressEquivalentJSON(t *testing.T) {
+func TestCustomerIOAudienceToState(t *testing.T) {
 	cases := []struct {
-		name     string
-		oldVal   string
-		newVal   string
-		expected bool
+		name      string
+		in        string
+		wantID    int
+		wantEmpty bool // expect (nil, nil) — typed block should be cleared
+		wantErr   bool
 	}{
-		{"identical strings", `{"a":1}`, `{"a":1}`, true},
-		{"different key order", `{"a":1,"b":2}`, `{"b":2,"a":1}`, true},
-		{"different whitespace", `{"a":1}`, ` {  "a" : 1 } `, true},
-		{"semantic difference", `{"a":1}`, `{"a":2}`, false},
-		{"different shape", `{"a":1}`, `{"b":1}`, false},
-		{"nested key reorder", `{"o":{"x":1,"y":2}}`, `{"o":{"y":2,"x":1}}`, true},
-		{"array order matters", `[1,2,3]`, `[3,2,1]`, false},
-		{"both invalid JSON", "{not json", "{not json", true},
-		{"only one invalid", `{"a":1}`, "{not json", false},
+		{name: "valid int audienceId", in: `{"audienceId": 7}`, wantID: 7},
+		{name: "zero audienceId", in: `{"audienceId": 0}`, wantID: 0},
+		{name: "extra fields are ignored", in: `{"audienceId": 9, "name": "x"}`, wantID: 9},
+		// JSON null is the server saying "no destination-specific config".
+		// Must NOT error — that would conflate a valid response with the
+		// "unsupported destination type" signal and break refresh on a real
+		// Customer.io Audience connection that ever received a null payload.
+		{name: "json null clears the typed block", in: `null`, wantEmpty: true},
+		{name: "missing audienceId is unsupported", in: `{}`, wantErr: true},
+		{name: "non-numeric audienceId is unsupported", in: `{"audienceId": "abc"}`, wantErr: true},
+		{name: "invalid JSON", in: `not json`, wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := suppressEquivalentJSON("", tc.oldVal, tc.newVal, nil)
-			if got != tc.expected {
-				t.Errorf("suppressEquivalentJSON(%q, %q) = %v, want %v", tc.oldVal, tc.newVal, got, tc.expected)
+			got, err := customerIOAudienceToState(json.RawMessage(tc.in))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
 			}
-		})
-	}
-}
-
-func TestNormalizeJSON(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		out  string
-	}{
-		{"empty", "", ""},
-		{"canonicalizes key order", `{"b":2,"a":1}`, `{"a":1,"b":2}`},
-		{"strips whitespace", ` { "a" : 1 } `, `{"a":1}`},
-		{"invalid JSON returned as-is", "{not json", "{not json"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := normalizeJSON(tc.in); got != tc.out {
-				t.Errorf("normalizeJSON(%q) = %q, want %q", tc.in, got, tc.out)
+			if tc.wantErr {
+				return
+			}
+			if tc.wantEmpty {
+				if got != nil {
+					t.Fatalf("expected nil typed block, got %v", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("expected 1 element, got %d", len(got))
+			}
+			if v, _ := got[0]["audience_id"].(int); v != tc.wantID {
+				t.Errorf("audience_id = %v, want %v", v, tc.wantID)
 			}
 		})
 	}
@@ -51,21 +52,21 @@ func TestNormalizeJSON(t *testing.T) {
 
 func TestFlowForceNewRules(t *testing.T) {
 	cases := []struct {
-		name                              string
-		objectSet, destConfigSet          bool
-		wantIdentifiers, wantConstants    bool
+		name                           string
+		objectSet, destSpecific        bool
+		wantIdentifiers, wantConstants bool
 	}{
-		{"json mapper (no object, no dest_config)", false, false, true, false},
+		{"json mapper (no object, no typed block)", false, false, true, false},
 		{"object mapping (object set)", true, false, true, true},
-		{"destination-specific (dest_config set)", false, true, false, true},
-		{"object set wins over dest_config", true, true, true, true},
+		{"customerio_audience (typed block set)", false, true, false, true},
+		{"object set wins over typed block", true, true, true, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotID, gotC := flowForceNewRules(tc.objectSet, tc.destConfigSet)
+			gotID, gotC := flowForceNewRules(tc.objectSet, tc.destSpecific)
 			if gotID != tc.wantIdentifiers || gotC != tc.wantConstants {
-				t.Errorf("flowForceNewRules(object=%v, destConfig=%v) = (%v, %v), want (%v, %v)",
-					tc.objectSet, tc.destConfigSet, gotID, gotC, tc.wantIdentifiers, tc.wantConstants)
+				t.Errorf("flowForceNewRules(object=%v, destSpecific=%v) = (%v, %v), want (%v, %v)",
+					tc.objectSet, tc.destSpecific, gotID, gotC, tc.wantIdentifiers, tc.wantConstants)
 			}
 		})
 	}

--- a/rudderstack/retl/connection_internal_test.go
+++ b/rudderstack/retl/connection_internal_test.go
@@ -23,6 +23,8 @@ func TestCustomerIOAudienceToState(t *testing.T) {
 		{name: "json null clears the typed block", in: `null`, wantEmpty: true},
 		{name: "missing audienceId is unsupported", in: `{}`, wantErr: true},
 		{name: "non-numeric audienceId is unsupported", in: `{"audienceId": "abc"}`, wantErr: true},
+		// Reject fractional audienceId — int(42.5) would silently truncate to 42.
+		{name: "fractional audienceId is rejected", in: `{"audienceId": 42.5}`, wantErr: true},
 		{name: "invalid JSON", in: `not json`, wantErr: true},
 	}
 	for _, tc := range cases {

--- a/rudderstack/retl/connection_test.go
+++ b/rudderstack/retl/connection_test.go
@@ -2,6 +2,7 @@ package retl_test
 
 import (
 	"context"
+	"encoding/json"
 	"regexp"
 	"testing"
 	"time"
@@ -278,6 +279,103 @@ func TestResourceConnection_BasicScheduleRequiresEveryMinutes(t *testing.T) {
 		},
 	})
 	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
+}
+
+func TestResourceConnection_CustomerIOAudienceConfig_TypedBlock(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+
+	// The typed block must be packed into destinationConfig as
+	// {"audienceId": <int>} so the API sees the same shape jsonencode would have
+	// produced.
+	createReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	created := &iacretl.RETLConnection{
+		ID:                "conn-cio",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	svc.On("CreateConnection", mock.Anything, createReq).Return(created, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-cio").Return(created, nil).Times(2)
+	svc.On("DeleteConnection", mock.Anything, "conn-cio").Return(nil).Once()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-cio"
+						sync_behaviour = "mirror"
+						schedule { type = "manual" }
+						identifiers {
+							from = "email"
+							to   = "email"
+						}
+						customerio_audience_config {
+							audience_id = 42
+						}
+					}
+				`,
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"id":                                       "conn-cio",
+						"customerio_audience_config.#":             "1",
+						"customerio_audience_config.0.audience_id": "42",
+					}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+}
+
+// Regression: a JSON-`null` destinationConfig in the API response must not
+// turn a real Customer.io Audience connection into a refresh-time error. The
+// resource calls customerIOAudienceToState, which returns (nil, nil) for the
+// literal bytes `null`; storeConnectionToState then clears the typed block in
+// state without erroring.
+func TestResourceConnection_CustomerIOAudienceConfig_NullDestinationConfigOnRead(t *testing.T) {
+	svc := &mockService{}
+	conn := &iacretl.RETLConnection{
+		ID:                "conn-cio-null",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`null`),
+	}
+	svc.On("GetConnection", mock.Anything, "conn-cio-null").Return(conn, nil).Once()
+
+	r := retl.ResourceConnection()
+	d := r.TestResourceData()
+	d.SetId("conn-cio-null")
+
+	diags := r.ReadContext(context.Background(), d, &rudderstack.Client{RETLSources: svc})
+	require.False(t, diags.HasError(), "diags=%v", diags)
+	require.Equal(t, 0, d.Get("customerio_audience_config.#"))
+	svc.AssertExpectations(t)
 }
 
 func TestResourceConnection_Delete404IsTreatedAsAlreadyGone(t *testing.T) {

--- a/rudderstack/retl/connection_test.go
+++ b/rudderstack/retl/connection_test.go
@@ -3,6 +3,7 @@ package retl_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -376,6 +377,147 @@ func TestResourceConnection_CustomerIOAudienceConfig_NullDestinationConfigOnRead
 	require.False(t, diags.HasError(), "diags=%v", diags)
 	require.Equal(t, 0, d.Get("customerio_audience_config.#"))
 	svc.AssertExpectations(t)
+}
+
+// Changing `audience_id` must recreate the connection. The Customer.io
+// Audience API rejects destinationConfig changes on update, so the field
+// carries `ForceNew: true` (in addition to the parent block's ForceNew, which
+// is defense-in-depth against the parent block being relaxed in the future).
+func TestResourceConnection_CustomerIOAudienceConfig_AudienceIDIsForceNew(t *testing.T) {
+	svc := &mockService{}
+	enabled := true
+
+	firstReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	firstCreated := &iacretl.RETLConnection{
+		ID:                "conn-cio-1",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
+	}
+	secondReq := &iacretl.CreateRETLConnectionRequest{
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           &enabled,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":99}`),
+	}
+	secondCreated := &iacretl.RETLConnection{
+		ID:                "conn-cio-2",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-cio",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourMirror,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
+		DestinationConfig: json.RawMessage(`{"audienceId":99}`),
+	}
+	svc.On("CreateConnection", mock.Anything, firstReq).Return(firstCreated, nil).Once()
+	svc.On("CreateConnection", mock.Anything, secondReq).Return(secondCreated, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-cio-1").Return(firstCreated, nil)
+	svc.On("GetConnection", mock.Anything, "conn-cio-2").Return(secondCreated, nil)
+	svc.On("DeleteConnection", mock.Anything, "conn-cio-1").Return(nil).Once()
+	svc.On("DeleteConnection", mock.Anything, "conn-cio-2").Return(nil).Once()
+
+	cfg := func(audienceID int) string {
+		return fmt.Sprintf(`
+			provider "rudderstack" { access_token = "tok" }
+			resource "rudderstack_retl_connection" "example" {
+				source_id      = "retl-src-1"
+				destination_id = "dest-cio"
+				sync_behaviour = "mirror"
+				schedule { type = "manual" }
+				identifiers {
+					from = "email"
+					to   = "email"
+				}
+				customerio_audience_config {
+					audience_id = %d
+				}
+			}
+		`, audienceID)
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(42),
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					return checkAll(map[string]string{
+						"id": "conn-cio-1",
+						"customerio_audience_config.0.audience_id": "42",
+					}, attrs)
+				},
+			},
+			{
+				Config: cfg(99),
+				Check: func(s *terraform.State) error {
+					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
+					if err != nil {
+						return err
+					}
+					// New ID proves the resource was destroyed and recreated
+					// rather than updated in place — i.e. ForceNew kicked in.
+					return checkAll(map[string]string{
+						"id": "conn-cio-2",
+						"customerio_audience_config.0.audience_id": "99",
+					}, attrs)
+				},
+			},
+		},
+	})
+
+	svc.AssertExpectations(t)
+}
+
+// Customer.io audience IDs are always positive — plan-time validation must
+// reject values < 1 so users see a clear error in `terraform plan` rather
+// than a generic API rejection at apply time.
+func TestResourceConnection_CustomerIOAudienceConfig_RejectsNonPositiveID(t *testing.T) {
+	svc := &mockService{}
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories(svc),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					provider "rudderstack" { access_token = "tok" }
+					resource "rudderstack_retl_connection" "example" {
+						source_id      = "retl-src-1"
+						destination_id = "dest-cio"
+						sync_behaviour = "mirror"
+						schedule { type = "manual" }
+						identifiers {
+							from = "email"
+							to   = "email"
+						}
+						customerio_audience_config {
+							audience_id = 0
+						}
+					}
+				`,
+				ExpectError: regexpMatches(`expected customerio_audience_config\.0\.audience_id to be at least \(1\)`),
+			},
+		},
+	})
+	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
 }
 
 func TestResourceConnection_Delete404IsTreatedAsAlreadyGone(t *testing.T) {

--- a/rudderstack/retl/connection_test.go
+++ b/rudderstack/retl/connection_test.go
@@ -2,8 +2,6 @@ package retl_test
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -282,242 +280,61 @@ func TestResourceConnection_BasicScheduleRequiresEveryMinutes(t *testing.T) {
 	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
 }
 
-func TestResourceConnection_CustomerIOAudienceConfig_TypedBlock(t *testing.T) {
-	svc := &mockService{}
-	enabled := true
-
-	// The typed block must be packed into destinationConfig as
-	// {"audienceId": <int>} so the API sees the same shape jsonencode would have
-	// produced.
-	createReq := &iacretl.CreateRETLConnectionRequest{
-		SourceID:          "retl-src-1",
-		DestinationID:     "dest-cio",
-		Enabled:           &enabled,
-		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
-		SyncBehaviour:     iacretl.SyncBehaviourMirror,
-		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
-	}
-	created := &iacretl.RETLConnection{
-		ID:                "conn-cio",
-		SourceID:          "retl-src-1",
-		DestinationID:     "dest-cio",
-		Enabled:           true,
-		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
-		SyncBehaviour:     iacretl.SyncBehaviourMirror,
-		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
-	}
-	svc.On("CreateConnection", mock.Anything, createReq).Return(created, nil).Once()
-	svc.On("GetConnection", mock.Anything, "conn-cio").Return(created, nil).Times(2)
-	svc.On("DeleteConnection", mock.Anything, "conn-cio").Return(nil).Once()
-
-	resource.UnitTest(t, resource.TestCase{
-		ProviderFactories: providerFactories(svc),
-		Steps: []resource.TestStep{
-			{
-				Config: `
-					provider "rudderstack" { access_token = "tok" }
-					resource "rudderstack_retl_connection" "example" {
-						source_id      = "retl-src-1"
-						destination_id = "dest-cio"
-						sync_behaviour = "mirror"
-						schedule { type = "manual" }
-						identifiers {
-							from = "email"
-							to   = "email"
-						}
-						customerio_audience_config {
-							audience_id = 42
-						}
-					}
-				`,
-				Check: func(s *terraform.State) error {
-					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
-					if err != nil {
-						return err
-					}
-					return checkAll(map[string]string{
-						"id":                                       "conn-cio",
-						"customerio_audience_config.#":             "1",
-						"customerio_audience_config.0.audience_id": "42",
-					}, attrs)
-				},
-			},
-		},
-	})
-
-	svc.AssertExpectations(t)
-}
-
-// Regression: a JSON-`null` destinationConfig in the API response must not
-// turn a real Customer.io Audience connection into a refresh-time error. The
-// resource calls customerIOAudienceToState, which returns (nil, nil) for the
-// literal bytes `null`; storeConnectionToState then clears the typed block in
-// state without erroring.
-func TestResourceConnection_CustomerIOAudienceConfig_NullDestinationConfigOnRead(t *testing.T) {
+// Refresh against an API response that has destination-specific config must
+// fail loudly on the generic resource — otherwise users with an existing
+// customerio_audience connection imported under the generic type would silently
+// lose their audience config from state.
+func TestResourceConnection_RefusesDestinationSpecificConfig(t *testing.T) {
 	svc := &mockService{}
 	conn := &iacretl.RETLConnection{
-		ID:                "conn-cio-null",
+		ID:                "conn-bad",
 		SourceID:          "retl-src-1",
 		DestinationID:     "dest-cio",
 		Enabled:           true,
 		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
 		SyncBehaviour:     iacretl.SyncBehaviourMirror,
 		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`null`),
+		DestinationConfig: []byte(`{"audienceId":42}`),
 	}
-	svc.On("GetConnection", mock.Anything, "conn-cio-null").Return(conn, nil).Once()
+	svc.On("GetConnection", mock.Anything, "conn-bad").Return(conn, nil).Once()
 
 	r := retl.ResourceConnection()
 	d := r.TestResourceData()
-	d.SetId("conn-cio-null")
+	d.SetId("conn-bad")
+
+	diags := r.ReadContext(context.Background(), d, &rudderstack.Client{RETLSources: svc})
+	require.True(t, diags.HasError(), "expected refresh to error on destination-specific config")
+	require.Regexp(t,
+		`rudderstack_retl_connection_customerio_audience`,
+		diags[0].Summary,
+	)
+	svc.AssertExpectations(t)
+}
+
+// Regression: JSON-`null` destinationConfig in the API response must NOT error
+// on the generic resource — `null` is the server's "no destination-specific
+// config" signal and should be treated as a no-op.
+func TestResourceConnection_NullDestinationConfigOnRead(t *testing.T) {
+	svc := &mockService{}
+	conn := &iacretl.RETLConnection{
+		ID:                "conn-null",
+		SourceID:          "retl-src-1",
+		DestinationID:     "dest-1",
+		Enabled:           true,
+		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
+		SyncBehaviour:     iacretl.SyncBehaviourFull,
+		Identifiers:       []iacretl.Mapping{{From: "email", To: "user_id"}},
+		DestinationConfig: []byte(`null`),
+	}
+	svc.On("GetConnection", mock.Anything, "conn-null").Return(conn, nil).Once()
+
+	r := retl.ResourceConnection()
+	d := r.TestResourceData()
+	d.SetId("conn-null")
 
 	diags := r.ReadContext(context.Background(), d, &rudderstack.Client{RETLSources: svc})
 	require.False(t, diags.HasError(), "diags=%v", diags)
-	require.Equal(t, 0, d.Get("customerio_audience_config.#"))
 	svc.AssertExpectations(t)
-}
-
-// Changing `audience_id` must recreate the connection. The Customer.io
-// Audience API rejects destinationConfig changes on update, so the field
-// carries `ForceNew: true` (in addition to the parent block's ForceNew, which
-// is defense-in-depth against the parent block being relaxed in the future).
-func TestResourceConnection_CustomerIOAudienceConfig_AudienceIDIsForceNew(t *testing.T) {
-	svc := &mockService{}
-	enabled := true
-
-	firstReq := &iacretl.CreateRETLConnectionRequest{
-		SourceID:          "retl-src-1",
-		DestinationID:     "dest-cio",
-		Enabled:           &enabled,
-		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
-		SyncBehaviour:     iacretl.SyncBehaviourMirror,
-		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
-	}
-	firstCreated := &iacretl.RETLConnection{
-		ID:                "conn-cio-1",
-		SourceID:          "retl-src-1",
-		DestinationID:     "dest-cio",
-		Enabled:           true,
-		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
-		SyncBehaviour:     iacretl.SyncBehaviourMirror,
-		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`{"audienceId":42}`),
-	}
-	secondReq := &iacretl.CreateRETLConnectionRequest{
-		SourceID:          "retl-src-1",
-		DestinationID:     "dest-cio",
-		Enabled:           &enabled,
-		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
-		SyncBehaviour:     iacretl.SyncBehaviourMirror,
-		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`{"audienceId":99}`),
-	}
-	secondCreated := &iacretl.RETLConnection{
-		ID:                "conn-cio-2",
-		SourceID:          "retl-src-1",
-		DestinationID:     "dest-cio",
-		Enabled:           true,
-		Schedule:          iacretl.Schedule{Type: iacretl.ScheduleTypeManual},
-		SyncBehaviour:     iacretl.SyncBehaviourMirror,
-		Identifiers:       []iacretl.Mapping{{From: "email", To: "email"}},
-		DestinationConfig: json.RawMessage(`{"audienceId":99}`),
-	}
-	svc.On("CreateConnection", mock.Anything, firstReq).Return(firstCreated, nil).Once()
-	svc.On("CreateConnection", mock.Anything, secondReq).Return(secondCreated, nil).Once()
-	svc.On("GetConnection", mock.Anything, "conn-cio-1").Return(firstCreated, nil)
-	svc.On("GetConnection", mock.Anything, "conn-cio-2").Return(secondCreated, nil)
-	svc.On("DeleteConnection", mock.Anything, "conn-cio-1").Return(nil).Once()
-	svc.On("DeleteConnection", mock.Anything, "conn-cio-2").Return(nil).Once()
-
-	cfg := func(audienceID int) string {
-		return fmt.Sprintf(`
-			provider "rudderstack" { access_token = "tok" }
-			resource "rudderstack_retl_connection" "example" {
-				source_id      = "retl-src-1"
-				destination_id = "dest-cio"
-				sync_behaviour = "mirror"
-				schedule { type = "manual" }
-				identifiers {
-					from = "email"
-					to   = "email"
-				}
-				customerio_audience_config {
-					audience_id = %d
-				}
-			}
-		`, audienceID)
-	}
-
-	resource.UnitTest(t, resource.TestCase{
-		ProviderFactories: providerFactories(svc),
-		Steps: []resource.TestStep{
-			{
-				Config: cfg(42),
-				Check: func(s *terraform.State) error {
-					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
-					if err != nil {
-						return err
-					}
-					return checkAll(map[string]string{
-						"id": "conn-cio-1",
-						"customerio_audience_config.0.audience_id": "42",
-					}, attrs)
-				},
-			},
-			{
-				Config: cfg(99),
-				Check: func(s *terraform.State) error {
-					attrs, err := resourceAttrs(s, "rudderstack_retl_connection.example")
-					if err != nil {
-						return err
-					}
-					// New ID proves the resource was destroyed and recreated
-					// rather than updated in place — i.e. ForceNew kicked in.
-					return checkAll(map[string]string{
-						"id": "conn-cio-2",
-						"customerio_audience_config.0.audience_id": "99",
-					}, attrs)
-				},
-			},
-		},
-	})
-
-	svc.AssertExpectations(t)
-}
-
-// Customer.io audience IDs are always positive — plan-time validation must
-// reject values < 1 so users see a clear error in `terraform plan` rather
-// than a generic API rejection at apply time.
-func TestResourceConnection_CustomerIOAudienceConfig_RejectsNonPositiveID(t *testing.T) {
-	svc := &mockService{}
-	resource.UnitTest(t, resource.TestCase{
-		ProviderFactories: providerFactories(svc),
-		Steps: []resource.TestStep{
-			{
-				Config: `
-					provider "rudderstack" { access_token = "tok" }
-					resource "rudderstack_retl_connection" "example" {
-						source_id      = "retl-src-1"
-						destination_id = "dest-cio"
-						sync_behaviour = "mirror"
-						schedule { type = "manual" }
-						identifiers {
-							from = "email"
-							to   = "email"
-						}
-						customerio_audience_config {
-							audience_id = 0
-						}
-					}
-				`,
-				ExpectError: regexpMatches(`expected customerio_audience_config\.0\.audience_id to be at least \(1\)`),
-			},
-		},
-	})
-	svc.AssertNotCalled(t, "CreateConnection", mock.Anything, mock.Anything)
 }
 
 func TestResourceConnection_Delete404IsTreatedAsAlreadyGone(t *testing.T) {


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## Summary

Replaces the generic `destination_config` JSON-encoded string on `rudderstack_retl_connection` with a typed `customerio_audience_config { audience_id = N }` block. Customer.io Audience is the only VDM-next destination this resource exposes; other destination-specific connections are skipped by the generator and surface as a clear error on read.

## Key Changes

- **Schema** (`rudderstack/retl/connection.go`): added typed `customerio_audience_config` block (`ForceNew`, matching the API contract where `destinationConfig` isn't accepted on update). Removed `destination_config` and the `normalizeJSON`/`suppressEquivalentJSON` helpers. Flow detection in `customizeConnectionDiff` now keys off `hasCustomerIOAudienceConfig` for the destination-specific signal.
- **Read path** (`storeConnectionToState`): the server's `destinationConfig` JSON is decoded directly into the typed block. JSON `null` clears the block without erroring; any other shape without a numeric `audienceId` fails loudly — that's the "you imported an unsupported destination-specific connection" signal.
- **Generator** (`cmd/generatetf/generator/generator.go`): emits the typed block for Customer.io Audience and skip-and-logs any other RETL connection with a non-empty `destinationConfig`. Skip parity preserved between HCL output and the import script.
- **Validation**: both `customerIOAudienceToState` (provider) and `customerIOAudienceConfigBlock` (generator) reject non-integer, NaN, or Inf `audienceId` values via `math.Trunc(n) == n` — protects against silent truncation of `42.5 → 42`.

## Things to Note

- **No `destination_config` escape hatch.** Intentional: only typed destination-specific flows are supported, so the contract between the Terraform provider and the API is closed. [PRO-5694](https://linear.app/rudderstack/issue/PRO-5694) tracks adding server-side schema validation in the config backend to make the contract two-sided.
- **No migration path for existing `destination_config` users.** The `rudderstack_retl_connection` resource is brand new (added in #233), so this is treated as a fresh schema change rather than a versioned migration. Terraform discards unknown attributes from old state — it won't panic — but anyone with an existing `destination_config = jsonencode({...})` would need to rewrite to the typed block.
- **Imported connections that aren't Customer.io Audience now fail loudly.** A `terraform refresh` on a connection imported from a different destination-specific flow returns an error rather than populating `destination_config` with opaque JSON. Intended UX for the closed surface.

## What is the related Linear task?

Resolves [PRO-5693](https://linear.app/rudderstack/issue/PRO-5693) (parent: [PRO-5692](https://linear.app/rudderstack/issue/PRO-5692) → [PRO-5544](https://linear.app/rudderstack/issue/PRO-5544))

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
