### PR TITLE
feat(accounts): register account resource + data source in provider (DEX-380)

### DIFF
--- a/rudderstack/integrations/integrations.go
+++ b/rudderstack/integrations/integrations.go
@@ -1,6 +1,7 @@
 package integrations
 
 import (
+	_ "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/integrations/accounts"
 	_ "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/integrations/destinations"
 	_ "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/integrations/sources"
 )

--- a/rudderstack/provider.go
+++ b/rudderstack/provider.go
@@ -42,7 +42,8 @@ func NewWithConfigureClientFunc(f ConfigureClientFunc) *schema.Provider {
 					"and fail with an error if that is missing.",
 			},
 		},
-		ResourcesMap: resourcesMap(),
+		ResourcesMap:   resourcesMap(),
+		DataSourcesMap: dataSourcesMap(),
 	}
 
 	return p
@@ -72,7 +73,17 @@ func resourcesMap() map[string]*schema.Resource {
 		resource := resourceDestination(v)
 		resources[key] = resource
 	}
+	for k, v := range configs.Accounts.Entries() {
+		key := fmt.Sprintf("rudderstack_account_source_%s", k)
+		resources[key] = resourceAccount(v)
+	}
 	return resources
+}
+
+func dataSourcesMap() map[string]*schema.Resource {
+	return map[string]*schema.Resource{
+		"rudderstack_account": dataSourceAccount(),
+	}
 }
 
 func configureClient(ctx context.Context, d *schema.ResourceData) (*Client, diag.Diagnostics) {

--- a/rudderstack/provider_test.go
+++ b/rudderstack/provider_test.go
@@ -1,0 +1,33 @@
+package rudderstack
+
+import (
+	"testing"
+
+	_ "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/integrations"
+)
+
+// TestProvider validates the provider schema and that key resources/data sources are registered.
+func TestProvider(t *testing.T) {
+	p := New()
+	if err := p.InternalValidate(); err != nil {
+		t.Fatalf("provider InternalValidate: %v", err)
+	}
+}
+
+// TestProviderAccountRegistration confirms that the account resource and data source
+// are registered in the provider after wiring (DEX-380).
+func TestProviderAccountRegistration(t *testing.T) {
+	p := New()
+
+	if _, ok := p.ResourcesMap["rudderstack_account_source_bigquery"]; !ok {
+		t.Error("expected rudderstack_account_source_bigquery in ResourcesMap, but it is missing")
+	}
+	if _, ok := p.DataSourcesMap["rudderstack_account"]; !ok {
+		t.Error("expected rudderstack_account in DataSourcesMap, but it is missing")
+	}
+
+	// Spot-check that existing registrations are still present.
+	if _, ok := p.ResourcesMap["rudderstack_connection"]; !ok {
+		t.Error("expected rudderstack_connection in ResourcesMap, but it is missing")
+	}
+}


### PR DESCRIPTION
Implements [DEX-380](https://linear.app/rudderstack/issue/DEX-380) — wires the account resource + data source into the provider.

**Stacked on #264** (DEX-379).

- `provider.go`: loops `configs.Accounts.Entries()` → `rudderstack_account_source_bigquery`; adds a `DataSourcesMap` (the provider's first) registering `rudderstack_account`.
- `integrations/integrations.go`: blank-imports the accounts package so the BigQuery `init()` runs.
- `provider_test.go`: `InternalValidate()` + asserts both register and existing resources are intact.

**Real-client swap NOT done here** (DEX-375 pending): registration runs against the stub seam; `*Client.Accounts` stays nil (no real apply in CI; unit tests inject a mock; plan-only makes no client calls). The swap (go.mod bump, wire `NewAPIClient`, delete the stub) is the one DEX-375-gated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)