### PR TITLE
feat: require non-empty consents in consent management schema [SDK-4965]

### DIFF
--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -77,6 +77,7 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 						"consents": {
 							Type:        schema.TypeList,
 							Required:    true,
+							MinItems:    1,
 							Description: "The list of consent IDs for the provider.",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,

--- a/rudderstack/integrations/destinations/common_config_meta.go
+++ b/rudderstack/integrations/destinations/common_config_meta.go
@@ -81,6 +81,13 @@ func GetConfigMetaForGenericConsentManagement(supportedSourceTypes []string) ([]
 							Description: "The list of consent IDs for the provider.",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
+								// Mirror the integrations-config consent schema (pattern
+								// ^(?=.*\S).{1,100}$): reject empty/whitespace-only IDs and
+								// cap length at 100 so local plan validation matches the backend.
+								ValidateFunc: validation.All(
+									validation.StringIsNotWhiteSpace,
+									validation.StringLenBetween(1, 100),
+								),
 							},
 						},
 					},

--- a/rudderstack/resource_destination_test.go
+++ b/rudderstack/resource_destination_test.go
@@ -65,6 +65,53 @@ func TestResourceDestinationConsentManagementDuplicateProvider(t *testing.T) {
 	})
 }
 
+func TestResourceDestinationConsentManagementRejectsEmptyConsents(t *testing.T) {
+	_, consentSchema := destinations.GetConfigMetaForGenericConsentManagement([]string{"web", "android"})
+
+	cm := configs.ConfigMeta{
+		APIType:      "TEST",
+		ConfigSchema: consentSchema,
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"rudderstack": func() (*schema.Provider, error) {
+				return &schema.Provider{
+					ConfigureContextFunc: func(_ context.Context, _ *schema.ResourceData) (interface{}, diag.Diagnostics) {
+						return nil, nil
+					},
+					ResourcesMap: map[string]*schema.Resource{
+						"rudderstack_destination_test": resourceDestination(cm),
+					},
+				}, nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				PlanOnly: true,
+				Config: `
+					resource "rudderstack_destination_test" "example" {
+						name = "test-destination"
+
+						config {
+							consent_management {
+								web = [
+									{
+										provider = "oneTrust"
+										consents = []
+										resolution_strategy = ""
+									}
+								]
+							}
+						}
+					}
+				`,
+				ExpectError: regexp.MustCompile(`consents requires 1 item\s+minimum, but config has only 0 declared`),
+			},
+		},
+	})
+}
+
 func TestResourceDestinationConsentManagementAllowsDistinctAndPerSourceType(t *testing.T) {
 	_, consentSchema := destinations.GetConfigMetaForGenericConsentManagement([]string{"web", "android"})
 

--- a/rudderstack/resource_destination_test.go
+++ b/rudderstack/resource_destination_test.go
@@ -106,7 +106,7 @@ func TestResourceDestinationConsentManagementRejectsEmptyConsents(t *testing.T) 
 						}
 					}
 				`,
-				ExpectError: regexp.MustCompile(`consents requires 1 item\s+minimum, but config has only 0 declared`),
+				ExpectError: regexp.MustCompile(`consents requires 1 item\s+minimum`),
 			},
 		},
 	})

--- a/rudderstack/resource_destination_test.go
+++ b/rudderstack/resource_destination_test.go
@@ -112,6 +112,53 @@ func TestResourceDestinationConsentManagementRejectsEmptyConsents(t *testing.T) 
 	})
 }
 
+func TestResourceDestinationConsentManagementRejectsBlankConsentValue(t *testing.T) {
+	_, consentSchema := destinations.GetConfigMetaForGenericConsentManagement([]string{"web", "android"})
+
+	cm := configs.ConfigMeta{
+		APIType:      "TEST",
+		ConfigSchema: consentSchema,
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"rudderstack": func() (*schema.Provider, error) {
+				return &schema.Provider{
+					ConfigureContextFunc: func(_ context.Context, _ *schema.ResourceData) (interface{}, diag.Diagnostics) {
+						return nil, nil
+					},
+					ResourcesMap: map[string]*schema.Resource{
+						"rudderstack_destination_test": resourceDestination(cm),
+					},
+				}, nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				PlanOnly: true,
+				Config: `
+					resource "rudderstack_destination_test" "example" {
+						name = "test-destination"
+
+						config {
+							consent_management {
+								web = [
+									{
+										provider = "oneTrust"
+										consents = ["   "]
+										resolution_strategy = ""
+									}
+								]
+							}
+						}
+					}
+				`,
+				ExpectError: regexp.MustCompile(`empty string or whitespace`),
+			},
+		},
+	})
+}
+
 func TestResourceDestinationConsentManagementAllowsDistinctAndPerSourceType(t *testing.T) {
 	_, consentSchema := destinations.GetConfigMetaForGenericConsentManagement([]string{"web", "android"})
 


### PR DESCRIPTION
## What

Make the `consents` list mandatory with **at least 1 item** and reject blank/over-long consent IDs in the consent management config of the destination schema, mirroring the change already shipped in the integrations-config schema (each `consentManagement` source-type entry requires a `provider` and a **non-empty** `consents` array, with each consent ID matching `^(?=.*\S).{1,100}$`).

## Changes

- `rudderstack/integrations/destinations/common_config_meta.go`
  - added `MinItems: 1` to the `consents` schema inside `GetConfigMetaForGenericConsentManagement` (matching the `MinItems: 1` convention used in `retl/connection_base.go`).
  - added a per-element `ValidateFunc` on the `consents` list — `validation.All(validation.StringIsNotWhiteSpace, validation.StringLenBetween(1, 100))` — mirroring the integrations-config consent pattern `^(?=.*\S).{1,100}$`. Go's RE2 has no lookahead, so the constraint is expressed via the SDK validators rather than `StringMatch`. This rejects empty/whitespace-only IDs and caps length at 100 at **plan time** instead of relying on the backend backstop at apply time.
- `rudderstack/resource_destination_test.go` — added two plan-only unit tests:
  - `TestResourceDestinationConsentManagementRejectsEmptyConsents` — asserts an empty `consents = []` is rejected (`MinItems`).
  - `TestResourceDestinationConsentManagementRejectsBlankConsentValue` — asserts a whitespace-only consent ID is rejected (element `ValidateFunc`).

> Note: the per-element validator is a user-visible plan-time behavior change. It only rejects configs that were already invalid against the backend/integrations-config schema (empty, whitespace-only, or >100-char consent IDs), so valid configs are unaffected; it surfaces those failures locally at plan time instead of at apply.

## Checks

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (all packages)
- `golangci-lint run ./rudderstack/...` — 0 issues
- `tfplugindocs` — no doc drift (`MinItems` / `ValidateFunc` are not rendered as text)

## Context

- Ticket: [SDK-4965](https://linear.app/rudderstack/issue/SDK-4965)
- Pairs with the corresponding webapp / integrations-config changes.

### Related PRs (SDK-4965)
- rudderlabs/rudder-webapp#9661 — webapp (form builder)
- rudderlabs/rudder-integrations-config#2562 — schema/ui-config
- rudderlabs/rudder-config-backend#6348 — cleanup admin script
