### PR TITLE
feat(accounts): BigQuery account ConfigMeta + example/template (DEX-379)

### DIFF
--- a/examples/account_source_bigquery.tf
+++ b/examples/account_source_bigquery.tf
@@ -1,0 +1,8 @@
+resource "rudderstack_account_source_bigquery" "example" {
+  name = "my-bigquery-account"
+  config {
+    project     = "my-gcp-project"
+    location    = "US"
+    credentials = "{\"type\":\"service_account\"}"
+  }
+}

--- a/rudderstack/integrations/accounts/account_bigquery.go
+++ b/rudderstack/integrations/accounts/account_bigquery.go
@@ -1,0 +1,39 @@
+package accounts
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+)
+
+func init() {
+	properties := []c.ConfigProperty{
+		c.Simple("options.projectId", "project"),
+		c.Simple("options.location", "location", c.SkipZeroValue),
+		c.Simple("secret.credentials", "credentials"),
+	}
+	cfgSchema := map[string]*schema.Schema{
+		"project": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Description:      "GCP project ID where the BigQuery dataset lives.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|^[a-z][a-z0-9.:-]{4,28}[a-z0-9]$"),
+		},
+		"location": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "BigQuery dataset location (e.g. US, EU).",
+		},
+		"credentials": {
+			Type:             schema.TypeString,
+			Required:         true,
+			Sensitive:        true,
+			Description:      "GCP service account key JSON.",
+			ValidateDiagFunc: c.StringMatchesRegexp("(^env[.].+)|[\\s\\S]+"),
+		},
+	}
+	c.Accounts.Register("bigquery", c.ConfigMeta{
+		APIType:      "SOURCE_BIGQUERY",
+		Properties:   properties,
+		ConfigSchema: cfgSchema,
+	})
+}

--- a/rudderstack/integrations/accounts/account_bigquery_registration_test.go
+++ b/rudderstack/integrations/accounts/account_bigquery_registration_test.go
@@ -1,0 +1,38 @@
+package accounts_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+	_ "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/integrations/accounts"
+)
+
+func TestBigQueryAccountRegistration(t *testing.T) {
+	entries := configs.Accounts.Entries()
+	cm, ok := entries["bigquery"]
+	require.True(t, ok, "bigquery must be registered in the Accounts registry")
+
+	require.Equal(t, "SOURCE_BIGQUERY", cm.APIType, "APIType must be SOURCE_BIGQUERY")
+
+	schema := cm.ConfigSchema
+	require.NotNil(t, schema, "ConfigSchema must not be nil")
+
+	// project: Required
+	project, ok := schema["project"]
+	require.True(t, ok, "ConfigSchema must contain 'project'")
+	require.True(t, project.Required, "'project' must be Required")
+
+	// location: Optional
+	location, ok := schema["location"]
+	require.True(t, ok, "ConfigSchema must contain 'location'")
+	require.True(t, location.Optional, "'location' must be Optional")
+	require.False(t, location.Required, "'location' must not be Required")
+
+	// credentials: Required and Sensitive
+	credentials, ok := schema["credentials"]
+	require.True(t, ok, "ConfigSchema must contain 'credentials'")
+	require.True(t, credentials.Required, "'credentials' must be Required")
+	require.True(t, credentials.Sensitive, "'credentials' must be Sensitive")
+}

--- a/templates/resources/account_source_bigquery.md.tmpl
+++ b/templates/resources/account_source_bigquery.md.tmpl
@@ -1,0 +1,17 @@
+---
+page_title: "rudderstack_account_source_bigquery Resource - terraform-provider-rudderstack"
+subcategory: ""
+description: |-
+
+---
+
+# rudderstack_account_source_bigquery (Resource)
+
+This resource represents a BigQuery rETL account for storing warehouse credentials used in reverse-ETL pipelines. For more information check
+https://www.rudderstack.com/docs/sources/reverse-etl/google-bigquery/
+
+## Example Usage
+
+{{tffile "examples/account_source_bigquery.tf"}}
+
+{{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
Implements [DEX-379](https://linear.app/rudderstack/issue/DEX-379) — registers the BigQuery account definition into the `Accounts` registry.

**Stacked on #263** (DEX-381).

- `rudderstack/integrations/accounts/account_bigquery.go` — `init()` registers `bigquery` with `APIType: SOURCE_BIGQUERY` and ConfigMeta: `project`→`options.projectId`, `location`→`options.location` (optional), `credentials`→`secret.credentials` (Sensitive). Field names per [rudder-integrations-config #2522](https://github.com/rudderlabs/rudder-integrations-config/pull/2522).
- `account_bigquery_registration_test.go` — asserts registration + `credentials` Sensitive.
- `examples/account_source_bigquery.tf` + `templates/resources/account_source_bigquery.md.tmpl`.

The blank import that triggers `init()` in the provider is added by DEX-380; `make docs` runs in DEX-382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)