### PR TITLE
feat(accounts): wire real Accounts client + staging e2e smoke harness

### DIFF
--- a/rudderstack/client.go
+++ b/rudderstack/client.go
@@ -63,5 +63,6 @@ func NewAPIClient(accessToken string, options ...client.Option) (*Client, error)
 		Destinations: api.Destinations,
 		Connections:  api.Connections,
 		RETLSources:  iacretl.NewRudderRETLStore(api),
+		Accounts:     api.Accounts,
 	}, nil
 }

--- a/rudderstack/resource_account.go
+++ b/rudderstack/resource_account.go
@@ -18,7 +18,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-iac/api/client"
-
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
 

--- a/rudderstack/resource_account.go
+++ b/rudderstack/resource_account.go
@@ -10,6 +10,7 @@ package rudderstack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -135,6 +136,11 @@ func resourceAccountRead(cm configs.ConfigMeta) schema.ReadContextFunc {
 
 		acc, err := c.Accounts.Get(ctx, d.Id())
 		if err != nil {
+			var apiErr *client.APIError
+			if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
 			return diag.FromErr(fmt.Errorf("could not get account: %w", err))
 		}
 

--- a/rudderstack/resource_account_test.go
+++ b/rudderstack/resource_account_test.go
@@ -251,6 +251,59 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 	})
 }
 
+// TestResourceAccountRead_404ClearsState verifies that when the accounts API returns
+// a 404 (out-of-band deletion / import of a missing ID), resourceAccountRead clears
+// the resource ID and returns no Terraform error — matching the drift-detection
+// pattern used in rudderstack/retl/common.go.
+func TestResourceAccountRead_404ClearsState(t *testing.T) {
+	cm := testAccountConfigMeta()
+	accounts := &mockAccountsService{}
+
+	accounts.On("Get", mock.Anything, "acct-gone").
+		Return(nil, &client.APIError{HTTPStatusCode: 404}).Once()
+
+	res := resourceAccount(cm)
+	d := res.Data(nil)
+	d.SetId("acct-gone")
+
+	c := &Client{Accounts: accounts}
+	diags := resourceAccountRead(cm)(context.Background(), d, c)
+	if diags.HasError() {
+		t.Fatalf("expected no error on 404, got %+v", diags)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID cleared on 404, got %q", d.Id())
+	}
+
+	accounts.AssertExpectations(t)
+}
+
+// TestResourceAccountRead_NonNotFoundErrorReturnsError verifies that non-404 API errors
+// are surfaced as Terraform diagnostics (not silently swallowed).
+func TestResourceAccountRead_NonNotFoundErrorReturnsError(t *testing.T) {
+	cm := testAccountConfigMeta()
+	accounts := &mockAccountsService{}
+
+	accounts.On("Get", mock.Anything, "acct-err").
+		Return(nil, &client.APIError{HTTPStatusCode: 500, Message: "internal server error"}).Once()
+
+	res := resourceAccount(cm)
+	d := res.Data(nil)
+	d.SetId("acct-err")
+
+	c := &Client{Accounts: accounts}
+	diags := resourceAccountRead(cm)(context.Background(), d, c)
+	if !diags.HasError() {
+		t.Fatal("expected error on 500, got none")
+	}
+	// ID must NOT be cleared on a non-404 error.
+	if d.Id() == "" {
+		t.Fatal("expected ID to remain set on non-404 error")
+	}
+
+	accounts.AssertExpectations(t)
+}
+
 // TestResourceAccountSchemaNoSecretInState verifies that after a Read whose mocked
 // Get returns no secret, the bar field is absent from state. This test exercises the
 // schema + read function directly without needing a full provider lifecycle.

--- a/rudderstack/resource_account_test.go
+++ b/rudderstack/resource_account_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/rudderlabs/rudder-iac/api/client"
-
 	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil"
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
@@ -99,8 +98,16 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 			testutil.JSONEq(string(req.Options), createOptionsJSON) &&
 			testutil.JSONEq(string(req.Secret), createSecretJSON)
 	})).Return(&client.Account{
-		ID:        "acct-001",
-		Name:      "example",
+		ID:   "acct-001",
+		Name: "example",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		Options:   json.RawMessage(createOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
 		UpdatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
@@ -110,6 +117,14 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 	accounts.On("Get", mock.Anything, "acct-001").Return(&client.Account{
 		ID:   "acct-001",
 		Name: "example",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		// Secret intentionally absent — API never returns it.
 		Options:   json.RawMessage(createOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
@@ -122,8 +137,16 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 			testutil.JSONEq(string(req.Options), updateOptionsJSON) &&
 			testutil.JSONEq(string(req.Secret), updateSecretJSON)
 	})).Return(&client.Account{
-		ID:        "acct-001",
-		Name:      "example-updated",
+		ID:   "acct-001",
+		Name: "example-updated",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		Options:   json.RawMessage(updateOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
 		UpdatedAt: testutil.TimePtr(time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)),
@@ -131,8 +154,16 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 
 	// --- Read mock after Update (called twice: post-update refresh + destroy plan check) ---
 	accounts.On("Get", mock.Anything, "acct-001").Return(&client.Account{
-		ID:        "acct-001",
-		Name:      "example-updated",
+		ID:   "acct-001",
+		Name: "example-updated",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		Options:   json.RawMessage(updateOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
 		UpdatedAt: testutil.TimePtr(time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)),
@@ -230,6 +261,14 @@ func TestResourceAccountSchemaNoSecretInState(t *testing.T) {
 	accounts.On("Get", mock.Anything, "acct-002").Return(&client.Account{
 		ID:   "acct-002",
 		Name: "test-acct",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		// Options returned, secret NOT returned.
 		Options:   json.RawMessage(`{"foo":"val1"}`),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)),

--- a/test/e2e/staging/.gitignore
+++ b/test/e2e/staging/.gitignore
@@ -1,0 +1,7 @@
+*.tfvars
+*.tfstate*
+.terraform/
+.terraform.lock.hcl
+.bin/
+sa.json
+.env

--- a/test/e2e/staging/README.md
+++ b/test/e2e/staging/README.md
@@ -1,0 +1,149 @@
+# Staging smoke test — BigQuery account → rETL source → connection
+
+This config applies a minimal chain against the RudderStack staging environment
+to verify that the Terraform provider can create and link:
+
+1. A BigQuery rETL **account** (`rudderstack_account_source_bigquery`)
+2. An rETL **source table** (`rudderstack_retl_source_table`) backed by that account
+3. A webhook **destination** (`rudderstack_destination_webhook`) — throwaway endpoint
+4. An rETL **connection** (`rudderstack_retl_connection`) wiring source → destination
+
+No real syncs are triggered (schedule type is `manual`).
+
+---
+
+## Prerequisites
+
+- Terraform ≥ 1.0
+- Go ≥ 1.21 (to build the provider locally)
+- A RudderStack staging personal access token
+- A GCP service-account JSON key with BigQuery access
+
+---
+
+## 1. Build and install the provider locally
+
+```sh
+cd /path/to/terraform-provider-rudderstack
+go build -o /tmp/terraform-provider-rudderstack .
+```
+
+Create a dev-override Terraform CLI config at `/tmp/dev.tfrc`:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "rudderstack.com/rudderlabs/rudderstack" = "/tmp"
+  }
+  direct {}
+}
+```
+
+---
+
+## 2. Supply credentials via a git-ignored tfvars file
+
+Create `test/e2e/staging/secret.tfvars` (this path is in `.gitignore` — never
+commit it):
+
+```hcl
+# secret.tfvars — DO NOT COMMIT
+access_token   = "rsa_REPLACE_ME"
+bq_project     = "my-gcp-project"
+bq_dataset     = "my_dataset"
+bq_table       = "users"
+bq_credentials = <<EOT
+{
+  "type": "service_account",
+  "project_id": "my-gcp-project",
+  ...
+}
+EOT
+```
+
+Optional overrides (have defaults):
+
+```hcl
+api_url     = "https://api.staging.rudderlabs.com"
+bq_location = "US"
+```
+
+---
+
+## 3. Run
+
+`run.sh` builds the provider locally into `.bin/` (git-ignored), wires a
+Terraform dev-override pointing at that directory, runs `apply`, asserts no
+drift, prints the created resource IDs, and always destroys on exit.
+
+```sh
+# Standard smoke run — no staging creds needed in the env:
+./run.sh
+
+# Override the tfvars file path:
+./run.sh path/to/other.tfvars
+
+# Or via env:
+TFVARS_FILE=path/to/other.tfvars ./run.sh
+```
+
+The script does **not** require `TF_CLI_CONFIG_FILE` to be set beforehand; it
+writes a temporary dev-override config and exports the variable itself.
+
+### `--backfill` flag (opt-in, not yet wired)
+
+```sh
+./run.sh --backfill
+```
+
+After the drift assertion the script will attempt to trigger a manual rETL
+sync on the connection and poll to completion. **This branch currently exits
+with a clear error (exit 3)** because the rudder-iac client
+(`api/client/retl/connections.go`, v0.17.1) does not yet expose a
+sync-trigger endpoint. See the comment block in `run.sh` for exactly which
+endpoint and polling contract need to be confirmed before this can be wired.
+
+### Generated files
+
+| Path | Description |
+|------|-------------|
+| `.bin/terraform-provider-rudderstack` | Provider binary built by `run.sh` — git-ignored |
+
+To apply manually without `run.sh`:
+
+```sh
+# 1. Build first:
+go build -o test/e2e/staging/.bin/terraform-provider-rudderstack .
+
+# 2. Write a dev-override config:
+cat > /tmp/dev.tfrc <<'HCL'
+provider_installation {
+  dev_overrides {
+    "rudderstack.com/rudderlabs/rudderstack" = "test/e2e/staging/.bin"
+  }
+  direct {}
+}
+HCL
+
+# 3. Apply:
+TF_CLI_CONFIG_FILE=/tmp/dev.tfrc terraform -chdir=test/e2e/staging \
+  apply -var-file=test/e2e/staging/secret.tfvars -auto-approve
+```
+
+---
+
+## 4. What success looks like
+
+After `apply`, Terraform prints four non-empty IDs:
+
+```
+account_id     = "<id>"
+connection_id  = "<id>"
+destination_id = "<id>"
+retl_source_id = "<id>"
+```
+
+`run.sh` then asserts these are correct by running
+`terraform plan -detailed-exitcode`.  Exit code 0 means the provider Read
+path returned state that matches the config exactly — no drift.  Exit code 2
+(drift) or 1 (error) fail the script loudly before destroy runs.

--- a/test/e2e/staging/main.tf
+++ b/test/e2e/staging/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  required_providers {
+    rudderstack = { source = "rudderstack.com/rudderlabs/rudderstack" }
+  }
+}
+
+provider "rudderstack" {
+  api_url      = var.api_url
+  access_token = var.access_token
+}
+
+# 1. BigQuery rETL account — stores warehouse credentials.
+resource "rudderstack_account_source_bigquery" "acct" {
+  name = "tf-e2e-bigquery"
+  config {
+    project     = var.bq_project
+    location    = var.bq_location
+    credentials = var.bq_credentials
+  }
+}
+
+# 2. rETL source that reads from a single BigQuery table.
+resource "rudderstack_retl_source_table" "users" {
+  name                   = "tf-e2e-users-table"
+  source_definition_name = "bigquery"
+  account_id             = rudderstack_account_source_bigquery.acct.id
+  enabled                = true
+  config {
+    primary_key = "user_id"
+    schema      = var.bq_dataset
+    table       = var.bq_table
+  }
+}
+
+# 3. Webhook destination — throwaway endpoint; delivery is not the point here.
+resource "rudderstack_destination_webhook" "demo" {
+  name = "tf-e2e-webhook"
+  config {
+    webhook_url    = "https://example.com/test"
+    webhook_method = "POST"
+  }
+}
+
+# 4. rETL connection wiring the source to the destination.
+#    Uses a manual schedule so no automatic syncs are triggered during the test.
+resource "rudderstack_retl_connection" "to_webhook" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_webhook.demo.id
+  enabled        = true
+  sync_behaviour = "full"
+
+  schedule {
+    type = "manual"
+  }
+
+  event {
+    type = "identify"
+  }
+
+  identifiers {
+    from = "user_id"
+    to   = "user_id"
+  }
+
+  mappings {
+    from = "email"
+    to   = "email"
+  }
+}
+
+# Outputs — consumed by run.sh to verify IDs were created.
+output "account_id" {
+  description = "ID of the created BigQuery rETL account."
+  value       = rudderstack_account_source_bigquery.acct.id
+}
+
+output "retl_source_id" {
+  description = "ID of the created rETL source table."
+  value       = rudderstack_retl_source_table.users.id
+}
+
+output "destination_id" {
+  description = "ID of the created webhook destination."
+  value       = rudderstack_destination_webhook.demo.id
+}
+
+output "connection_id" {
+  description = "ID of the created rETL connection."
+  value       = rudderstack_retl_connection.to_webhook.id
+}

--- a/test/e2e/staging/run.sh
+++ b/test/e2e/staging/run.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# run.sh — Staging smoke runner for the terraform-provider-rudderstack.
+#
+# Usage:
+#   ./run.sh [--backfill] [path/to/secret.tfvars]
+#
+# The script:
+#   1. Builds the provider locally (into .bin/) and wires a TF dev-override.
+#   2. Runs terraform apply.
+#   3. Asserts no drift via terraform plan -detailed-exitcode.
+#   4. Prints the created resource IDs from terraform output.
+#   5. On EXIT (success or failure) runs terraform destroy to clean up staging.
+#
+# With --backfill the script would trigger and poll a sync on the rETL
+# connection; however, no trigger endpoint currently exists in the
+# rudder-iac client (v0.17.1).  That branch prints a clear TODO and exits
+# non-zero — see the --backfill section below for the tracking comment.
+#
+# Prerequisites:
+#   - Go ≥ 1.21
+#   - Terraform ≥ 1.0
+#   - secret.tfvars (or the path supplied as $1 / $TFVARS_FILE) with at least:
+#       access_token, bq_project, bq_dataset, bq_table, bq_credentials
+
+set -euo pipefail
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+BACKFILL=false
+TFVARS_FILE="${TFVARS_FILE:-}"   # can also be set in the environment
+
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    --backfill) BACKFILL=true ;;
+    *) args+=("$arg") ;;
+  esac
+done
+
+# First non-flag positional arg overrides the var-file path.
+if [[ ${#args[@]} -gt 0 ]]; then
+  TFVARS_FILE="${args[0]}"
+fi
+
+# Resolve relative paths against the script's own directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${TFVARS_FILE}" ]]; then
+  TFVARS_FILE="${SCRIPT_DIR}/secret.tfvars"
+fi
+
+if [[ ! -f "${TFVARS_FILE}" ]]; then
+  echo "ERROR: var-file not found: ${TFVARS_FILE}"
+  echo "       Create it (see README) or pass a path as the first argument."
+  exit 1
+fi
+
+# ── Repo root (two levels above test/e2e/staging) ───────────────────────────
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# ── Provider binary paths ────────────────────────────────────────────────────
+BIN_DIR="${SCRIPT_DIR}/.bin"
+PROVIDER_BINARY="${BIN_DIR}/terraform-provider-rudderstack"
+
+# ── Temp dev-override CLI config ─────────────────────────────────────────────
+OVERRIDE_CFG="$(mktemp "${TMPDIR:-/tmp}/tf-dev-override-XXXXXX.tfrc")"
+trap 'rm -f "${OVERRIDE_CFG}"' EXIT
+
+# ── Build the provider ───────────────────────────────────────────────────────
+echo "==> Building provider binary …"
+mkdir -p "${BIN_DIR}"
+go build -o "${PROVIDER_BINARY}" "${REPO_ROOT}"
+echo "    Provider written to: ${PROVIDER_BINARY}"
+
+# ── Write dev-override config and export for Terraform ───────────────────────
+cat > "${OVERRIDE_CFG}" <<HCL
+provider_installation {
+  dev_overrides {
+    "rudderstack.com/rudderlabs/rudderstack" = "${BIN_DIR}"
+  }
+  direct {}
+}
+HCL
+export TF_CLI_CONFIG_FILE="${OVERRIDE_CFG}"
+echo "==> TF_CLI_CONFIG_FILE=${TF_CLI_CONFIG_FILE}"
+
+# ── Destroy trap (always runs on EXIT) ───────────────────────────────────────
+# Best-effort: errors here must NOT mask the original script exit code.
+_destroy() {
+  local original_exit=$?
+  echo "==> [trap] Running terraform destroy (cleanup) …"
+  terraform -chdir="${SCRIPT_DIR}" destroy -auto-approve \
+    -var-file="${TFVARS_FILE}" || true
+  echo "==> [trap] Destroy complete."
+  rm -f "${OVERRIDE_CFG}"  # this trap replaces the earlier rm-only trap; fold its cleanup in here
+  exit "${original_exit}"
+}
+trap '_destroy' EXIT
+
+# ── Apply ────────────────────────────────────────────────────────────────────
+echo "==> Running terraform apply …"
+terraform -chdir="${SCRIPT_DIR}" apply -auto-approve \
+  -var-file="${TFVARS_FILE}"
+echo "==> Apply succeeded."
+
+# ── Assert: plan must show zero drift ────────────────────────────────────────
+# terraform plan -detailed-exitcode exit codes:
+#   0 = success, no diff (what we want)
+#   1 = error
+#   2 = success, but diff exists (provider Read is wrong / resource drifted)
+echo "==> Asserting no drift (terraform plan -detailed-exitcode) …"
+set +e
+terraform -chdir="${SCRIPT_DIR}" plan -detailed-exitcode \
+  -var-file="${TFVARS_FILE}"
+PLAN_EXIT=$?
+set -e
+
+case "${PLAN_EXIT}" in
+  0)
+    echo "==> ASSERT PASSED: plan reports no drift — provider Read path is correct."
+    ;;
+  1)
+    echo "FAIL: terraform plan returned an error (exit 1)."
+    echo "      Check the output above for details."
+    exit 1
+    ;;
+  2)
+    echo "FAIL: terraform plan detected drift (exit 2)."
+    echo "      At least one resource does not match the control-plane state."
+    echo "      This indicates a bug in a provider Read/Refresh function."
+    exit 2
+    ;;
+  *)
+    echo "FAIL: terraform plan returned unexpected exit code ${PLAN_EXIT}."
+    exit "${PLAN_EXIT}"
+    ;;
+esac
+
+# ── Print created IDs ────────────────────────────────────────────────────────
+echo "==> Resource IDs created in staging:"
+terraform -chdir="${SCRIPT_DIR}" output
+
+# ── Optional backfill / sync trigger ─────────────────────────────────────────
+if [[ "${BACKFILL}" == "true" ]]; then
+  # NOTE: The rudder-iac client (github.com/rudderlabs/rudder-iac,
+  # currently at v0.17.1-0.20260612051227-31f63ee269cf) does NOT expose a
+  # sync-trigger or backfill endpoint.  The RETLConnectionStore interface
+  # (api/client/retl/retl.go) only covers CRUD + SetConnectionExternalId;
+  # there is no Trigger/Run/StartSync method and no corresponding HTTP path.
+  #
+  # Until that endpoint is added to the client (or confirmed via the
+  # RudderStack public API docs), this branch cannot be wired correctly.
+  #
+  # What needs confirming:
+  #   - The HTTP method and path for triggering a manual rETL sync, e.g.:
+  #       POST /v2/retl-connections/{id}/start    (guessed — NOT confirmed)
+  #       POST /v2/retl-connections/{id}/trigger  (guessed — NOT confirmed)
+  #   - The polling endpoint and its terminal state field, e.g.:
+  #       GET  /v2/retl-connections/{id}/sync-status/{syncId}
+  #   - The request/response shape.
+  #
+  # File to watch: api/client/retl/connections.go in the rudder-iac repo.
+  # Once that method exists, replace the block below with the real curl.
+  echo ""
+  echo "ERROR: --backfill is not yet wired."
+  echo ""
+  echo "  No sync-trigger endpoint was found in the rudder-iac client"
+  echo "  (api/client/retl/connections.go, v0.17.1).  The API path and"
+  echo "  polling contract need to be confirmed before this can be"
+  echo "  implemented correctly."
+  echo ""
+  echo "  See the comment block in run.sh (--backfill section) for details."
+  exit 3
+fi
+
+echo "==> Smoke run complete."

--- a/test/e2e/staging/run.sh
+++ b/test/e2e/staging/run.sh
@@ -62,7 +62,9 @@ BIN_DIR="${SCRIPT_DIR}/.bin"
 PROVIDER_BINARY="${BIN_DIR}/terraform-provider-rudderstack"
 
 # ── Temp dev-override CLI config ─────────────────────────────────────────────
-OVERRIDE_CFG="$(mktemp "${TMPDIR:-/tmp}/tf-dev-override-XXXXXX.tfrc")"
+# No .tfrc suffix on the template: BSD/macOS mktemp requires the X's at the end.
+# TF_CLI_CONFIG_FILE accepts any path, so the extension is unnecessary.
+OVERRIDE_CFG="$(mktemp "${TMPDIR:-/tmp}/tf-dev-override-XXXXXX")"
 trap 'rm -f "${OVERRIDE_CFG}"' EXIT
 
 # ── Build the provider ───────────────────────────────────────────────────────

--- a/test/e2e/staging/variables.tf
+++ b/test/e2e/staging/variables.tf
@@ -1,0 +1,38 @@
+variable "access_token" {
+  description = "RudderStack staging personal access token."
+  type        = string
+  sensitive   = true
+}
+
+variable "api_url" {
+  description = "RudderStack API base URL."
+  type        = string
+  default     = "https://api.staging.rudderlabs.com"
+}
+
+variable "bq_project" {
+  description = "GCP project ID where the BigQuery dataset lives."
+  type        = string
+}
+
+variable "bq_location" {
+  description = "BigQuery dataset location (e.g. US, EU)."
+  type        = string
+  default     = "US"
+}
+
+variable "bq_dataset" {
+  description = "BigQuery dataset (schema) name."
+  type        = string
+}
+
+variable "bq_table" {
+  description = "BigQuery table name."
+  type        = string
+}
+
+variable "bq_credentials" {
+  description = "GCP service-account key JSON (contents of the JSON key file)."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
PR 2 of 4 in the rETL + Accounts e2e verification stack. Stacked on #271.

- Wires the real rudder-iac Accounts client into `NewAPIClient` (deletes the temporary stub); adds 404→clear-state handling on account read.
- Adds `test/e2e/staging/` — a real `terraform apply` smoke (BigQuery account → rETL source → connection) with `run.sh` (apply → `plan -detailed-exitcode` assert → trap-destroy → opt-in `--backfill`).

⚠️ **Gated on rudder-iac [#617](https://github.com/rudderlabs/rudder-iac/pull/617):** `go.mod` pins the unmerged DEX-375 pseudo-version. Re-pin to a tagged release before merge.

Verified: build + vet pass. Live runs blocked on staging registering the `SOURCE_BIGQUERY` account definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)