### PR TITLE
test(retl): rETL acceptance tests on BigQuery (rebased from #237)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,10 +3,10 @@ name: E2E Tests
 permissions:
   contents: read
 
-# No base-branch filter: feature work ships as stacks of inter-dependent PRs
-# (feature/… → feature/…). Restricting to `main` meant the E2E suite never ran
-# on any stacked PR. detect-changes diffs base.sha..head.sha, so each PR's run
-# stays scoped to its incremental change regardless of base branch.
+# No base-branch filter: this work ships as a stack of inter-dependent feature
+# PRs (feature/… → feature/…), so restricting to `main` meant the E2E suite
+# never ran on any stacked PR. detect-changes diffs base.sha..head.sha, so it
+# scopes correctly to each PR's incremental change regardless of base branch.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -23,6 +23,7 @@ jobs:
       has_affected: ${{ steps.detect.outputs.has_affected }}
       has_affected_sources: ${{ steps.detect.outputs.has_affected_sources }}
       has_affected_connections: ${{ steps.detect.outputs.has_affected_connections }}
+      has_affected_retl: ${{ steps.detect.outputs.has_affected_retl }}
       has_affected_accounts: ${{ steps.detect.outputs.has_affected_accounts }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -97,6 +98,13 @@ jobs:
             echo "has_affected_connections=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_affected_connections=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # RETL detection: run RETL acceptance tests if retl/ or core files changed.
+          if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -q "rudderstack/retl/"; then
+            echo "has_affected_retl=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_affected_retl=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Account detection: run account acceptance tests if accounts/ or core files changed.
@@ -257,6 +265,53 @@ jobs:
             -timeout 10m \
             -count=1
 
+  e2e-retl-crud:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_affected_retl == 'true'
+    runs-on: ubuntu-latest
+    environment: e2e
+    timeout-minutes: 15
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
+
+      - name: Run E2E RETL CRUD tests
+        # RUDDERSTACK_RETL_TEST_ACCOUNT_ID is an opaque warehouse-account
+        # identifier (not a secret) and is sourced from the `e2e` GitHub
+        # Environment as a variable — same pattern as RUDDERSTACK_ACC_TEST_API_URL.
+        # Until the variable is set, the expression renders empty, the helpers
+        # t.Skip the live tests, and this job passes as a no-op. When the
+        # variable is added (Phase 2: a Snowflake account ID in the test
+        # workspace), live Create/Update/Import/Destroy starts running with no
+        # further code change.
+        env:
+          TF_ACC: "1"
+          RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDERSTACK_ACC_TEST_TOKEN }}
+          RUDDERSTACK_API_URL: ${{ vars.RUDDERSTACK_ACC_TEST_API_URL }}
+          RUDDERSTACK_RETL_TEST_ACCOUNT_ID: ${{ vars.RUDDERSTACK_RETL_TEST_ACCOUNT_ID }}
+        run: |
+          go test \
+            ./rudderstack/retl/ \
+            -v \
+            -run "TestAccRETL" \
+            -timeout 10m \
+            -count=1
+
   e2e-account-crud:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_affected_accounts == 'true'
@@ -301,7 +356,7 @@ jobs:
             -count=1
 
   e2e-summary:
-    needs: [detect-changes, plan-only, e2e-crud, e2e-source-crud, e2e-conn-crud, e2e-account-crud]
+    needs: [detect-changes, plan-only, e2e-crud, e2e-source-crud, e2e-conn-crud, e2e-retl-crud, e2e-account-crud]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -316,10 +371,12 @@ jobs:
           CRUD_RESULT: ${{ needs.e2e-crud.result }}
           SOURCE_CRUD_RESULT: ${{ needs.e2e-source-crud.result }}
           CONN_CRUD_RESULT: ${{ needs.e2e-conn-crud.result }}
+          RETL_CRUD_RESULT: ${{ needs.e2e-retl-crud.result }}
           ACCOUNT_CRUD_RESULT: ${{ needs.e2e-account-crud.result }}
           HAS_AFFECTED: ${{ needs.detect-changes.outputs.has_affected }}
           HAS_AFFECTED_SOURCES: ${{ needs.detect-changes.outputs.has_affected_sources }}
           HAS_AFFECTED_CONNECTIONS: ${{ needs.detect-changes.outputs.has_affected_connections }}
+          HAS_AFFECTED_RETL: ${{ needs.detect-changes.outputs.has_affected_retl }}
           HAS_AFFECTED_ACCOUNTS: ${{ needs.detect-changes.outputs.has_affected_accounts }}
         run: |
           if [ "$PLAN_RESULT" != "success" ]; then
@@ -336,6 +393,10 @@ jobs:
           fi
           if [ "$HAS_AFFECTED_CONNECTIONS" = "true" ] && [ "$CONN_CRUD_RESULT" != "success" ]; then
             echo "E2E connection CRUD tests failed."
+            exit 1
+          fi
+          if [ "$HAS_AFFECTED_RETL" = "true" ] && [ "$RETL_CRUD_RESULT" != "success" ]; then
+            echo "E2E RETL CRUD tests failed."
             exit 1
           fi
           if [ "$HAS_AFFECTED_ACCOUNTS" = "true" ] && [ "$ACCOUNT_CRUD_RESULT" != "success" ]; then

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-ci:
 
 .PHONY: testacc-all
 testacc-all: ## Run all E2E acceptance tests (full CRUD)
-	TF_ACC=1 go test ./rudderstack/integrations/... -v -run "TestAcc" -timeout 60m -count=1
+	TF_ACC=1 go test ./rudderstack/integrations/... ./rudderstack/retl/ -v -run "TestAcc" -timeout 60m -count=1
 
 .PHONY: testacc-dest
 testacc-dest: ## Run E2E for one destination. Usage: make testacc-dest DEST=webhook
@@ -86,6 +86,10 @@ testacc-source: ## Run E2E for one source. Usage: make testacc-source SRC=http
 testacc-conn: ## Run E2E for connections. Usage: make testacc-conn
 	TF_ACC=1 go test ./rudderstack/integrations/connections/ -v -run "TestAccConnection" -timeout 10m -count=1
 
+.PHONY: testacc-retl
+testacc-retl: ## Run E2E for RETL resources (sources + connections)
+	TF_ACC=1 go test ./rudderstack/retl/ -v -run "TestAccRETL" -timeout 10m -count=1
+
 .PHONY: testacc-plan
 testacc-plan: ## Plan-only validation for all integrations (no API calls)
-	TF_ACC=1 TF_ACC_PLAN_ONLY=1 go test ./rudderstack/integrations/... -run "TestAcc" -timeout 5m -count=1
+	TF_ACC=1 TF_ACC_PLAN_ONLY=1 go test ./rudderstack/integrations/... ./rudderstack/retl/ -run "TestAcc" -timeout 5m -count=1

--- a/internal/testutil/acc/coverage_test.go
+++ b/internal/testutil/acc/coverage_test.go
@@ -48,6 +48,33 @@ func TestAllSourcesHaveAcceptanceTests(t *testing.T) {
 	}
 }
 
+// retlResources lists the RETL resources registered in rudderstack/provider.go.
+// They have no registry like configs.Sources/Destinations, so the coverage gate
+// hard-codes the set. Update this list when adding a new RETL resource.
+var retlResources = []string{
+	"retl_source_model",
+	"retl_source_table",
+	"retl_connection",
+}
+
+// TestAllRETLResourcesHaveAcceptanceTests verifies that every RETL resource
+// has a corresponding TestAccRETL* function in rudderstack/retl/.
+func TestAllRETLResourcesHaveAcceptanceTests(t *testing.T) {
+	testFuncs, err := collectTestFunctions("rudderstack/retl")
+	if err != nil {
+		t.Fatalf("failed to scan test functions: %v", err)
+	}
+
+	for _, name := range retlResources {
+		// Drop the leading "retl_" so "retl_source_model" matches
+		// TestAccRETLSourceModel*.
+		key := normalizeKey(strings.TrimPrefix(name, "retl_"))
+		if !hasMatchingFuncPrefix(testFuncs, "TestAccRETL", key) {
+			t.Errorf("RETL resource %q has no acceptance test matching TestAccRETL<Name>*", name)
+		}
+	}
+}
+
 // collectTestFunctions parses *_test.go files in the given directory and returns
 // a set of all top-level test function names.
 func collectTestFunctions(relDir string) (map[string]bool, error) {
@@ -121,6 +148,25 @@ func hasMatchingFunc(funcs map[string]bool, prefix, normalizedKey string) bool {
 		}
 		rest := lower[len(lowerPrefix):]
 		if rest == normalizedKey {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMatchingFuncPrefix is the prefix-matching variant of hasMatchingFunc:
+// after stripping `prefix`, the remainder need only START with `normalizedKey`.
+// Used for RETL acceptance tests which name variants with suffixes
+// (e.g. TestAccRETLSourceModel_Snowflake matches key "sourcemodel").
+func hasMatchingFuncPrefix(funcs map[string]bool, prefix, normalizedKey string) bool {
+	lowerPrefix := strings.ToLower(prefix)
+	for fn := range funcs {
+		lower := strings.ToLower(fn)
+		if !strings.HasPrefix(lower, lowerPrefix) {
+			continue
+		}
+		rest := lower[len(lowerPrefix):]
+		if strings.HasPrefix(rest, normalizedKey) {
 			return true
 		}
 	}

--- a/internal/testutil/acc/coverage_test.go
+++ b/internal/testutil/acc/coverage_test.go
@@ -51,6 +51,11 @@ func TestAllSourcesHaveAcceptanceTests(t *testing.T) {
 // retlResources lists the RETL resources registered in rudderstack/provider.go.
 // They have no registry like configs.Sources/Destinations, so the coverage gate
 // hard-codes the set. Update this list when adding a new RETL resource.
+//
+// rudderstack_retl_connection_customerio_audience is intentionally excluded here:
+// it is a vendor-gated integration (needs a Customer.io account to exercise live),
+// handled the same way as other vendor-gated integrations. It is brought under the
+// gate by its own follow-up change.
 var retlResources = []string{
 	"retl_source_model",
 	"retl_source_table",

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -1,0 +1,393 @@
+package acc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/client/retl"
+)
+
+// retlAccountIDEnv names the env var that supplies a real warehouse account ID
+// for live RETL acceptance tests. When unset (and the test is not running in
+// plan-only mode) the helpers t.Skip — local runs without a workspace fixture
+// shouldn't fail. CI sets this from a GitHub Environment secret in the live phase.
+const retlAccountIDEnv = "RUDDERSTACK_RETL_TEST_ACCOUNT_ID"
+
+// planOnlyAccountID is a placeholder used in plan-only mode where no API call
+// is made; the value just has to satisfy the schema (non-empty string).
+const planOnlyAccountID = "acc-plan-only"
+
+// RETLSourceTestConfig is the shape consumed by AccAssertRETLSourceModel /
+// AccAssertRETLSourceTable. The Config / UpdateConfig fields are HCL fragments
+// that go inside the resource's `config { }` block.
+type RETLSourceTestConfig struct {
+	SourceDefinitionName string // e.g. "snowflake"
+	Config               string // HCL inside config { } block for the create step
+	UpdateConfig         string // HCL for the update step (omit to skip update)
+}
+
+// RETLConnectionTestConfig describes a connection variant. The helper builds
+// a complete pipeline (RETL source + webhook destination + connection) so
+// tests don't need to repeat the boilerplate.
+type RETLConnectionTestConfig struct {
+	// Variant is a short label included in the test resource names so
+	// concurrent runs don't collide.
+	Variant string
+
+	SyncBehaviour string // "upsert" | "mirror" | "full"
+	Schedule      string // HCL fragment for the schedule { } block body
+	Identifiers   string // HCL fragment for one or more identifiers { } blocks
+	Mappings      string // HCL fragment for mappings { } blocks (optional)
+	Event         string // HCL fragment for event { } block (optional)
+	CursorColumn  string // value for cursor_column (optional, requires upsert)
+
+	// UpdateMappings, when non-empty, runs an Update step replacing the
+	// connection's mappings { } blocks. Mappings are mutable across all flows,
+	// so this is the cheapest way to flex the Update path.
+	UpdateMappings string
+}
+
+// AccAssertRETLSourceModel runs the standard E2E lifecycle against
+// rudderstack_retl_source_model. In plan-only mode it validates HCL/schema only;
+// in live mode it runs Create → Update → Import → Destroy and verifies via the
+// RETL API.
+func AccAssertRETLSourceModel(t *testing.T, cfg RETLSourceTestConfig) {
+	t.Helper()
+	runRETLSourceLifecycle(t, "rudderstack_retl_source_model", cfg)
+}
+
+// AccAssertRETLSourceTable runs the standard E2E lifecycle against
+// rudderstack_retl_source_table. See AccAssertRETLSourceModel.
+func AccAssertRETLSourceTable(t *testing.T, cfg RETLSourceTestConfig) {
+	t.Helper()
+	runRETLSourceLifecycle(t, "rudderstack_retl_source_table", cfg)
+}
+
+func runRETLSourceLifecycle(t *testing.T, resourceType string, cfg RETLSourceTestConfig) {
+	t.Helper()
+
+	planOnly := PlanOnly()
+	if planOnly {
+		t.Parallel()
+	}
+
+	resourceName := fmt.Sprintf("%s.test", resourceType)
+	name := RandomName(resourceType)
+
+	accountID := planOnlyAccountID
+	if !planOnly {
+		accountID = os.Getenv(retlAccountIDEnv)
+		if accountID == "" {
+			t.Skipf("%s is not set; skipping live RETL source test (set it to a workspace warehouse account ID)", retlAccountIDEnv)
+		}
+	}
+
+	createHCL := retlSourceHCL(resourceType, name, cfg.SourceDefinitionName, accountID, cfg.Config)
+
+	if planOnly {
+		ensureDummyToken(t)
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             createHCL,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+		return
+	}
+
+	steps := []resource.TestStep{
+		{
+			Config: createHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLSourceExists(resourceName),
+				resource.TestCheckResourceAttr(resourceName, "name", name),
+				resource.TestCheckResourceAttr(resourceName, "source_definition_name", cfg.SourceDefinitionName),
+				resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+			),
+		},
+	}
+
+	if cfg.UpdateConfig != "" {
+		updateHCL := retlSourceHCL(resourceType, name+"-updated", cfg.SourceDefinitionName, accountID, cfg.UpdateConfig)
+		steps = append(steps, resource.TestStep{
+			Config: updateHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLSourceExists(resourceName),
+				resource.TestCheckResourceAttr(resourceName, "name", name+"-updated"),
+			),
+		})
+	}
+
+	steps = append(steps, resource.TestStep{
+		ResourceName:      resourceName,
+		ImportState:       true,
+		ImportStateVerify: true,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRETLSourceDestroy(resourceType),
+		Steps:             steps,
+	})
+}
+
+// AccAssertRETLConnection wires a model source + webhook destination +
+// rudderstack_retl_connection and runs the lifecycle. The webhook destination
+// is sufficient for the control-plane API (it doesn't validate downstream
+// connectivity) and avoids needing real warehouse credentials in CI.
+func AccAssertRETLConnection(t *testing.T, cfg RETLConnectionTestConfig) {
+	t.Helper()
+
+	planOnly := PlanOnly()
+	if planOnly {
+		t.Parallel()
+	}
+
+	connResource := "rudderstack_retl_connection.test"
+	srcResource := "rudderstack_retl_source_model.test"
+	dstResource := "rudderstack_destination_webhook.test"
+
+	suffix := cfg.Variant
+	if suffix == "" {
+		suffix = "conn"
+	}
+	srcName := RandomName("retl-src-" + suffix)
+	dstName := RandomName("retl-dst-" + suffix)
+
+	accountID := planOnlyAccountID
+	if !planOnly {
+		accountID = os.Getenv(retlAccountIDEnv)
+		if accountID == "" {
+			t.Skipf("%s is not set; skipping live RETL connection test", retlAccountIDEnv)
+		}
+	}
+
+	createHCL := retlConnectionHCL(srcName, dstName, accountID, cfg)
+
+	if planOnly {
+		ensureDummyToken(t)
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             createHCL,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+		return
+	}
+
+	steps := []resource.TestStep{
+		{
+			Config: createHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+				resource.TestCheckResourceAttrSet(connResource, "id"),
+				resource.TestCheckResourceAttr(connResource, "enabled", "true"),
+				resource.TestCheckResourceAttr(connResource, "sync_behaviour", cfg.SyncBehaviour),
+				resource.TestCheckResourceAttrPair(connResource, "source_id", srcResource, "id"),
+				resource.TestCheckResourceAttrPair(connResource, "destination_id", dstResource, "id"),
+			),
+		},
+	}
+
+	if cfg.UpdateMappings != "" {
+		updated := cfg
+		updated.Mappings = cfg.UpdateMappings
+		updated.UpdateMappings = ""
+		steps = append(steps, resource.TestStep{
+			Config: retlConnectionHCL(srcName, dstName, accountID, updated),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+			),
+		})
+	}
+
+	steps = append(steps, resource.TestStep{
+		ResourceName:      connResource,
+		ImportState:       true,
+		ImportStateVerify: true,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRETLConnectionDestroy,
+		Steps:             steps,
+	})
+}
+
+// retlSourceHCL builds the HCL for a single RETL source resource.
+func retlSourceHCL(resourceType, name, sourceDefinitionName, accountID, configBlock string) string {
+	return fmt.Sprintf(`
+resource %q "test" {
+  name                   = %q
+  source_definition_name = %q
+  account_id             = %q
+  config {
+    %s
+  }
+}
+`, resourceType, name, sourceDefinitionName, accountID, configBlock)
+}
+
+// retlConnectionHCL builds the HCL for the source + webhook destination +
+// connection pipeline. Identifier/mapping/event/cursor blocks are interpolated
+// raw — callers supply the inner HCL.
+func retlConnectionHCL(srcName, dstName, accountID string, cfg RETLConnectionTestConfig) string {
+	mappingsBlock := ""
+	if cfg.Mappings != "" {
+		mappingsBlock = "\n  " + cfg.Mappings
+	}
+	eventBlock := ""
+	if cfg.Event != "" {
+		eventBlock = "\n  event {\n    " + cfg.Event + "\n  }"
+	}
+	cursorAttr := ""
+	if cfg.CursorColumn != "" {
+		cursorAttr = fmt.Sprintf("\n  cursor_column  = %q", cfg.CursorColumn)
+	}
+
+	return fmt.Sprintf(`
+resource "rudderstack_retl_source_model" "test" {
+  name                   = %q
+  source_definition_name = "snowflake"
+  account_id             = %q
+  config {
+    primary_key = "id"
+    sql         = "select 1"
+  }
+}
+
+resource "rudderstack_destination_webhook" "test" {
+  name = %q
+  config {
+    webhook_url    = "https://example.com/test"
+    webhook_method = "POST"
+  }
+}
+
+resource "rudderstack_retl_connection" "test" {
+  source_id      = rudderstack_retl_source_model.test.id
+  destination_id = rudderstack_destination_webhook.test.id
+  sync_behaviour = %q%s
+  schedule {
+    %s
+  }
+  identifiers {
+    %s
+  }%s%s
+}
+`, srcName, accountID, dstName, cfg.SyncBehaviour, cursorAttr, cfg.Schedule, cfg.Identifiers, mappingsBlock, eventBlock)
+}
+
+// newTestRETLClient wraps the live API client with a typed RETL store.
+func newTestRETLClient() (retl.RETLStore, error) {
+	cl, err := newTestAPIClient()
+	if err != nil {
+		return nil, err
+	}
+	return retl.NewRudderRETLStore(cl), nil
+}
+
+func testAccCheckRETLSourceExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is empty")
+		}
+
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		if _, err := store.GetRetlSource(context.Background(), rs.Primary.ID); err != nil {
+			return fmt.Errorf("RETL source %s not found in API: %w", rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRETLSourceDestroy(resourceType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != resourceType {
+				continue
+			}
+			// Tolerant of soft-delete: the API may still return the resource
+			// after delete. We don't fail here — Destroy already verified the
+			// Delete handler ran without error.
+			_, _ = store.GetRetlSource(context.Background(), rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRETLConnectionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is empty")
+		}
+
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		if _, err := store.GetConnection(context.Background(), rs.Primary.ID); err != nil {
+			return fmt.Errorf("RETL connection %s not found in API: %w", rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRETLConnectionDestroy(s *terraform.State) error {
+	store, err := newTestRETLClient()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rudderstack_retl_connection" {
+			continue
+		}
+		// Expect 404 after delete; tolerant of any error (network blips,
+		// soft-delete) — we don't fail the test here.
+		_, getErr := store.GetConnection(context.Background(), rs.Primary.ID)
+		if getErr == nil {
+			// If it still exists, surface that — it's likely a real bug.
+			return fmt.Errorf("RETL connection %s still exists after destroy", rs.Primary.ID)
+		}
+		var apiErr *client.APIError
+		if errors.As(getErr, &apiErr) && apiErr.HTTPStatusCode == 404 {
+			continue
+		}
+	}
+	return nil
+}

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -17,7 +17,10 @@ import (
 // retlAccountIDEnv names the env var that supplies a real warehouse account ID
 // for live RETL acceptance tests. When unset (and the test is not running in
 // plan-only mode) the helpers t.Skip — local runs without a workspace fixture
-// shouldn't fail. CI sets this from a GitHub Environment secret in the live phase.
+// shouldn't fail. The e2e-tests.yml workflow forwards `vars.RUDDERSTACK_RETL_TEST_ACCOUNT_ID`
+// (a GitHub Environment variable, not a secret — the ID is opaque, not credentials)
+// to this env var; until that variable is added, the expression renders empty
+// in CI and the live RETL tests skip.
 const retlAccountIDEnv = "RUDDERSTACK_RETL_TEST_ACCOUNT_ID"
 
 // planOnlyAccountID is a placeholder used in plan-only mode where no API call
@@ -43,9 +46,9 @@ type RETLConnectionTestConfig struct {
 
 	SyncBehaviour string // "upsert" | "mirror" | "full"
 	Schedule      string // HCL fragment for the schedule { } block body
-	Identifiers   string // HCL fragment for one or more identifiers { } blocks
-	Mappings      string // HCL fragment for mappings { } blocks (optional)
-	Event         string // HCL fragment for event { } block (optional)
+	Identifiers   string // HCL fragment for one or more raw identifiers { } blocks (required, ≥1)
+	Mappings      string // HCL fragment for one or more raw mappings { } blocks (optional)
+	Event         string // HCL fragment for event { } block body (optional)
 	CursorColumn  string // value for cursor_column (optional, requires upsert)
 
 	// UpdateMappings, when non-empty, runs an Update step replacing the
@@ -249,8 +252,9 @@ resource %q "test" {
 }
 
 // retlConnectionHCL builds the HCL for the source + webhook destination +
-// connection pipeline. Identifier/mapping/event/cursor blocks are interpolated
-// raw — callers supply the inner HCL.
+// connection pipeline. Identifiers / Mappings are full block fragments
+// (e.g. `identifiers { from = "..." to = "..." }`) so callers can pass
+// multiple of each. Event and cursor_column are inlined when non-empty.
 func retlConnectionHCL(srcName, dstName, accountID string, cfg RETLConnectionTestConfig) string {
 	mappingsBlock := ""
 	if cfg.Mappings != "" {
@@ -272,7 +276,7 @@ resource "rudderstack_retl_source_model" "test" {
   account_id             = %q
   config {
     primary_key = "id"
-    sql         = "select 1"
+    sql         = "select 1 as id"
   }
 }
 
@@ -291,9 +295,7 @@ resource "rudderstack_retl_connection" "test" {
   schedule {
     %s
   }
-  identifiers {
-    %s
-  }%s%s
+  %s%s%s
 }
 `, srcName, accountID, dstName, cfg.SyncBehaviour, cursorAttr, cfg.Schedule, cfg.Identifiers, mappingsBlock, eventBlock)
 }

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -291,6 +291,7 @@ resource "rudderstack_destination_webhook" "test" {
 resource "rudderstack_retl_connection" "test" {
   source_id      = rudderstack_retl_source_model.test.id
   destination_id = rudderstack_destination_webhook.test.id
+  enabled        = true
   sync_behaviour = %q%s
   schedule {
     %s

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -31,7 +31,7 @@ const planOnlyAccountID = "acc-plan-only"
 // AccAssertRETLSourceTable. The Config / UpdateConfig fields are HCL fragments
 // that go inside the resource's `config { }` block.
 type RETLSourceTestConfig struct {
-	SourceDefinitionName string // e.g. "snowflake"
+	SourceDefinitionName string // e.g. "bigquery"
 	Config               string // HCL inside config { } block for the create step
 	UpdateConfig         string // HCL for the update step (omit to skip update)
 }
@@ -272,7 +272,7 @@ func retlConnectionHCL(srcName, dstName, accountID string, cfg RETLConnectionTes
 	return fmt.Sprintf(`
 resource "rudderstack_retl_source_model" "test" {
   name                   = %q
-  source_definition_name = "snowflake"
+  source_definition_name = "bigquery"
   account_id             = %q
   config {
     primary_key = "id"

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -1,0 +1,109 @@
+package retl_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil/acc"
+)
+
+// TestAccRETLSourceModel_Snowflake exercises rudderstack_retl_source_model
+// against a snowflake account. SQL is intentionally trivial; the API accepts
+// it at create time and any sync-time SQL validation is out of scope here.
+func TestAccRETLSourceModel_Snowflake(t *testing.T) {
+	acc.AccAssertRETLSourceModel(t, acc.RETLSourceTestConfig{
+		SourceDefinitionName: "snowflake",
+		Config: `
+			primary_key = "id"
+			sql         = "select 1 as id"
+		`,
+		UpdateConfig: `
+			primary_key = "id"
+			sql         = "select 1 as id, 'two' as name"
+			description = "v2"
+		`,
+	})
+}
+
+// TestAccRETLSourceTable_Snowflake exercises rudderstack_retl_source_table.
+func TestAccRETLSourceTable_Snowflake(t *testing.T) {
+	acc.AccAssertRETLSourceTable(t, acc.RETLSourceTestConfig{
+		SourceDefinitionName: "snowflake",
+		Config: `
+			primary_key = "id"
+			schema      = "public"
+			table       = "users"
+		`,
+		UpdateConfig: `
+			primary_key = "id"
+			schema      = "public"
+			table       = "events"
+		`,
+	})
+}
+
+// TestAccRETLConnection_JSONMapperBasicSchedule covers the JSON-mapper flow
+// (no `object`, no `destination_config`) with a basic-interval schedule and an
+// identify event. Mappings update verifies the mutable Update path.
+func TestAccRETLConnection_JSONMapperBasicSchedule(t *testing.T) {
+	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
+		Variant:       "jm-basic",
+		SyncBehaviour: "upsert",
+		Schedule: `
+			type          = "basic"
+			every_minutes = 60
+		`,
+		Identifiers: `
+			from = "email"
+			to   = "user_id"
+		`,
+		Mappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
+			}
+		`,
+		Event: `type = "identify"`,
+		UpdateMappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
+			}
+			mappings {
+				from = "phone"
+				to   = "phone_number"
+			}
+		`,
+	})
+}
+
+// TestAccRETLConnection_CronSchedule covers the cron schedule branch.
+func TestAccRETLConnection_CronSchedule(t *testing.T) {
+	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
+		Variant:       "cron",
+		SyncBehaviour: "upsert",
+		Schedule: `
+			type            = "cron"
+			cron_expression = "30 13 * * *"
+		`,
+		Identifiers: `
+			from = "email"
+			to   = "user_id"
+		`,
+		Event: `type = "identify"`,
+	})
+}
+
+// TestAccRETLConnection_ManualSchedule covers the manual schedule branch.
+// `mirror` sync_behaviour is used here to flex a non-upsert path.
+func TestAccRETLConnection_ManualSchedule(t *testing.T) {
+	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
+		Variant:       "manual",
+		SyncBehaviour: "mirror",
+		Schedule:      `type = "manual"`,
+		Identifiers: `
+			from = "email"
+			to   = "user_id"
+		`,
+		Event: `type = "identify"`,
+	})
+}

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -95,21 +95,34 @@ func TestAccRETLConnection_CronSchedule(t *testing.T) {
 				to   = "user_id"
 			}
 		`,
+		Mappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
+			}
+		`,
 		Event: `type = "identify"`,
 	})
 }
 
 // TestAccRETLConnection_ManualSchedule covers the manual schedule branch.
-// `mirror` sync_behaviour is used here to flex a non-upsert path.
+// `full` sync_behaviour flexes a non-upsert path (the JSON Mapper flow accepts
+// only "upsert" or "full" — "mirror" is rejected by the API).
 func TestAccRETLConnection_ManualSchedule(t *testing.T) {
 	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
 		Variant:       "manual",
-		SyncBehaviour: "mirror",
+		SyncBehaviour: "full",
 		Schedule:      `type = "manual"`,
 		Identifiers: `
 			identifiers {
 				from = "email"
 				to   = "user_id"
+			}
+		`,
+		Mappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
 			}
 		`,
 		Event: `type = "identify"`,

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -6,37 +6,39 @@ import (
 	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil/acc"
 )
 
-// TestAccRETLSourceModel_Snowflake exercises rudderstack_retl_source_model
-// against a snowflake account. SQL is intentionally trivial; the API accepts
-// it at create time and any sync-time SQL validation is out of scope here.
-func TestAccRETLSourceModel_Snowflake(t *testing.T) {
+// TestAccRETLSourceModel_BigQuery exercises rudderstack_retl_source_model
+// against a BigQuery account. The SQL references the e2e fixture table
+// (dataset.table, resolved in the account's project); the API accepts it at
+// create time and any sync-time SQL validation is out of scope here.
+func TestAccRETLSourceModel_BigQuery(t *testing.T) {
 	acc.AccAssertRETLSourceModel(t, acc.RETLSourceTestConfig{
-		SourceDefinitionName: "snowflake",
+		SourceDefinitionName: "bigquery",
 		Config: `
-			primary_key = "id"
-			sql         = "select 1 as id"
+			primary_key = "user_id"
+			sql         = "select user_id, email from rudder_tf_e2e.users"
 		`,
 		UpdateConfig: `
-			primary_key = "id"
-			sql         = "select 1 as id, 'two' as name"
+			primary_key = "user_id"
+			sql         = "select user_id, email, created_at from rudder_tf_e2e.users"
 			description = "v2"
 		`,
 	})
 }
 
-// TestAccRETLSourceTable_Snowflake exercises rudderstack_retl_source_table.
-func TestAccRETLSourceTable_Snowflake(t *testing.T) {
+// TestAccRETLSourceTable_BigQuery exercises rudderstack_retl_source_table.
+// schema is the BigQuery dataset; the e2e fixture is rudder_tf_e2e.users.
+func TestAccRETLSourceTable_BigQuery(t *testing.T) {
 	acc.AccAssertRETLSourceTable(t, acc.RETLSourceTestConfig{
-		SourceDefinitionName: "snowflake",
+		SourceDefinitionName: "bigquery",
 		Config: `
-			primary_key = "id"
-			schema      = "public"
+			primary_key = "user_id"
+			schema      = "rudder_tf_e2e"
 			table       = "users"
 		`,
 		UpdateConfig: `
-			primary_key = "id"
-			schema      = "public"
-			table       = "events"
+			primary_key = "email"
+			schema      = "rudder_tf_e2e"
+			table       = "users"
 		`,
 	})
 }

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -53,8 +53,10 @@ func TestAccRETLConnection_JSONMapperBasicSchedule(t *testing.T) {
 			every_minutes = 60
 		`,
 		Identifiers: `
-			from = "email"
-			to   = "user_id"
+			identifiers {
+				from = "email"
+				to   = "user_id"
+			}
 		`,
 		Mappings: `
 			mappings {
@@ -86,8 +88,10 @@ func TestAccRETLConnection_CronSchedule(t *testing.T) {
 			cron_expression = "30 13 * * *"
 		`,
 		Identifiers: `
-			from = "email"
-			to   = "user_id"
+			identifiers {
+				from = "email"
+				to   = "user_id"
+			}
 		`,
 		Event: `type = "identify"`,
 	})
@@ -101,8 +105,10 @@ func TestAccRETLConnection_ManualSchedule(t *testing.T) {
 		SyncBehaviour: "mirror",
 		Schedule:      `type = "manual"`,
 		Identifiers: `
-			from = "email"
-			to   = "user_id"
+			identifiers {
+				from = "email"
+				to   = "user_id"
+			}
 		`,
 		Event: `type = "identify"`,
 	})


### PR DESCRIPTION
Supersedes #237 (which could not be reopened — its branch was force-pushed, so GitHub blocks reopen). Same commits, **authorship preserved** (Alexandros Milaios's two original commits cherry-picked intact).

**What this is (PR 1 of 4)** in the rETL + Accounts e2e verification stack:
- Alexandros's original #237 rETL acceptance tests + CI integration, rebased onto the accounts stack tip (#266 / `feature/dex-382`).
- Converted Snowflake → **BigQuery** (`source_definition_name`, fixture `rudder_tf_e2e.users`).
- Sets connection `enabled` explicitly; documents `retl_connection_customerio_audience` as a coverage-gate exclusion (its acc test lands in PR 4).

**Stacked on** #266. Mergeable after the accounts stack lands. Verified: build, vet, coverage gate, and plan-only rETL tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)