### PR TITLE
feat(accounts): read-only rudderstack_account data source (DEX-378)

### DIFF
--- a/examples/data_source_account.tf
+++ b/examples/data_source_account.tf
@@ -1,0 +1,3 @@
+data "rudderstack_account" "example" {
+  id = "acc_01HX..."
+}

--- a/rudderstack/data_source_account.go
+++ b/rudderstack/data_source_account.go
@@ -1,0 +1,101 @@
+package rudderstack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAccount() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAccountRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The unique identifier of the account to look up.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Human readable name of the account.",
+			},
+			"definition_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The account definition name (e.g. SOURCE_BIGQUERY).",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The account definition type (e.g. bigquery).",
+			},
+			"options": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Free-form non-secret options for the account, as key-value string pairs.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAccountRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c, ok := m.(*Client)
+	if !ok {
+		return diag.FromErr(fmt.Errorf("API client is not configured"))
+	}
+
+	id := d.Get("id").(string)
+
+	acc, err := c.Accounts.Get(ctx, id)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("could not get account: %w", err))
+	}
+
+	d.SetId(acc.ID)
+
+	if err := d.Set("name", acc.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("definition_name", acc.Definition.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("type", acc.Definition.Type); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Unmarshal options from RawMessage into map[string]interface{}, then
+	// convert all values to strings so they fit the TypeMap(TypeString) schema.
+	var rawOpts map[string]interface{}
+	if len(acc.Options) > 0 && string(acc.Options) != "null" {
+		if err := json.Unmarshal(acc.Options, &rawOpts); err != nil {
+			return diag.FromErr(fmt.Errorf("could not unmarshal account options: %w", err))
+		}
+	}
+
+	optsMap := make(map[string]string, len(rawOpts))
+	for k, v := range rawOpts {
+		switch sv := v.(type) {
+		case string:
+			optsMap[k] = sv
+		default:
+			b, err := json.Marshal(v)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("could not stringify option key %q: %w", k, err))
+			}
+			optsMap[k] = string(b)
+		}
+	}
+
+	if err := d.Set("options", optsMap); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.Diagnostics{}
+}

--- a/rudderstack/data_source_account_test.go
+++ b/rudderstack/data_source_account_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
 )
 
 // TestDataSourceAccountRead exercises dataSourceAccountRead using a mock
@@ -18,10 +20,14 @@ func TestDataSourceAccountRead(t *testing.T) {
 
 	optionsJSON := `{"warehouse":"us-east-1","project":"my-project"}`
 
-	accounts.On("Get", mock.Anything, "acc_1").Return(&Account{
+	accounts.On("Get", mock.Anything, "acc_1").Return(&client.Account{
 		ID:   "acc_1",
 		Name: "my-bigquery-account",
-		Definition: AccountDefinition{
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
 			Name:     "SOURCE_BIGQUERY",
 			Type:     "bigquery",
 			Category: "warehouse",
@@ -94,10 +100,14 @@ func TestDataSourceAccountRead(t *testing.T) {
 func TestDataSourceAccountReadNilOptions(t *testing.T) {
 	accounts := &mockAccountsService{}
 
-	accounts.On("Get", mock.Anything, "acc_2").Return(&Account{
+	accounts.On("Get", mock.Anything, "acc_2").Return(&client.Account{
 		ID:   "acc_2",
 		Name: "no-options-account",
-		Definition: AccountDefinition{
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
 			Name: "SOURCE_SNOWFLAKE",
 			Type: "snowflake",
 		},

--- a/rudderstack/data_source_account_test.go
+++ b/rudderstack/data_source_account_test.go
@@ -1,0 +1,128 @@
+package rudderstack
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestDataSourceAccountRead exercises dataSourceAccountRead using a mock
+// AccountsService injected directly into *Client. It verifies that all
+// non-secret attributes (name, definition_name, type, options) are populated
+// from the mocked *Account, and that no "secret" attribute exists in the schema.
+func TestDataSourceAccountRead(t *testing.T) {
+	accounts := &mockAccountsService{}
+
+	optionsJSON := `{"warehouse":"us-east-1","project":"my-project"}`
+
+	accounts.On("Get", mock.Anything, "acc_1").Return(&Account{
+		ID:   "acc_1",
+		Name: "my-bigquery-account",
+		Definition: AccountDefinition{
+			Name:     "SOURCE_BIGQUERY",
+			Type:     "bigquery",
+			Category: "warehouse",
+		},
+		Options: json.RawMessage(optionsJSON),
+	}, nil)
+
+	ds := dataSourceAccount()
+
+	// Verify there is no "secret" attribute in the schema (CONTRACT §3).
+	if _, exists := ds.Schema["secret"]; exists {
+		t.Fatal("data source schema must not contain a 'secret' attribute")
+	}
+
+	d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+		"id": "acc_1",
+	})
+
+	c := &Client{Accounts: accounts}
+	diags := dataSourceAccountRead(context.Background(), d, c)
+	if diags.HasError() {
+		t.Fatalf("unexpected error from dataSourceAccountRead: %v", diags)
+	}
+
+	// ID must be set from the returned account.
+	if got := d.Id(); got != "acc_1" {
+		t.Errorf("expected id=acc_1, got %q", got)
+	}
+
+	// name
+	if got := d.Get("name").(string); got != "my-bigquery-account" {
+		t.Errorf("expected name=my-bigquery-account, got %q", got)
+	}
+
+	// definition_name
+	if got := d.Get("definition_name").(string); got != "SOURCE_BIGQUERY" {
+		t.Errorf("expected definition_name=SOURCE_BIGQUERY, got %q", got)
+	}
+
+	// type
+	if got := d.Get("type").(string); got != "bigquery" {
+		t.Errorf("expected type=bigquery, got %q", got)
+	}
+
+	// options — must be a map[string]interface{} with string values.
+	rawOpts := d.Get("options")
+	optsMap, ok := rawOpts.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected options to be map[string]interface{}, got %T", rawOpts)
+	}
+	checkOpt := func(key, want string) {
+		t.Helper()
+		v, exists := optsMap[key]
+		if !exists {
+			t.Errorf("options[%q] not found", key)
+			return
+		}
+		if got, _ := v.(string); got != want {
+			t.Errorf("options[%q]: expected %q, got %q", key, want, got)
+		}
+	}
+	checkOpt("warehouse", "us-east-1")
+	checkOpt("project", "my-project")
+
+	accounts.AssertExpectations(t)
+}
+
+// TestDataSourceAccountReadNilOptions verifies that a nil/empty options payload
+// results in an empty map rather than an error.
+func TestDataSourceAccountReadNilOptions(t *testing.T) {
+	accounts := &mockAccountsService{}
+
+	accounts.On("Get", mock.Anything, "acc_2").Return(&Account{
+		ID:   "acc_2",
+		Name: "no-options-account",
+		Definition: AccountDefinition{
+			Name: "SOURCE_SNOWFLAKE",
+			Type: "snowflake",
+		},
+		Options: nil,
+	}, nil)
+
+	ds := dataSourceAccount()
+	d := schema.TestResourceDataRaw(t, ds.Schema, map[string]interface{}{
+		"id": "acc_2",
+	})
+
+	c := &Client{Accounts: accounts}
+	diags := dataSourceAccountRead(context.Background(), d, c)
+	if diags.HasError() {
+		t.Fatalf("unexpected error from dataSourceAccountRead with nil options: %v", diags)
+	}
+
+	rawOpts := d.Get("options")
+	optsMap, ok := rawOpts.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected options to be map[string]interface{}, got %T", rawOpts)
+	}
+	if len(optsMap) != 0 {
+		t.Errorf("expected empty options map, got %v", optsMap)
+	}
+
+	accounts.AssertExpectations(t)
+}

--- a/templates/data-sources/account.md.tmpl
+++ b/templates/data-sources/account.md.tmpl
@@ -1,0 +1,17 @@
+---
+page_title: "rudderstack_account Data Source - terraform-provider-rudderstack"
+subcategory: ""
+description: |-
+
+---
+
+# rudderstack_account (Data Source)
+
+Use this data source to read an existing RudderStack warehouse account by ID without
+managing it as a Terraform-managed resource. Only non-secret attributes are exposed.
+
+## Example Usage
+
+{{tffile "examples/data_source_account.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Implements [DEX-378](https://linear.app/rudderstack/issue/DEX-378) — read-only `rudderstack_account` data source (look up an existing account by `id`, expose `name`/`definition_name`/`type`/`options`; **no secret**, no importer). The provider's first data source.

**Stacked on #261** (DEX-377) — uses its `AccountsService` seam.

Provider `DataSourcesMap` wiring is DEX-380; `make docs` is DEX-382. This PR authors the data source, a mock-backed read test, `examples/data_source_account.tf`, and `templates/data-sources/account.md.tmpl` (establishes that tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)