### PR TITLE
feat(accounts): add Accounts integration registry (DEX-376)

### DIFF
--- a/rudderstack/configs/registries.go
+++ b/rudderstack/configs/registries.go
@@ -5,6 +5,7 @@ import "fmt"
 var (
 	Sources      *Registry = &Registry{name: "sources"}
 	Destinations *Registry = &Registry{name: "destinations"}
+	Accounts     *Registry = &Registry{name: "accounts"}
 )
 
 type Registry struct {


### PR DESCRIPTION
Implements [DEX-376](https://linear.app/rudderstack/issue/DEX-376) — adds the `Accounts` integration registry alongside `Sources` and `Destinations` in `rudderstack/configs/registries.go`.

**Stack position:** base of the Stream E stack (TF rETL Account Management — Lovable Phase 1). Subsequent PRs stack on this:
`main ← **dex-376** ← dex-377 ← dex-378 ← dex-381 ← dex-379 ← dex-380 ← dex-382`

The registry is intentionally empty until DEX-379 registers the BigQuery account into it.

Spec: CONTRACT-ACCT-V1 §9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)