### PR TITLE
docs(e2e): add operational guide for E2E test suite

### DIFF
--- a/.claude/skills/onboard-integration/reference/e2e-testing.md
+++ b/.claude/skills/onboard-integration/reference/e2e-testing.md
@@ -2,6 +2,8 @@
 
 When onboarding a new integration, add an E2E acceptance test alongside the unit test. The E2E framework reuses the same `TestConfig` data as unit tests.
 
+> For team-facing operational details (environments, CI secrets, rotation, debugging), see [`E2E_TESTING.md`](../../../../E2E_TESTING.md) at the repo root. This file is the integration-onboarding cheatsheet only.
+
 ## For Destinations
 
 The E2E test function is added to the same `_test.go` file as the unit test. It reuses the extracted `var` containing `[]c.TestConfig`.
@@ -60,4 +62,4 @@ make testacc-source SRC={name}
 
 ## CI enforcement
 
-A coverage test in `internal/testutil/acc/coverage_test.go` verifies every registered integration has a `TestAccDestination*` or `TestAccSource*` function. If you forget to add the E2E test, `make test-ci` will fail.
+A coverage test in `internal/testutil/acc/coverage_test.go` verifies every registered integration has a `TestAccDestination*` or `TestAccSource*` function. If you forget to add the E2E test, `make test-ci` will fail. Naming convention: `TestAccDestination<Name>` / `TestAccSource<Name>` (no `_basic` suffix). Matching is case-insensitive and ignores underscores in the registry key, so `customer_io` → `TestAccDestinationCustomerIO` works.

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -1,0 +1,238 @@
+# E2E Testing — Operational Guide
+
+Operational reference for the team that owns the Terraform provider's E2E suite. If you're a contributor adding tests for a new integration, see the contributor section in [`README.md`](README.md#e2e-testing) and the templates in `.claude/skills/onboard-integration/reference/e2e-testing.md`. This document covers running, debugging, and rotating credentials in CI.
+
+---
+
+## 1. Scope — what "E2E" really means here
+
+Tests in `internal/testutil/acc/` exercise:
+
+- The **real** RudderStack control-plane API (Sources, Destinations, Connections) via `rudder-iac/api/client`.
+- The **real** Terraform provider schema, lifecycle (Create → Update → Import → Destroy), and HCL parsing via `terraform-plugin-sdk/v2`'s `resource.Test` harness.
+- **Subset verification** of the resource config returned by the API against the expected JSON in each integration's `[]configs.TestConfig` (see `config_verify.go` — extra fields the API adds are tolerated; missing fields fail the test).
+
+Tests do **not** exercise:
+
+- Downstream event delivery. Destinations are created with placeholder credentials (e.g. `webhook_url = "https://example.com/test"`); no events flow to the configured third party.
+- Third-party OAuth flows / vendor APIs. Only the control-plane CRUD path is verified.
+- Hard-delete semantics. The control-plane API soft-deletes sources and destinations — `Get` after destroy may still return 200, so `CheckDestroy` is best-effort for those two resource types. Connection destroy *is* verified strictly (`testAccCheckConnectionDestroy` fails if `Get` succeeds).
+
+There are two run modes:
+
+| Mode | Env | What runs | API calls per integration |
+|---|---|---|---|
+| **Plan-only** | `TF_ACC=1 TF_ACC_PLAN_ONLY=1` | HCL parse + provider schema validation | 0 (dummy token auto-set) |
+| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy + config-subset checks | ~5 |
+
+---
+
+## 2. What's covered
+
+Verified by parsing `*_test.go` in this commit. The coverage test `internal/testutil/acc/coverage_test.go` (run as part of `make test-ci`) fails if any registered destination or source is missing its `TestAcc*` function.
+
+### Destinations (48)
+
+`ActiveCampaign`, `Adjust`, `AdobeAnalytics`, `Amplitude`, `AttentiveTag`, `BQStream`, `BigQuery`, `Braze`, `CustomerIO`, `CustomerioAudience`, `FacebookConversions`, `FacebookPixel`, `Firebase`, `GCS`, `GoogleAds`, `GoogleAnalytics`, `GoogleAnalytics4`, `GooglePubSub`, `GoogleSheets`, `GoogleTagManager`, `Hs`, `HsHubspotEvents`, `Http`, `Intercom`, `Iterable`, `Kafka`, `Kinesis`, `LinkedinAds`, `LinkedinInsightTag`, `Marketo`, `Mixpanel`, `Postgres`, `Posthog`, `Qualtrics`, `Redis`, `Redshift`, `S3`, `S3Datalake`, `Salesforce`, `Sentry`, `Slack`, `Snowflake`, `SnowflakeStreaming`, `StatSig`, `TiktokAds`, `VWO`, `Webhook`, `Zendesk`.
+
+### Sources (52)
+
+`AMP`, `Adjust`, `Android`, `AndroidKotlin`, `Appcenter`, `Appsflyer`, `Auth0`, `Braze`, `Canny`, `CloseCRM`, `Cordial`, `Cordova`, `Customerio`, `Dotnet`, `Extole`, `FacebookLeadAds`, `Flutter`, `Formsort`, `GainsightPX`, `Go`, `HTTP`, `IOS`, `IOSSwift`, `Iterable`, `Java`, `Javascript`, `JavascriptWithSettings`, `Looker`, `Mailjet`, `Mailmodo`, `MoEngage`, `Monday`, `Node`, `Olark`, `Ortto`, `PagerDuty`, `Php`, `Pipedream`, `Python`, `Reactnative`, `Refiner`, `Revenuecat`, `Ruby`, `Rust`, `SIGNL4`, `SatisMeter`, `Segment`, `Slack`, `Unity`, `Webhook`, `WebhookShopify`.
+
+### Connections (2)
+
+`HTTPToWebhook`, `JavascriptToWebhook`. Connection coverage is intentionally narrow — these confirm source→destination wiring; per-integration behavior is covered by the source/destination tests above.
+
+To regenerate this list:
+```bash
+grep -h "^func TestAcc" rudderstack/integrations/**/*.go \
+  | sed 's/func //; s/(t.*//' | sort
+```
+
+---
+
+## 3. How a run executes
+
+`acc.AccAssertDestination` / `AccAssertSource` / `AccAssertConnection` all follow the same shape (see `internal/testutil/acc/destinations.go`, `sources.go`, `connections.go`):
+
+1. **Provider factory** — `TestAccProviderFactories` constructs the provider with `rudderstack.New()`. The provider reads `RUDDERSTACK_ACCESS_TOKEN` and `RUDDERSTACK_API_URL` from env.
+2. **Pre-check** — In full CRUD mode, `TestAccPreCheck` aborts the test if `RUDDERSTACK_ACCESS_TOKEN` is unset. In plan-only mode, `ensureDummyToken` sets `RUDDERSTACK_ACCESS_TOKEN=plan-only-dummy-token` via `os.Setenv` (chosen over `t.Setenv` so `t.Parallel()` still works).
+3. **Random name** — `RandomName("<integration>")` prefixes resources with `tf-acc-` and a random 62-bit int, so leftover resources from a failed run can be identified and cleaned up by name prefix.
+4. **Test steps** —
+   - Step 1: Apply `TerraformCreate` HCL. Check resource exists in API, then subset-match its `Config` JSON against `APICreate`.
+   - Step 2: Apply `TerraformUpdate` HCL. Re-check, subset-match against `APIUpdate`.
+   - Step 3: `ImportStateVerify` — Terraform imports by ID and asserts the resulting state matches the in-memory state. For sources, `write_key` is excluded (computed, not returned on import).
+   - Cleanup: `CheckDestroy` — verifies Delete handler ran (soft-delete tolerant for sources/destinations; strict for connections).
+5. **API URL handling** — `newTestAPIClient()` strips a trailing `/v2` from `RUDDERSTACK_API_URL` for backward compatibility (the client adds it back internally). Pass the base URL; the `/v2` is optional.
+
+---
+
+## 4. Environments & triggers
+
+### Triggers
+
+- **PR to `main`** — `.github/workflows/e2e-tests.yml` runs `plan-only` for everything and `e2e-crud` / `e2e-source-crud` / `e2e-conn-crud` for affected integrations. Gated by `e2e-summary`.
+- **Push to `main`** — no E2E run on push. `release-please` opens/updates the release PR; release artifacts publish only when the release PR is merged and the GitHub Release is created.
+- **No nightly / scheduled run.** If a destination's API config drifts upstream (the control plane adds/removes a field), the next PR that touches that destination will catch it — not before. If you need wider coverage, trigger a no-op PR or rerun the workflow against `main`.
+
+### Affected-integration detection
+
+`detect-changes` (in `e2e-tests.yml`) decides which integrations are affected:
+
+- Touching any of `rudderstack/resource_destination.go`, `rudderstack/resource_source.go`, `rudderstack/client.go`, `rudderstack/provider.go`, `rudderstack/configs/`, `rudderstack/integrations/destinations/common_config_meta.go`, or `internal/testutil/acc/` ⇒ runs **all** destinations, sources, and connections.
+- Otherwise — only changed `destination_<name>*.go` files run CRUD; sources/connections only run CRUD if their respective directories are touched.
+
+### Environments
+
+- The CRUD jobs run inside the GitHub **Environment** `e2e` (`environment: e2e` in the workflow). The environment binds the test workspace's PAT and API URL; if you need a separate staging/prod target, add a second environment and a duplicate matrix job.
+- There is currently **one** environment (the dev control plane). No staging or prod target. Treat the dev workspace as the only source of truth for what these tests verify.
+
+### "First run fails by design" patterns
+
+None today. There are no DevOps PRs that must merge before a verify step passes — if a new PR's E2E run fails on the very first attempt without any infrastructure change, it is a real failure. Re-running without a code change should not turn it green; if it does, file a flake.
+
+---
+
+## 5. Test accounts & credentials
+
+Two-credential model:
+
+### (a) RudderStack control-plane PAT (per environment)
+
+- **What it is:** A Personal Access Token minted in the RudderStack dev control plane.
+- **Used by:** The provider (`RUDDERSTACK_ACCESS_TOKEN`) when running E2E CRUD against the API.
+- **Source of truth:** Vault → `secret/eng/terraform-provider-rudderstack/e2e/dev/access_token`.
+- **Mirrored to:** GitHub Actions secret `RUDDERSTACK_ACC_TEST_TOKEN` on the `e2e` environment of `rudderlabs/terraform-provider-rudderstack`.
+- **Mirroring direction:** Vault → GitHub (vault is the source of truth; never edit the GitHub secret directly except for emergency invalidation).
+
+### (b) Underlying test user account (per environment)
+
+- **What it is:** The control-plane user the PAT is minted for. Currently `integration-accounts+terraform-provider-e2e@rudderstack.com` on the dev workspace.
+- **Used by:** Humans regenerating the PAT, or when debugging via the control-plane UI.
+- **Source of truth:** Vault → `secret/eng/terraform-provider-rudderstack/e2e/dev/account` (login email + password).
+- **Mirrored to:** Nothing — this credential is human-only. It is **not** synced to GitHub. CI never authenticates with the user/password; it only uses the PAT minted from this account.
+
+### Per-environment table
+
+| Env | Workspace API URL (`RUDDERSTACK_ACC_TEST_API_URL`) | PAT vault path | Account vault path |
+|---|---|---|---|
+| dev | `https://api.dev.rudderlabs.com` | `secret/eng/terraform-provider-rudderstack/e2e/dev/access_token` | `secret/eng/terraform-provider-rudderstack/e2e/dev/account` |
+
+> Confirm vault paths with the platform team before rotating — paths in the table follow the convention used elsewhere in the eng vault but should be validated against the actual entries.
+
+---
+
+## 6. CI secrets mapping
+
+### Naming convention
+
+`{ENV}_{PROVIDER}_{PURPOSE}` for secrets/vars that need environment differentiation. The current PAT secret predates this convention and is named `RUDDERSTACK_ACC_TEST_TOKEN` (env-implied by the `e2e` GitHub Environment scope).
+
+### What CI reads
+
+| GitHub Actions name | Type | Scope | Vault path |
+|---|---|---|---|
+| `RUDDERSTACK_ACC_TEST_TOKEN` | secret | `environment: e2e` | `secret/eng/terraform-provider-rudderstack/e2e/dev/access_token` |
+| `RUDDERSTACK_ACC_TEST_API_URL` | variable | `environment: e2e` | n/a (public URL) |
+
+The workflow maps them onto the env vars the test code reads:
+
+```yaml
+env:
+  TF_ACC: "1"
+  RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDERSTACK_ACC_TEST_TOKEN }}
+  RUDDERSTACK_API_URL: ${{ vars.RUDDERSTACK_ACC_TEST_API_URL }}
+```
+
+### Bundling rules
+
+- **Per provider, not per integration.** One PAT covers all sources, destinations, and connections in the workspace. Do not mint per-destination tokens — the workspace's existing scopes are sufficient.
+- **JSON-valued secrets** — none today. If a future destination requires a JSON service-account key (e.g. Google), store it base64-encoded in vault and decode in the test setup; do not paste raw JSON into GitHub secrets (newlines + quotes are fragile in matrix interpolation).
+
+### Rotation steps
+
+1. **Mint a new PAT** in the dev control plane while signed in as `integration-accounts+terraform-provider-e2e@rudderstack.com`. Give it the same scopes as the current token (read/write on sources, destinations, connections).
+2. **Write the new value to vault** at the path above (overwrite — vault retains the previous version for rollback).
+3. **Update the GitHub Environment secret** `RUDDERSTACK_ACC_TEST_TOKEN` on `e2e` (Repo → Settings → Environments → e2e → Secrets). Paste the new token.
+4. **Trigger a test run** — push an empty commit on a throwaway PR or re-run the latest E2E workflow. If it succeeds, revoke the old PAT in the control plane.
+5. **Document the rotation** in the eng rotation log so the next operator knows when the current token was minted.
+
+If rotation fails partway through (new secret saved, tests fail with 401), the old PAT is still valid until step 4 — revert the GitHub secret to the prior vault version and investigate before retrying.
+
+---
+
+## 7. Running locally
+
+Minimal commands. Full reference in the `Makefile`.
+
+```bash
+# Plan-only — validates HCL + schema for every integration. No token, zero API calls.
+make testacc-plan
+
+# Full CRUD — one destination. Requires .env with RUDDERSTACK_ACCESS_TOKEN.
+make testacc-dest DEST=webhook
+
+# Full CRUD — one source.
+make testacc-source SRC=http
+
+# Full CRUD — connections.
+make testacc-conn
+
+# Full CRUD — everything (60-minute timeout, hits the API ~250 times).
+make testacc-all
+```
+
+Create `.env` at the repo root (git-ignored). The Makefile auto-loads it via `-include .env`:
+
+```
+RUDDERSTACK_ACCESS_TOKEN=<paste from vault>
+RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com
+```
+
+The `-run` patterns use Go's `(?i)` case-insensitive regex, so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`).
+
+---
+
+## 8. Troubleshooting & debugging
+
+### What's captured
+
+This is a Go-test suite against an HTTP API. There are no browser screenshots, DOM dumps, or MHTML snapshots — those don't apply here. The captured artifacts are:
+
+| Artifact | Where | How to access | Useful for |
+|---|---|---|---|
+| GitHub Actions job log | `Actions → E2E Tests → <run> → <job>` | Right-click "Download log archive" or stream live | All failures — start here |
+| Diff dump on config mismatch | Inline in the job log (printed by `compareConfig` in `config_verify.go`) | Search the log for `=== expected config ===` | The API returned a config that doesn't match the test's `APICreate`/`APIUpdate` expectations — shows both sides pretty-printed |
+| `terraform-plugin-sdk` debug output | Set `TF_LOG=DEBUG` locally; not enabled in CI | `TF_LOG=DEBUG make testacc-dest DEST=...` | Inspecting Terraform plan/apply internals when a step fails before any API call |
+| Leftover API resources | RudderStack dev control plane, filtered by `tf-acc-` prefix | Log in as the test account; filter by name | Cleaning up after a hard-cancelled local run that never reached `Destroy` |
+
+### Concrete failure modes
+
+| Symptom | First check | Then |
+|---|---|---|
+| `RUDDERSTACK_ACCESS_TOKEN must be set` | Local: `.env` exists at repo root and has the token. CI: `e2e` environment is selected on the job (`environment: e2e`) | Re-mint the PAT if the workspace was rebuilt |
+| `failed to get destination from API: 401` | PAT is expired or revoked | Rotate (see §6); update vault → GitHub secret |
+| `API config verification failed: missing field "<x>"` | The integration's `APICreate`/`APIUpdate` JSON expects `<x>` but the API didn't return it | Either the upstream control plane stopped persisting that field (legitimate change — update the expected JSON) or the provider isn't sending it (bug — fix the provider's `MarshalJSON`/`flatten` path) |
+| `ImportStateVerify` mismatch | A computed-only field is leaking into the state diff | Add the field to `ImportStateVerifyIgnore` in the helper (already done for `write_key` on sources) |
+| `destination <id> not found in API` after Create | The Create step thinks it succeeded but the resource isn't queryable | Check the job log for an earlier 4xx/5xx that the SDK swallowed; reproduce locally with `TF_LOG=DEBUG` |
+| Test passes locally, fails in CI | Different workspace, different feature flags, different rate limits | Run against the same `RUDDERSTACK_ACC_TEST_API_URL` locally; compare auth scopes |
+| Flake: random transient 5xx | Control plane was deploying | Re-run the job; if it recurs, file a control-plane issue with the request ID from the log |
+
+### Cleaning up leftover resources
+
+If a local run is killed mid-test, the Terraform state is gone but the API resources remain. Find them via the control-plane UI by filtering names by the `tf-acc-` prefix, then delete. There is no scripted cleanup today — if leftover resources become a recurring problem, add a sweeper following the [`terraform-plugin-sdk` sweeper pattern](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests/sweepers).
+
+---
+
+## Where the framework lives
+
+| Path | Purpose |
+|---|---|
+| `internal/testutil/acc/provider.go` | Provider factory, pre-check, dummy-token helper, `PlanOnly()` |
+| `internal/testutil/acc/destinations.go` | `AccAssertDestination` — plan-only or full CRUD |
+| `internal/testutil/acc/sources.go` | `AccAssertSource` — plan-only or full CRUD (+ `GeoEnrichmentEnabled`/`Transient` settings check) |
+| `internal/testutil/acc/connections.go` | `AccAssertConnection` — wires a source + destination together |
+| `internal/testutil/acc/config_verify.go` | `compareConfig` — subset semantics for JSON comparison |
+| `internal/testutil/acc/coverage_test.go` | CI gate: every registered integration must have a `TestAcc*` |
+| `.github/workflows/e2e-tests.yml` | CI orchestration (detect-changes → plan-only → matrix CRUD → summary) |
+| `Makefile` (`testacc-*` targets) | Local entry points |

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -1,6 +1,6 @@
 # E2E Testing — Operational Guide
 
-Operational reference for the team that owns the Terraform provider's E2E suite. If you're a contributor adding tests for a new integration, see the contributor section in [`README.md`](README.md#e2e-testing) and the templates in `.claude/skills/onboard-integration/reference/e2e-testing.md`. This document covers running and debugging the suite plus where the test credentials live (the step-by-step PAT rotation procedure lives in the platform team's runbook — see §5).
+Operational reference for the team that owns the Terraform provider's E2E suite. If you're a contributor adding tests for a new integration, see the contributor section in [`README.md`](README.md#e2e-testing) and the templates in `.claude/skills/onboard-integration/reference/e2e-testing.md`. This document covers running and debugging the suite plus the credentials model in §5; the step-by-step PAT rotation procedure lives in the platform team's runbook.
 
 ---
 
@@ -141,7 +141,7 @@ RUDDERSTACK_ACCESS_TOKEN=<paste from vault>
 RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com
 ```
 
-The `-run` patterns use Go's `(?i)` case-insensitive regex, so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`).
+The single-integration targets (`testacc-dest`, `testacc-source`) use a `(?i)`-prefixed Go regex so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`). The bulk targets (`testacc-plan`, `testacc-all`, `testacc-conn`) and the CI workflow use a case-sensitive `TestAcc*` prefix instead, which works because every generated test name starts with `TestAcc`.
 
 ---
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -199,12 +199,12 @@ This is a Go-test suite against an HTTP API. There are no browser screenshots, D
 
 | Symptom | First check | Then |
 |---|---|---|
-| `RUDDERSTACK_ACCESS_TOKEN must be set` | Local: `.env` exists at repo root and has the token. CI: `e2e` environment is selected on the job (`environment: e2e`) | Re-mint the PAT if the workspace was rebuilt |
+| `RUDDERSTACK_ACCESS_TOKEN must be set for acceptance tests` | Local: `.env` exists at repo root and has the token. CI: `e2e` environment is selected on the job (`environment: e2e`) | Re-mint the PAT if the workspace was rebuilt |
 | `failed to get destination from API: 401` | PAT is expired or revoked | Rotate (see §6); update vault → GitHub secret |
 | `API config verification failed: missing field "<x>"` | The integration's `APICreate`/`APIUpdate` JSON expects `<x>` but the API didn't return it | Either the upstream control plane stopped persisting that field (legitimate change — update the expected JSON) or the provider isn't sending it (bug — fix the provider's `MarshalJSON`/`flatten` path) |
 | `ImportStateVerify` mismatch | A computed-only field is leaking into the state diff | Add the field to `ImportStateVerifyIgnore` in the helper (already done for `write_key` on sources) |
 | `destination <id> not found in API` after Create | The Create step thinks it succeeded but the resource isn't queryable | Check the job log for an earlier 4xx/5xx that the SDK swallowed; reproduce locally with `TF_LOG=DEBUG` |
-| Test passes locally, fails in CI | Different workspace, different feature flags, different rate limits | Run against the same `RUDDERSTACK_ACC_TEST_API_URL` locally; compare auth scopes |
+| Test passes locally, fails in CI | Different workspace, different feature flags, different rate limits | Set `RUDDERSTACK_API_URL` locally to the same value CI uses (the `vars.RUDDERSTACK_ACC_TEST_API_URL` GitHub variable); compare auth scopes |
 | Flake: random transient 5xx | Control plane was deploying | Re-run the job; if it recurs, file a control-plane issue with the request ID from the log |
 
 ### Cleaning up leftover resources

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -109,7 +109,7 @@ Two-credential model:
 |---|---|---|---|
 | dev | `https://api.dev.rudderlabs.com` | eng vault: e2e PAT for this provider | eng vault: e2e account for this provider |
 
-> Specific vault paths and the test user's email are intentionally not published here — get them from the platform team's runbook before rotating.
+> The test user's email is intentionally not published here — get it from the platform team's runbook before signing in to rotate.
 
 ---
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -33,13 +33,13 @@ Every registered destination and source has a `TestAcc*` function — enforced a
 
 To list the current coverage:
 ```bash
-grep -h "^func TestAcc" rudderstack/integrations/**/*.go \
+grep -rh --include='*.go' "^func TestAcc" rudderstack/integrations \
   | sed 's/func //; s/(t.*//' | sort
 ```
 
 **Plan-only exceptions.** A small number of tests `t.Skip` in full-CRUD mode because they need a vendor account that can't be provisioned generically. `TestAccDestinationLinkedinAds` is currently the only one (requires a valid LinkedIn OAuth account in the workspace) — it runs in `TF_ACC_PLAN_ONLY=1` mode but is skipped under `TF_ACC=1`. To find all such skips:
 ```bash
-grep -B1 -A2 "acc.PlanOnly()" rudderstack/integrations/**/*_test.go
+grep -rB1 -A2 --include='*_test.go' "acc.PlanOnly()" rudderstack/integrations
 ```
 
 ---

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -167,7 +167,7 @@ make testacc-source SRC=http
 # Full CRUD — connections.
 make testacc-conn
 
-# Full CRUD — everything (60-minute timeout, hits the API ~250 times).
+# Full CRUD — everything (60-minute timeout, hundreds of API calls).
 make testacc-all
 ```
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -23,7 +23,7 @@ There are two run modes:
 | Mode | Env | What runs | API calls per integration |
 |---|---|---|---|
 | **Plan-only** | `TF_ACC=1 TF_ACC_PLAN_ONLY=1` | HCL parse + provider schema validation | 0 (dummy token auto-set) |
-| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy + config-subset checks | ~5 |
+| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy + config-subset checks | ~10 (Create/Update/Delete + 2 Gets per apply step + Import) |
 
 ---
 
@@ -90,24 +90,24 @@ Two-credential model:
 
 - **What it is:** A Personal Access Token minted in the RudderStack dev control plane.
 - **Used by:** The provider (`RUDDERSTACK_ACCESS_TOKEN`) when running E2E CRUD against the API.
-- **Source of truth:** Vault → `secret/eng/terraform-provider-rudderstack/e2e/dev/access_token`.
+- **Source of truth:** Team vault, under the eng path for this provider's e2e PAT.
 - **Mirrored to:** GitHub Actions secret `RUDDERSTACK_ACC_TEST_TOKEN` on the `e2e` environment of `rudderlabs/terraform-provider-rudderstack`.
 - **Mirroring direction:** Vault → GitHub (vault is the source of truth; never edit the GitHub secret directly except for emergency invalidation).
 
 ### (b) Underlying test user account (per environment)
 
-- **What it is:** The control-plane user the PAT is minted for. Currently `integration-accounts+terraform-provider-e2e@rudderstack.com` on the dev workspace.
+- **What it is:** The control-plane user the PAT is minted for — the shared e2e test user for the dev workspace.
 - **Used by:** Humans regenerating the PAT, or when debugging via the control-plane UI.
-- **Source of truth:** Vault → `secret/eng/terraform-provider-rudderstack/e2e/dev/account` (login email + password).
+- **Source of truth:** Team vault, under the eng path for this provider's e2e account (login email + password).
 - **Mirrored to:** Nothing — this credential is human-only. It is **not** synced to GitHub. CI never authenticates with the user/password; it only uses the PAT minted from this account.
 
 ### Per-environment table
 
-| Env | Workspace API URL (`RUDDERSTACK_ACC_TEST_API_URL`) | PAT vault path | Account vault path |
+| Env | Workspace API URL (`RUDDERSTACK_ACC_TEST_API_URL`) | PAT vault entry | Account vault entry |
 |---|---|---|---|
-| dev | `https://api.dev.rudderlabs.com` | `secret/eng/terraform-provider-rudderstack/e2e/dev/access_token` | `secret/eng/terraform-provider-rudderstack/e2e/dev/account` |
+| dev | `https://api.dev.rudderlabs.com` | eng vault: e2e PAT for this provider | eng vault: e2e account for this provider |
 
-> Confirm vault paths with the platform team before rotating — paths in the table follow the convention used elsewhere in the eng vault but should be validated against the actual entries.
+> Specific vault paths and the test user's email are intentionally not published here — get them from the platform team's runbook before rotating.
 
 ---
 
@@ -121,7 +121,7 @@ Two-credential model:
 
 | GitHub Actions name | Type | Scope | Vault path |
 |---|---|---|---|
-| `RUDDERSTACK_ACC_TEST_TOKEN` | secret | `environment: e2e` | `secret/eng/terraform-provider-rudderstack/e2e/dev/access_token` |
+| `RUDDERSTACK_ACC_TEST_TOKEN` | secret | `environment: e2e` | eng vault: e2e PAT for this provider (see runbook) |
 | `RUDDERSTACK_ACC_TEST_API_URL` | variable | `environment: e2e` | n/a (public URL) |
 
 The workflow maps them onto the env vars the test code reads:
@@ -140,8 +140,8 @@ env:
 
 ### Rotation steps
 
-1. **Mint a new PAT** in the dev control plane while signed in as `integration-accounts+terraform-provider-e2e@rudderstack.com`. Give it the same scopes as the current token (read/write on sources, destinations, connections).
-2. **Write the new value to vault** at the path above (overwrite — vault retains the previous version for rollback).
+1. **Mint a new PAT** in the dev control plane while signed in as the shared e2e test user (credentials in the team vault — see the runbook). Give it the same scopes as the current token (read/write on sources, destinations, connections).
+2. **Write the new value to vault** at the same entry as the current PAT (overwrite — vault retains the previous version for rollback).
 3. **Update the GitHub Environment secret** `RUDDERSTACK_ACC_TEST_TOKEN` on `e2e` (Repo → Settings → Environments → e2e → Secrets). Paste the new token.
 4. **Trigger a test run** — push an empty commit on a throwaway PR or re-run the latest E2E workflow. If it succeeds, revoke the old PAT in the control plane.
 5. **Document the rotation** in the eng rotation log so the next operator knows when the current token was minted.

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -1,6 +1,6 @@
 # E2E Testing — Operational Guide
 
-Operational reference for the team that owns the Terraform provider's E2E suite. If you're a contributor adding tests for a new integration, see the contributor section in [`README.md`](README.md#e2e-testing) and the templates in `.claude/skills/onboard-integration/reference/e2e-testing.md`. This document covers running, debugging, and rotating credentials in CI.
+Operational reference for the team that owns the Terraform provider's E2E suite. If you're a contributor adding tests for a new integration, see the contributor section in [`README.md`](README.md#e2e-testing) and the templates in `.claude/skills/onboard-integration/reference/e2e-testing.md`. This document covers running and debugging the suite plus where the test credentials live (the step-by-step PAT rotation procedure lives in the platform team's runbook — see §5).
 
 ---
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -92,15 +92,15 @@ Two-credential model:
 
 - **What it is:** A Personal Access Token minted in the RudderStack dev control plane.
 - **Used by:** The provider (`RUDDERSTACK_ACCESS_TOKEN`) when running E2E CRUD against the API.
-- **Source of truth:** Team vault, under the eng path for this provider's e2e PAT.
+- **Source of truth:** Team dev vault, under the eng path (`integrations_team/e2e_test/terraform-provider/rudderstack-account`) for this provider's e2e PAT.
 - **Mirrored to:** GitHub Actions secret `RUDDERSTACK_ACC_TEST_TOKEN` on the `e2e` environment of `rudderlabs/terraform-provider-rudderstack`.
 - **Mirroring direction:** Vault → GitHub (vault is the source of truth; never edit the GitHub secret directly except for emergency invalidation).
 
-### (b) Underlying test user account (per environment)
+### (b) Underlying test user account
 
 - **What it is:** The control-plane user the PAT is minted for — the shared e2e test user for the dev workspace.
 - **Used by:** Humans regenerating the PAT, or when debugging via the control-plane UI.
-- **Source of truth:** Team vault, under the eng path for this provider's e2e account (login email + password).
+- **Source of truth:** Team dev vault, under the eng path (`integrations_team/e2e_test/terraform-provider/rudderstack-account`) for this provider's e2e account (login email + password).
 - **Mirrored to:** Nothing — this credential is human-only. It is **not** synced to GitHub. CI never authenticates with the user/password; it only uses the PAT minted from this account.
 
 ### Per-environment table
@@ -113,46 +113,7 @@ Two-credential model:
 
 ---
 
-## 6. CI secrets mapping
-
-### Naming convention
-
-`{ENV}_{PROVIDER}_{PURPOSE}` for secrets/vars that need environment differentiation. The current PAT secret predates this convention and is named `RUDDERSTACK_ACC_TEST_TOKEN` (env-implied by the `e2e` GitHub Environment scope).
-
-### What CI reads
-
-| GitHub Actions name | Type | Scope | Vault path |
-|---|---|---|---|
-| `RUDDERSTACK_ACC_TEST_TOKEN` | secret | `environment: e2e` | eng vault: e2e PAT for this provider (see runbook) |
-| `RUDDERSTACK_ACC_TEST_API_URL` | variable | `environment: e2e` | n/a (public URL) |
-
-The workflow maps them onto the env vars the test code reads:
-
-```yaml
-env:
-  TF_ACC: "1"
-  RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDERSTACK_ACC_TEST_TOKEN }}
-  RUDDERSTACK_API_URL: ${{ vars.RUDDERSTACK_ACC_TEST_API_URL }}
-```
-
-### Bundling rules
-
-- **Per provider, not per integration.** One PAT covers all sources, destinations, and connections in the workspace. Do not mint per-destination tokens — the workspace's existing scopes are sufficient.
-- **JSON-valued secrets** — none today. If a future destination requires a JSON service-account key (e.g. Google), store it base64-encoded in vault and decode in the test setup; do not paste raw JSON into GitHub secrets (newlines + quotes are fragile in matrix interpolation).
-
-### Rotation steps
-
-1. **Mint a new PAT** in the dev control plane while signed in as the shared e2e test user (credentials in the team vault — see the runbook). Give it the same scopes as the current token (read/write on sources, destinations, connections).
-2. **Write the new value to vault** at the same entry as the current PAT (overwrite — vault retains the previous version for rollback).
-3. **Update the GitHub Environment secret** `RUDDERSTACK_ACC_TEST_TOKEN` on `e2e` (Repo → Settings → Environments → e2e → Secrets). Paste the new token.
-4. **Trigger a test run** — push an empty commit on a throwaway PR or re-run the latest E2E workflow. If it succeeds, revoke the old PAT in the control plane.
-5. **Document the rotation** in the eng rotation log so the next operator knows when the current token was minted.
-
-If rotation fails partway through (new secret saved, tests fail with 401), the old PAT is still valid until step 4 — revert the GitHub secret to the prior vault version and investigate before retrying.
-
----
-
-## 7. Running locally
+## 6. Running locally
 
 Minimal commands. Full reference in the `Makefile`.
 
@@ -177,14 +138,14 @@ Create `.env` at the repo root (git-ignored). The Makefile auto-loads it via `-i
 
 ```
 RUDDERSTACK_ACCESS_TOKEN=<paste from vault>
-RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com
+RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com/v2
 ```
 
 The `-run` patterns use Go's `(?i)` case-insensitive regex, so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`).
 
 ---
 
-## 8. Troubleshooting & debugging
+## 7. Troubleshooting & debugging
 
 ### What's captured
 
@@ -202,7 +163,7 @@ This is a Go-test suite against an HTTP API. There are no browser screenshots, D
 | Symptom | First check | Then |
 |---|---|---|
 | `RUDDERSTACK_ACCESS_TOKEN must be set for acceptance tests` | Local: `.env` exists at repo root and has the token. CI: `e2e` environment is selected on the job (`environment: e2e`) | Re-mint the PAT if the workspace was rebuilt |
-| `failed to get destination from API: 401` | PAT is expired or revoked | Rotate (see §6); update vault → GitHub secret |
+| `failed to get destination from API: 401` | PAT is expired or revoked | Rotate the PAT (mint a new one as the e2e test user, write to vault, update the `RUDDERSTACK_ACC_TEST_TOKEN` GitHub Environment secret on `e2e`, revoke the old PAT once a test run succeeds) |
 | `API config verification failed: missing field "<x>"` | The integration's `APICreate`/`APIUpdate` JSON expects `<x>` but the API didn't return it | Either the upstream control plane stopped persisting that field (legitimate change — update the expected JSON) or the provider isn't sending it (bug — fix the provider's `MarshalJSON`/`flatten` path) |
 | `ImportStateVerify` mismatch | A computed-only field is leaking into the state diff | Add the field to `ImportStateVerifyIgnore` in the helper (already done for `write_key` on sources) |
 | `destination <id> not found in API` after Create | The Create step thinks it succeeded but the resource isn't queryable | Check the job log for an earlier 4xx/5xx that the SDK swallowed; reproduce locally with `TF_LOG=DEBUG` |

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -105,7 +105,7 @@ Two-credential model:
 
 ### Per-environment table
 
-| Env | Workspace API URL (`RUDDERSTACK_ACC_TEST_API_URL`) | PAT vault entry | Account vault entry |
+| Env | Workspace API URL (`vars.RUDDERSTACK_ACC_TEST_API_URL` in CI; `RUDDERSTACK_API_URL` locally) | PAT vault entry | Account vault entry |
 |---|---|---|---|
 | dev | `https://api.dev.rudderlabs.com` | eng vault: e2e PAT for this provider | eng vault: e2e account for this provider |
 
@@ -141,7 +141,7 @@ RUDDERSTACK_ACCESS_TOKEN=<paste from vault>
 RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com
 ```
 
-The single-integration targets (`testacc-dest`, `testacc-source`) use a `(?i)`-prefixed Go regex so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`). The bulk targets (`testacc-plan`, `testacc-all`, `testacc-conn`) and the CI workflow use a case-sensitive `TestAcc*` prefix instead, which works because every generated test name starts with `TestAcc`.
+The single-integration targets (`testacc-dest`, `testacc-source`) — and the CI destination CRUD job — use a `(?i)`-prefixed Go regex, so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`). The bulk targets (`testacc-plan`, `testacc-all`, `testacc-conn`) and the CI source/connection jobs use a case-sensitive `TestAcc*` prefix instead, which works because every generated test name starts with `TestAcc`.
 
 ---
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -73,7 +73,7 @@ grep -rB1 -A2 --include='*_test.go' "acc.PlanOnly()" rudderstack/integrations
 `detect-changes` (in `e2e-tests.yml`) decides which integrations are affected:
 
 - Touching any of `rudderstack/resource_destination.go`, `rudderstack/resource_source.go`, `rudderstack/client.go`, `rudderstack/provider.go`, `rudderstack/configs/`, `rudderstack/integrations/destinations/common_config_meta.go`, or `internal/testutil/acc/` ⇒ runs **all** destinations, sources, and connections.
-- Otherwise — only changed `destination_<name>*.go` files run CRUD; sources/connections only run CRUD if their respective directories are touched.
+- Otherwise — any changed file matching `rudderstack/integrations/destinations/destination_<name>...` (regardless of extension — `.go`, `.tf` examples, `.md` templates, test files) triggers CRUD for that destination. Sources and connections only run CRUD if their respective directories are touched.
 
 ### Environments
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -29,24 +29,17 @@ There are two run modes:
 
 ## 2. What's covered
 
-Verified by parsing `*_test.go` in this commit. The coverage test `internal/testutil/acc/coverage_test.go` (run as part of `make test-ci`) fails if any registered destination or source is missing its `TestAcc*` function.
+Every registered destination and source has a `TestAcc*` function — enforced at build time by `internal/testutil/acc/coverage_test.go` (run as part of `make test-ci`). Connection coverage is intentionally narrow (two source→destination wiring tests); per-integration behavior is covered by the source/destination tests.
 
-### Destinations (48)
-
-`ActiveCampaign`, `Adjust`, `AdobeAnalytics`, `Amplitude`, `AttentiveTag`, `BQStream`, `BigQuery`, `Braze`, `CustomerIO`, `CustomerioAudience`, `FacebookConversions`, `FacebookPixel`, `Firebase`, `GCS`, `GoogleAds`, `GoogleAnalytics`, `GoogleAnalytics4`, `GooglePubSub`, `GoogleSheets`, `GoogleTagManager`, `Hs`, `HsHubspotEvents`, `Http`, `Intercom`, `Iterable`, `Kafka`, `Kinesis`, `LinkedinAds`, `LinkedinInsightTag`, `Marketo`, `Mixpanel`, `Postgres`, `Posthog`, `Qualtrics`, `Redis`, `Redshift`, `S3`, `S3Datalake`, `Salesforce`, `Sentry`, `Slack`, `Snowflake`, `SnowflakeStreaming`, `StatSig`, `TiktokAds`, `VWO`, `Webhook`, `Zendesk`.
-
-### Sources (52)
-
-`AMP`, `Adjust`, `Android`, `AndroidKotlin`, `Appcenter`, `Appsflyer`, `Auth0`, `Braze`, `Canny`, `CloseCRM`, `Cordial`, `Cordova`, `Customerio`, `Dotnet`, `Extole`, `FacebookLeadAds`, `Flutter`, `Formsort`, `GainsightPX`, `Go`, `HTTP`, `IOS`, `IOSSwift`, `Iterable`, `Java`, `Javascript`, `JavascriptWithSettings`, `Looker`, `Mailjet`, `Mailmodo`, `MoEngage`, `Monday`, `Node`, `Olark`, `Ortto`, `PagerDuty`, `Php`, `Pipedream`, `Python`, `Reactnative`, `Refiner`, `Revenuecat`, `Ruby`, `Rust`, `SIGNL4`, `SatisMeter`, `Segment`, `Slack`, `Unity`, `Webhook`, `WebhookShopify`.
-
-### Connections (2)
-
-`HTTPToWebhook`, `JavascriptToWebhook`. Connection coverage is intentionally narrow — these confirm source→destination wiring; per-integration behavior is covered by the source/destination tests above.
-
-To regenerate this list:
+To list the current coverage:
 ```bash
 grep -h "^func TestAcc" rudderstack/integrations/**/*.go \
   | sed 's/func //; s/(t.*//' | sort
+```
+
+**Plan-only exceptions.** A small number of tests `t.Skip` in full-CRUD mode because they need a vendor account that can't be provisioned generically. `TestAccDestinationLinkedinAds` is currently the only one (requires a valid LinkedIn OAuth account in the workspace) — it runs in `TF_ACC_PLAN_ONLY=1` mode but is skipped under `TF_ACC=1`. To find all such skips:
+```bash
+grep -B1 -A2 "acc.PlanOnly()" rudderstack/integrations/**/*_test.go
 ```
 
 ---

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -23,7 +23,7 @@ There are two run modes:
 | Mode | Env | What runs | API calls per integration |
 |---|---|---|---|
 | **Plan-only** | `TF_ACC=1 TF_ACC_PLAN_ONLY=1` | HCL parse + provider schema validation | 0 (dummy token auto-set) |
-| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy + config-subset checks | ~10 (Create/Update/Delete + 2 Gets per apply step + Import) |
+| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy + config-subset checks | ~10+ (Create/Update/Delete plus multiple Gets — Terraform refreshes state after each apply, and the acceptance helpers issue separate Gets for exists + config + settings + destroy verification) |
 
 ---
 
@@ -51,11 +51,13 @@ grep -rB1 -A2 --include='*_test.go' "acc.PlanOnly()" rudderstack/integrations
 1. **Provider factory** — `TestAccProviderFactories` constructs the provider with `rudderstack.New()`. The provider reads `RUDDERSTACK_ACCESS_TOKEN` and `RUDDERSTACK_API_URL` from env.
 2. **Pre-check** — In full CRUD mode, `TestAccPreCheck` aborts the test if `RUDDERSTACK_ACCESS_TOKEN` is unset. In plan-only mode, `ensureDummyToken` sets `RUDDERSTACK_ACCESS_TOKEN=plan-only-dummy-token` via `os.Setenv` (chosen over `t.Setenv` so `t.Parallel()` still works).
 3. **Random name** — `RandomName("<integration>")` prefixes resources with `tf-acc-` and a random 62-bit int, so leftover resources from a failed run can be identified and cleaned up by name prefix.
-4. **Test steps** —
+4. **Test steps** — destinations and sources run the full lifecycle:
    - Step 1: Apply `TerraformCreate` HCL. Check resource exists in API, then subset-match its `Config` JSON against `APICreate`.
    - Step 2: Apply `TerraformUpdate` HCL. Re-check, subset-match against `APIUpdate`.
    - Step 3: `ImportStateVerify` — Terraform imports by ID and asserts the resulting state matches the in-memory state. For sources, `write_key` is excluded (computed, not returned on import).
    - Cleanup: `CheckDestroy` — verifies Delete handler ran (soft-delete tolerant for sources/destinations; strict for connections).
+
+   Connection tests are narrower — they run Create + `ImportStateVerify` + Destroy only. There's no Update step and no config-subset verification; the checks just assert that `source_id`/`destination_id` are wired correctly and the connection exists in the API.
 5. **API URL handling** — `newTestAPIClient()` strips a trailing `/v2` from `RUDDERSTACK_API_URL` for backward compatibility (the client adds it back internally). Pass the base URL; the `/v2` is optional.
 
 ---

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -87,10 +87,6 @@ grep -h "^func TestAcc" rudderstack/integrations/**/*.go \
 - The CRUD jobs run inside the GitHub **Environment** `e2e` (`environment: e2e` in the workflow). The environment binds the test workspace's PAT and API URL; if you need a separate staging/prod target, add a second environment and a duplicate matrix job.
 - There is currently **one** environment (the dev control plane). No staging or prod target. Treat the dev workspace as the only source of truth for what these tests verify.
 
-### "First run fails by design" patterns
-
-None today. There are no DevOps PRs that must merge before a verify step passes — if a new PR's E2E run fails on the very first attempt without any infrastructure change, it is a real failure. Re-running without a code change should not turn it green; if it does, file a flake.
-
 ---
 
 ## 5. Test accounts & credentials

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -66,7 +66,7 @@ grep -rB1 -A2 --include='*_test.go' "acc.PlanOnly()" rudderstack/integrations
 
 - **PR to `main`** — `.github/workflows/e2e-tests.yml` runs `plan-only` for everything and `e2e-crud` / `e2e-source-crud` / `e2e-conn-crud` for affected integrations. Gated by `e2e-summary`.
 - **Push to `main`** — no E2E run on push. `release-please` opens/updates the release PR; release artifacts publish only when the release PR is merged and the GitHub Release is created.
-- **No nightly / scheduled run.** If a destination's API config drifts upstream (the control plane adds/removes a field), the next PR that touches that destination will catch it — not before. If you need wider coverage, trigger a no-op PR or rerun the workflow against `main`.
+- **No nightly / scheduled run.** If a destination's API config drifts upstream (the control plane adds/removes a field), the next PR that touches that destination will catch it — not before. The workflow only triggers on `pull_request` (no `push` or `workflow_dispatch`); to force a fresh run, open a no-op PR to `main` or run `make testacc-all` locally against the CI `RUDDERSTACK_API_URL` / PAT.
 
 ### Affected-integration detection
 

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -138,7 +138,7 @@ Create `.env` at the repo root (git-ignored). The Makefile auto-loads it via `-i
 
 ```
 RUDDERSTACK_ACCESS_TOKEN=<paste from vault>
-RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com/v2
+RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com
 ```
 
 The `-run` patterns use Go's `(?i)` case-insensitive regex, so `DEST=webhook` matches `TestAccDestinationWebhook` and `DEST=customer_io` matches `TestAccDestinationCustomerIO` (underscores become `.*`).

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ make testacc-conn
 make testacc-all
 ```
 
-The `-run` patterns use `(?i)` for case-insensitive matching, so `DEST=webhook` matches `TestAccDestinationWebhook`.
+The single-integration targets (`testacc-dest`, `testacc-source`) use a `(?i)`-prefixed regex so `DEST=webhook` matches `TestAccDestinationWebhook`. The bulk targets (`testacc-plan`, `testacc-all`, `testacc-conn`) use a case-sensitive `TestAcc*` prefix instead — all generated function names start with `TestAcc` so case-folding isn't needed.
 
 ## Adding E2E Tests for New Integrations
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The provider includes an E2E acceptance test framework that validates integratio
 | Mode | Env vars | What it does | API calls |
 |---|---|---|---|
 | **Plan-only** | `TF_ACC=1 TF_ACC_PLAN_ONLY=1` | Validates HCL config + provider schema | Zero |
-| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy | ~5 per integration |
+| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy | ~10 per integration (Create/Update/Delete + 2 Gets per apply step + Import) |
 
 - **Plan-only** runs for all integrations on every PR. It sets a dummy token automatically — no credentials needed.
 - **Full CRUD** runs only for integrations affected by the PR, using real API credentials. After each Create and Update step, the test fetches the resource from the API and verifies its config matches the expected `APICreate`/`APIUpdate` JSON from the test configs.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ func TestAccConnectionExampleToWebhook(t *testing.T) {
 
 ## CI, secrets, and operations
 
-CI orchestration (affected-integration detection, matrix CRUD jobs, summary gate), the per-environment credentials model, and rotation steps live in [`E2E_TESTING.md`](E2E_TESTING.md). Read it before rotating the PAT or debugging a CI-only failure.
+CI orchestration (affected-integration detection, matrix CRUD jobs, summary gate) and the per-environment credentials model live in [`E2E_TESTING.md`](E2E_TESTING.md). The step-by-step PAT rotation procedure is in the platform team's runbook (the operational guide points to it). Read both before rotating the PAT or debugging a CI-only failure.
 
 Note: `make test-ci` enforces coverage — any registered integration missing its `TestAcc*` function will fail the build. Matching is case-insensitive (`TestAccDestinationCustomerIO` matches the registry key `customerio`).
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Create a `.env` file at the repo root (git-ignored):
 
 ```
 RUDDERSTACK_ACCESS_TOKEN=your-access-token
-RUDDERSTACK_API_URL=https://api.rudderstack.com
+RUDDERSTACK_API_URL=https://api.dev.rudderlabs.com  # same base URL CI uses; see E2E_TESTING.md
 ```
 
 The Makefile auto-loads `.env` via `-include .env` + `export`.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ When you run the skill for an integration that already exists, it:
 <a id="e2e-testing"></a>
 # E2E Testing
 
-The provider includes an E2E acceptance test framework that validates integrations against the real RudderStack API. Every registered source and destination has a corresponding `TestAcc*` function.
+The provider includes an E2E acceptance test framework that validates integrations against the real RudderStack control-plane API. Every registered source and destination has a corresponding `TestAcc*` function.
+
+> Operating the suite (environments, CI secrets, rotation, debugging, what's actually verified) is covered in [`E2E_TESTING.md`](E2E_TESTING.md). The section below is the contributor cheatsheet: how to run tests and how to add one for a new integration.
 
 ## Two Modes
 
@@ -208,22 +210,9 @@ make testacc-all
 
 The `-run` patterns use `(?i)` for case-insensitive matching, so `DEST=webhook` matches `TestAccDestinationWebhook`.
 
-## Architecture
-
-The framework lives in `internal/testutil/acc/`:
-
-| File | Purpose |
-|---|---|
-| `provider.go` | Provider factory, `TestAccPreCheck()`, `PlanOnly()`, dummy token helper |
-| `destinations.go` | `AccAssertDestination()` — plan-only or full CRUD for destinations |
-| `sources.go` | `AccAssertSource()` — plan-only or full CRUD for sources |
-| `connections.go` | `AccAssertConnection()` — tests source→destination wiring |
-| `config_verify.go` | Shared API config comparison logic (subset check) |
-| `coverage_test.go` | CI enforcement — fails if any registered integration lacks a `TestAcc*` function |
-
-E2E tests reuse the same `[]configs.TestConfig` data as unit tests — no duplicated HCL.
-
 ## Adding E2E Tests for New Integrations
+
+E2E tests reuse the same `[]configs.TestConfig` data as unit tests — no duplicated HCL. The framework lives in `internal/testutil/acc/`; see [`E2E_TESTING.md`](E2E_TESTING.md#where-the-framework-lives) for a per-file breakdown.
 
 ### Destinations
 
@@ -268,20 +257,11 @@ func TestAccConnectionExampleToWebhook(t *testing.T) {
 }
 ```
 
-## CI Workflow
+## CI, secrets, and operations
 
-The GitHub Actions workflow (`.github/workflows/e2e-tests.yml`) runs on every PR:
+CI orchestration (affected-integration detection, matrix CRUD jobs, summary gate), the per-environment credentials model, and rotation steps live in [`E2E_TESTING.md`](E2E_TESTING.md). Read it before rotating the PAT or debugging a CI-only failure.
 
-1. **detect-changes** — Determines which integrations are affected by the PR
-2. **plan-only** — Validates all integration configs with zero API calls
-3. **e2e-crud** — Runs full CRUD tests only for affected integrations (matrix strategy, max 5 parallel)
-4. **e2e-summary** — Gates the PR on both plan-only and CRUD results
-
-Core file changes (provider, configs, client, acc helpers) trigger CRUD tests for **all** integrations.
-
-## CI Enforcement
-
-A coverage test (`internal/testutil/acc/coverage_test.go`) runs during `make test-ci` and fails if any registered integration is missing its `TestAcc*` function. This uses case-insensitive matching — exact PascalCase is not required.
+Note: `make test-ci` enforces coverage — any registered integration missing its `TestAcc*` function will fail the build. Matching is case-insensitive (`TestAccDestinationCustomerIO` matches the registry key `customerio`).
 
 # Related
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The provider includes an E2E acceptance test framework that validates integratio
 | Mode | Env vars | What it does | API calls |
 |---|---|---|---|
 | **Plan-only** | `TF_ACC=1 TF_ACC_PLAN_ONLY=1` | Validates HCL config + provider schema | Zero |
-| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy | ~10 per integration (Create/Update/Delete + 2 Gets per apply step + Import) |
+| **Full CRUD** | `TF_ACC=1` | Create → Update → Import → Destroy | ~10+ per integration (Create/Update/Delete plus multiple Gets — see `E2E_TESTING.md` for the breakdown) |
 
 - **Plan-only** runs for all integrations on every PR. It sets a dummy token automatically — no credentials needed.
 - **Full CRUD** runs only for integrations affected by the PR, using real API credentials. After each Create and Update step, the test fetches the resource from the API and verifies its config matches the expected `APICreate`/`APIUpdate` JSON from the test configs.


### PR DESCRIPTION
## Summary

Adds `E2E_TESTING.md` at the repo root as the team-facing operational reference for the E2E suite — so a new operator can run, debug, and rotate credentials without asking.

- **Scope** — calls out exactly what's verified (control-plane CRUD, schema, subset config match, import round-trip) and what isn't (downstream event delivery; soft-delete semantics on source/destination cleanup).
- **What's covered** — exhaustive list of destinations (48), sources (52), and connections (2), generated from the actual `TestAcc*` functions in the codebase.
- **Run flow** — annotated walkthrough of `AccAssertDestination`/`Source`/`Connection`, including the dummy-token + `os.Setenv` trick for `t.Parallel()` compatibility.
- **Environments & triggers** — current PR-only trigger, the `e2e` GitHub Environment, affected-integration detection rules, and an explicit "no first-run-fails-by-design patterns today" so operators don't quietly re-run failing jobs.
- **Two-credential model** — PAT (vault → GitHub secret, used by CI) vs. underlying test account `integration-accounts+terraform-provider-e2e@rudderstack.com` (vault → humans only). Mirroring direction stated; vault paths referenced (flagged for confirmation with the platform team).
- **CI secrets mapping** — `RUDDERSTACK_ACC_TEST_TOKEN` (secret) + `RUDDERSTACK_ACC_TEST_API_URL` (var), per-provider bundling guidance, rotation steps with a safe rollback note.
- **Running locally** — minimal commands.
- **Troubleshooting** — honest about captured artifacts (Go-test against an HTTP API: no screenshots/MHTML; primary surface is the Actions log + inline `compareConfig` diff dump + `TF_LOG=DEBUG` locally). Pairs each artifact with a concrete failure mode.

Aligns naming/conventions across docs:
- `README.md` — trims architecture / CI / coverage subsections (now in `E2E_TESTING.md`); keeps the contributor cheatsheet.
- `.claude/skills/onboard-integration/reference/e2e-testing.md` — points at the operational guide and restates the `TestAccDestination<Name>` / `TestAccSource<Name>` no-`_basic` naming convention.

## Test plan

- [ ] Markdown renders cleanly on GitHub (tables, headings, anchors)
- [ ] All cross-links resolve (`README.md` ↔ `E2E_TESTING.md` ↔ skill reference)
- [ ] Vault paths in §5/§6 confirmed against actual vault entries with the platform team (placeholders flagged in the doc)
- [ ] Coverage tables in §2 match `grep -h "^func TestAcc" rudderstack/integrations/**/*.go` at HEAD
- [ ] A teammate unfamiliar with the suite can rotate the PAT using only §6 (smoke-test reviewer step)