### PR TITLE
test(retl): rETL acceptance tests + upstream config verification (PRO-5676, PRO-5768)

### DIFF
--- a/.github/workflows/e2e-staging-smoke.yml
+++ b/.github/workflows/e2e-staging-smoke.yml
@@ -1,0 +1,83 @@
+name: E2E Staging Smoke
+
+permissions:
+  contents: read
+
+# Applies REAL resources to the staging workspace (BigQuery account → rETL
+# source → connection), asserts no drift, destroys them on exit — the CI
+# counterpart of test/e2e/staging/run.sh (the #274 black-box smoke).
+#
+# Triggers:
+#   - pull_request, gated by the `e2e-staging` label — runnable on a PR BEFORE
+#     merge. For pull_request, GitHub reads this workflow from the PR HEAD, so
+#     it works even though the file isn't on the default branch yet. Add the
+#     label to run; pushes re-run while it's present.
+#   - workflow_dispatch — manual runs once this file is on the default branch
+#     (post-merge). Dispatch is NOT available pre-merge: GitHub lists dispatch
+#     workflows from the default branch only.
+#
+# Opt-in (label/manual), never automatic on every push: main.tf uses fixed
+# resource names (tf-e2e-*), so the concurrency group serializes runs.
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-staging-smoke
+  cancel-in-progress: false
+
+jobs:
+  staging-smoke:
+    # Always on manual dispatch; on a PR only when the `e2e-staging` label is set.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e-staging')
+    runs-on: ubuntu-latest
+    environment: e2e
+    timeout-minutes: 20
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Run staging smoke (apply → assert no drift → destroy)
+        # Creds come from the `e2e` GitHub Environment. bq_credentials is passed
+        # via TF_VAR_ (not the tfvars file) to avoid embedding the JSON key.
+        # If the staging token is unset the job no-ops (skips) rather than
+        # failing — same pattern as RUDDERSTACK_RETL_TEST_ACCOUNT_ID. PAUSE is
+        # intentionally not set: the hold-open path is for local runs only.
+        env:
+          STAGING_ACCESS_TOKEN: ${{ secrets.RUDDERSTACK_STAGING_ACCESS_TOKEN }}
+          STAGING_API_URL: ${{ vars.RUDDERSTACK_STAGING_API_URL }}
+          BQ_PROJECT: ${{ vars.RUDDERSTACK_STAGING_BQ_PROJECT }}
+          BQ_DATASET: ${{ vars.RUDDERSTACK_STAGING_BQ_DATASET }}
+          BQ_TABLE: ${{ vars.RUDDERSTACK_STAGING_BQ_TABLE }}
+          TF_VAR_bq_credentials: ${{ secrets.RUDDERSTACK_STAGING_BQ_CREDENTIALS }}
+        run: |
+          if [ -z "$STAGING_ACCESS_TOKEN" ]; then
+            echo "RUDDERSTACK_STAGING_ACCESS_TOKEN is not set on the e2e environment; skipping staging smoke."
+            exit 0
+          fi
+          cat > test/e2e/staging/secret.tfvars <<EOF
+          access_token = "$STAGING_ACCESS_TOKEN"
+          api_url      = "${STAGING_API_URL:-https://api.staging.rudderlabs.com}"
+          bq_project   = "$BQ_PROJECT"
+          bq_dataset   = "$BQ_DATASET"
+          bq_table     = "$BQ_TABLE"
+          EOF
+          bash test/e2e/staging/run.sh test/e2e/staging/secret.tfvars

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-ci:
 
 .PHONY: testacc-all
 testacc-all: ## Run all E2E acceptance tests (full CRUD)
-	TF_ACC=1 go test ./rudderstack/integrations/... ./rudderstack/accounts/ -v -run "TestAcc" -timeout 60m -count=1
+	TF_ACC=1 go test ./rudderstack/integrations/... ./rudderstack/accounts/ ./rudderstack/retl/ -v -run "TestAcc" -timeout 60m -count=1
 
 .PHONY: testacc-dest
 testacc-dest: ## Run E2E for one destination. Usage: make testacc-dest DEST=webhook
@@ -86,6 +86,10 @@ testacc-source: ## Run E2E for one source. Usage: make testacc-source SRC=http
 testacc-conn: ## Run E2E for connections. Usage: make testacc-conn
 	TF_ACC=1 go test ./rudderstack/integrations/connections/ -v -run "TestAccConnection" -timeout 10m -count=1
 
+.PHONY: testacc-retl
+testacc-retl: ## Run E2E for RETL resources (sources + connections)
+	TF_ACC=1 go test ./rudderstack/retl/ -v -run "TestAccRETL" -timeout 10m -count=1
+
 .PHONY: testacc-plan
 testacc-plan: ## Plan-only validation for all integrations (no API calls)
-	TF_ACC=1 TF_ACC_PLAN_ONLY=1 go test ./rudderstack/integrations/... ./rudderstack/accounts/ -run "TestAcc" -timeout 5m -count=1
+	TF_ACC=1 TF_ACC_PLAN_ONLY=1 go test ./rudderstack/integrations/... ./rudderstack/accounts/ ./rudderstack/retl/ -run "TestAcc" -timeout 5m -count=1

--- a/internal/testutil/acc/coverage_test.go
+++ b/internal/testutil/acc/coverage_test.go
@@ -48,6 +48,33 @@ func TestAllSourcesHaveAcceptanceTests(t *testing.T) {
 	}
 }
 
+// retlResources lists the RETL resources registered in rudderstack/provider.go.
+// They have no registry like configs.Sources/Destinations, so the coverage gate
+// hard-codes the set. Update this list when adding a new RETL resource.
+var retlResources = []string{
+	"retl_source_model",
+	"retl_source_table",
+	"retl_connection",
+}
+
+// TestAllRETLResourcesHaveAcceptanceTests verifies that every RETL resource
+// has a corresponding TestAccRETL* function in rudderstack/retl/.
+func TestAllRETLResourcesHaveAcceptanceTests(t *testing.T) {
+	testFuncs, err := collectTestFunctions("rudderstack/retl")
+	if err != nil {
+		t.Fatalf("failed to scan test functions: %v", err)
+	}
+
+	for _, name := range retlResources {
+		// Drop the leading "retl_" so "retl_source_model" matches
+		// TestAccRETLSourceModel*.
+		key := normalizeKey(strings.TrimPrefix(name, "retl_"))
+		if !hasMatchingFuncPrefix(testFuncs, "TestAccRETL", key) {
+			t.Errorf("RETL resource %q has no acceptance test matching TestAccRETL<Name>*", name)
+		}
+	}
+}
+
 // collectTestFunctions parses *_test.go files in the given directory and returns
 // a set of all top-level test function names.
 func collectTestFunctions(relDir string) (map[string]bool, error) {
@@ -121,6 +148,25 @@ func hasMatchingFunc(funcs map[string]bool, prefix, normalizedKey string) bool {
 		}
 		rest := lower[len(lowerPrefix):]
 		if rest == normalizedKey {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMatchingFuncPrefix is the prefix-matching variant of hasMatchingFunc:
+// after stripping `prefix`, the remainder need only START with `normalizedKey`.
+// Used for RETL acceptance tests which name variants with suffixes
+// (e.g. TestAccRETLSourceModel_Snowflake matches key "sourcemodel").
+func hasMatchingFuncPrefix(funcs map[string]bool, prefix, normalizedKey string) bool {
+	lowerPrefix := strings.ToLower(prefix)
+	for fn := range funcs {
+		lower := strings.ToLower(fn)
+		if !strings.HasPrefix(lower, lowerPrefix) {
+			continue
+		}
+		rest := lower[len(lowerPrefix):]
+		if strings.HasPrefix(rest, normalizedKey) {
 			return true
 		}
 	}

--- a/internal/testutil/acc/coverage_test.go
+++ b/internal/testutil/acc/coverage_test.go
@@ -51,6 +51,11 @@ func TestAllSourcesHaveAcceptanceTests(t *testing.T) {
 // retlResources lists the RETL resources registered in rudderstack/provider.go.
 // They have no registry like configs.Sources/Destinations, so the coverage gate
 // hard-codes the set. Update this list when adding a new RETL resource.
+//
+// rudderstack_retl_connection_customerio_audience is intentionally excluded here:
+// it is a vendor-gated integration (needs a Customer.io account to exercise live),
+// handled the same way as other vendor-gated integrations. It is brought under the
+// gate by its own follow-up change.
 var retlResources = []string{
 	"retl_source_model",
 	"retl_source_table",

--- a/internal/testutil/acc/coverage_test.go
+++ b/internal/testutil/acc/coverage_test.go
@@ -48,18 +48,20 @@ func TestAllSourcesHaveAcceptanceTests(t *testing.T) {
 	}
 }
 
-// retlResources lists the RETL resources registered in rudderstack/provider.go.
-// They have no registry like configs.Sources/Destinations, so the coverage gate
-// hard-codes the set. Update this list when adding a new RETL resource.
+// retlResources lists the RETL resources registered in rudderstack/provider.go
+// that are enforced by this coverage gate. They have no registry like
+// configs.Sources/Destinations, so the set is hard-coded here. Update this
+// list when adding a new RETL resource that has full acceptance-test coverage.
 //
-// rudderstack_retl_connection_customerio_audience is intentionally excluded here:
-// it is a vendor-gated integration (needs a Customer.io account to exercise live),
-// handled the same way as other vendor-gated integrations. It is brought under the
-// gate by its own follow-up change.
+// rudderstack_retl_connection_customerio_audience is covered by a plan-only-safe
+// acceptance test (TestAccRETLConnectionCustomerIOAudience_*); its live path is
+// vendor-gated on a Customer.io env var, the same way the other vendor-gated
+// integrations are handled.
 var retlResources = []string{
 	"retl_source_model",
 	"retl_source_table",
 	"retl_connection",
+	"retl_connection_customerio_audience",
 }
 
 // TestAllRETLResourcesHaveAcceptanceTests verifies that every RETL resource

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -2,6 +2,7 @@ package acc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -34,6 +35,12 @@ type RETLSourceTestConfig struct {
 	SourceDefinitionName string // e.g. "bigquery"
 	Config               string // HCL inside config { } block for the create step
 	UpdateConfig         string // HCL for the update step (omit to skip update)
+
+	// ExpectedConfigJSON / ExpectedUpdateConfigJSON are API-shaped config JSON
+	// (camelCase keys, e.g. "primaryKey") verified as a subset against the
+	// source's persisted config after the create / update step. Empty = skip.
+	ExpectedConfigJSON       string
+	ExpectedUpdateConfigJSON string
 }
 
 // RETLConnectionTestConfig describes a connection variant. The helper builds
@@ -55,6 +62,14 @@ type RETLConnectionTestConfig struct {
 	// connection's mappings { } blocks. Mappings are mutable across all flows,
 	// so this is the cheapest way to flex the Update path.
 	UpdateMappings string
+
+	// ExpectedConfigJSON / ExpectedUpdateConfigJSON are API-shaped JSON
+	// (camelCase keys, e.g. "syncBehaviour", "everyMinutes") verified as a
+	// subset against the connection returned by the API after the create /
+	// update step. Empty = skip. Extra API fields (id, sourceId, …) are
+	// tolerated by the subset matcher.
+	ExpectedConfigJSON       string
+	ExpectedUpdateConfigJSON string
 }
 
 // AccAssertRETLSourceModel runs the standard E2E lifecycle against
@@ -120,6 +135,7 @@ func runRETLSourceLifecycle(t *testing.T, resourceType string, cfg RETLSourceTes
 				resource.TestCheckResourceAttrSet(resourceName, "id"),
 				resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				testAccCheckRETLSourceConfig(resourceName, cfg.ExpectedConfigJSON),
 			),
 		},
 	}
@@ -131,6 +147,7 @@ func runRETLSourceLifecycle(t *testing.T, resourceType string, cfg RETLSourceTes
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckRETLSourceExists(resourceName),
 				resource.TestCheckResourceAttr(resourceName, "name", name+"-updated"),
+				testAccCheckRETLSourceConfig(resourceName, cfg.ExpectedUpdateConfigJSON),
 			),
 		})
 	}
@@ -207,6 +224,7 @@ func AccAssertRETLConnection(t *testing.T, cfg RETLConnectionTestConfig) {
 				resource.TestCheckResourceAttr(connResource, "sync_behaviour", cfg.SyncBehaviour),
 				resource.TestCheckResourceAttrPair(connResource, "source_id", srcResource, "id"),
 				resource.TestCheckResourceAttrPair(connResource, "destination_id", dstResource, "id"),
+				testAccCheckRETLConnectionConfig(connResource, cfg.ExpectedConfigJSON),
 			),
 		},
 	}
@@ -219,6 +237,7 @@ func AccAssertRETLConnection(t *testing.T, cfg RETLConnectionTestConfig) {
 			Config: retlConnectionHCL(srcName, dstName, accountID, updated),
 			Check: resource.ComposeTestCheckFunc(
 				testAccCheckRETLConnectionExists(connResource),
+				testAccCheckRETLConnectionConfig(connResource, cfg.ExpectedUpdateConfigJSON),
 			),
 		})
 	}
@@ -328,6 +347,65 @@ func testAccCheckRETLSourceExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("RETL source %s not found in API: %w", rs.Primary.ID, err)
 		}
 		return nil
+	}
+}
+
+// testAccCheckRETLSourceConfig fetches the source from the RETL API and verifies
+// its persisted config contains every field in expectedJSON (subset match —
+// extra API-added fields are tolerated). expectedJSON uses the API's camelCase
+// keys (e.g. "primaryKey"). No-op when expectedJSON is empty.
+func testAccCheckRETLSourceConfig(resourceName, expectedJSON string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if expectedJSON == "" {
+			return nil
+		}
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		src, err := store.GetRetlSource(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get RETL source from API: %w", err)
+		}
+		actual, err := json.Marshal(src.Config)
+		if err != nil {
+			return fmt.Errorf("failed to marshal RETL source config: %w", err)
+		}
+		return compareConfig(actual, expectedJSON)
+	}
+}
+
+// testAccCheckRETLConnectionConfig fetches the connection from the RETL API and
+// verifies it contains every field in expectedJSON (subset match). The whole
+// connection is marshalled, so expectedJSON may assert on any returned field
+// (syncBehaviour, schedule, identifiers, mappings, event, …); unlisted fields
+// like id/sourceId are ignored. No-op when expectedJSON is empty.
+func testAccCheckRETLConnectionConfig(resourceName, expectedJSON string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if expectedJSON == "" {
+			return nil
+		}
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		conn, err := store.GetConnection(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get RETL connection from API: %w", err)
+		}
+		actual, err := json.Marshal(conn)
+		if err != nil {
+			return fmt.Errorf("failed to marshal RETL connection: %w", err)
+		}
+		return compareConfig(actual, expectedJSON)
 	}
 }
 

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,10 +16,11 @@ import (
 	"github.com/rudderlabs/rudder-iac/api/client/retl"
 )
 
-// retlAccountIDEnv names the env var that supplies a real warehouse account ID
-// for live RETL acceptance tests. When unset (and the test is not running in
-// plan-only mode) the helpers t.Skip — local runs without a workspace fixture
-// shouldn't fail. The e2e-tests.yml workflow forwards `vars.RUDDERSTACK_RETL_TEST_ACCOUNT_ID`
+// retlAccountIDEnv names the env var that supplies a real BigQuery account ID
+// (a rudderstack_account_source_bigquery resource's id) for live RETL
+// acceptance tests. When unset (and the test is not running in plan-only mode)
+// the helpers t.Skip — local runs without a workspace fixture shouldn't fail.
+// The e2e-tests.yml workflow forwards `vars.RUDDERSTACK_RETL_TEST_ACCOUNT_ID`
 // (a GitHub Environment variable, not a secret — the ID is opaque, not credentials)
 // to this env var; until that variable is added, the expression renders empty
 // in CI and the live RETL tests skip.
@@ -27,6 +29,18 @@ const retlAccountIDEnv = "RUDDERSTACK_RETL_TEST_ACCOUNT_ID"
 // planOnlyAccountID is a placeholder used in plan-only mode where no API call
 // is made; the value just has to satisfy the schema (non-empty string).
 const planOnlyAccountID = "acc-plan-only"
+
+// customerIOAudienceEnv gates the LIVE Customer.io Audience connection test and
+// supplies the audience ID to use. Customer.io Audience is a vendor-specific
+// RETL flow; like the other vendor-gated integrations it only runs live when an
+// operator opts in by pointing this at a real audience ID. Unset (the CI
+// default) → the live path skips; the plan-only path always runs. The warehouse
+// source still needs retlAccountIDEnv on top of this.
+const customerIOAudienceEnv = "RUDDERSTACK_CUSTOMERIO_TEST_AUDIENCE_ID"
+
+// planOnlyAudienceID satisfies the audience_id IntAtLeast(1) schema in plan-only
+// mode, where no API call is made.
+const planOnlyAudienceID = 1
 
 // RETLSourceTestConfig is the shape consumed by AccAssertRETLSourceModel /
 // AccAssertRETLSourceTable. The Config / UpdateConfig fields are HCL fragments
@@ -103,7 +117,7 @@ func runRETLSourceLifecycle(t *testing.T, resourceType string, cfg RETLSourceTes
 	if !planOnly {
 		accountID = os.Getenv(retlAccountIDEnv)
 		if accountID == "" {
-			t.Skipf("%s is not set; skipping live RETL source test (set it to a workspace warehouse account ID)", retlAccountIDEnv)
+			t.Skipf("%s is not set; skipping live RETL source test (set it to a BigQuery account id)", retlAccountIDEnv)
 		}
 	}
 
@@ -251,9 +265,157 @@ func AccAssertRETLConnection(t *testing.T, cfg RETLConnectionTestConfig) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { TestAccPreCheck(t) },
 		ProviderFactories: TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRETLConnectionDestroy,
+		CheckDestroy:      testAccCheckRETLConnectionDestroy("rudderstack_retl_connection"),
 		Steps:             steps,
 	})
+}
+
+// AccAssertRETLConnectionCustomerIOAudience wires a model source + Customer.io
+// Audience destination + rudderstack_retl_connection_customerio_audience and
+// runs the lifecycle. The typed connection carries audience_id as a top-level
+// field (no event/cursor_column — those are JSON-mapper-only).
+//
+// Plan-only (CI default): validates HCL/schema with placeholder creds, zero API
+// calls. Live: gated on customerIOAudienceEnv (the audience ID) plus
+// retlAccountIDEnv (the warehouse source account); skips when either is unset.
+func AccAssertRETLConnectionCustomerIOAudience(t *testing.T, cfg RETLConnectionTestConfig) {
+	t.Helper()
+
+	planOnly := PlanOnly()
+	if planOnly {
+		t.Parallel()
+	}
+
+	connResource := "rudderstack_retl_connection_customerio_audience.test"
+	srcResource := "rudderstack_retl_source_model.test"
+	dstResource := "rudderstack_destination_customerio_audience.test"
+
+	suffix := cfg.Variant
+	if suffix == "" {
+		suffix = "cio-aud"
+	}
+	srcName := RandomName("retl-src-" + suffix)
+	dstName := RandomName("retl-dst-" + suffix)
+
+	accountID := planOnlyAccountID
+	audienceID := planOnlyAudienceID
+	if !planOnly {
+		accountID = os.Getenv(retlAccountIDEnv)
+		if accountID == "" {
+			t.Skipf("%s is not set; skipping live Customer.io Audience connection test", retlAccountIDEnv)
+		}
+		raw := os.Getenv(customerIOAudienceEnv)
+		if raw == "" {
+			t.Skipf("%s is not set; skipping live Customer.io Audience connection test", customerIOAudienceEnv)
+		}
+		id, err := strconv.Atoi(raw)
+		if err != nil || id < 1 {
+			t.Fatalf("%s must be a positive integer, got %q", customerIOAudienceEnv, raw)
+		}
+		audienceID = id
+	}
+
+	createHCL := retlCustomerIOAudienceHCL(srcName, dstName, accountID, audienceID, cfg)
+
+	if planOnly {
+		ensureDummyToken(t)
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             createHCL,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+		return
+	}
+
+	steps := []resource.TestStep{
+		{
+			Config: createHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+				resource.TestCheckResourceAttrSet(connResource, "id"),
+				resource.TestCheckResourceAttr(connResource, "audience_id", strconv.Itoa(audienceID)),
+				resource.TestCheckResourceAttr(connResource, "sync_behaviour", cfg.SyncBehaviour),
+				resource.TestCheckResourceAttrPair(connResource, "source_id", srcResource, "id"),
+				resource.TestCheckResourceAttrPair(connResource, "destination_id", dstResource, "id"),
+			),
+		},
+	}
+
+	if cfg.UpdateMappings != "" {
+		updated := cfg
+		updated.Mappings = cfg.UpdateMappings
+		updated.UpdateMappings = ""
+		steps = append(steps, resource.TestStep{
+			Config: retlCustomerIOAudienceHCL(srcName, dstName, accountID, audienceID, updated),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+			),
+		})
+	}
+
+	steps = append(steps, resource.TestStep{
+		ResourceName:      connResource,
+		ImportState:       true,
+		ImportStateVerify: true,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRETLConnectionDestroy("rudderstack_retl_connection_customerio_audience"),
+		Steps:             steps,
+	})
+}
+
+// retlCustomerIOAudienceHCL builds the source + Customer.io Audience destination
+// + typed connection pipeline. The destination creds are placeholders: the
+// control-plane API stores them without validating against Customer.io (same
+// rationale as the webhook destination in retlConnectionHCL), so live runs don't
+// need real keys — only a warehouse account and an audience ID.
+func retlCustomerIOAudienceHCL(srcName, dstName, accountID string, audienceID int, cfg RETLConnectionTestConfig) string {
+	mappingsBlock := ""
+	if cfg.Mappings != "" {
+		mappingsBlock = "\n  " + cfg.Mappings
+	}
+
+	return fmt.Sprintf(`
+resource "rudderstack_retl_source_model" "test" {
+  name                   = %q
+  source_definition_name = "bigquery"
+  account_id             = %q
+  config {
+    primary_key = "id"
+    sql         = "select 1 as id"
+  }
+}
+
+resource "rudderstack_destination_customerio_audience" "test" {
+  name = %q
+  config {
+    site_id     = "tf-acc-site"
+    api_key     = "tf-acc-api-key"
+    app_api_key = "tf-acc-app-api-key"
+    region      = "US"
+  }
+}
+
+resource "rudderstack_retl_connection_customerio_audience" "test" {
+  source_id      = rudderstack_retl_source_model.test.id
+  destination_id = rudderstack_destination_customerio_audience.test.id
+  enabled        = true
+  sync_behaviour = %q
+  audience_id    = %d
+  schedule {
+    %s
+  }
+  %s%s
+}
+`, srcName, accountID, dstName, cfg.SyncBehaviour, audienceID, cfg.Schedule, cfg.Identifiers, mappingsBlock)
 }
 
 // retlSourceHCL builds the HCL for a single RETL source resource.
@@ -449,26 +611,28 @@ func testAccCheckRETLConnectionExists(resourceName string) resource.TestCheckFun
 	}
 }
 
-func testAccCheckRETLConnectionDestroy(s *terraform.State) error {
-	store, err := newTestRETLClient()
-	if err != nil {
-		return err
+func testAccCheckRETLConnectionDestroy(resourceType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != resourceType {
+				continue
+			}
+			// Expect 404 after delete; tolerant of any error (network blips,
+			// soft-delete) — we don't fail the test here.
+			_, getErr := store.GetConnection(context.Background(), rs.Primary.ID)
+			if getErr == nil {
+				// If it still exists, surface that — it's likely a real bug.
+				return fmt.Errorf("RETL connection %s still exists after destroy", rs.Primary.ID)
+			}
+			var apiErr *client.APIError
+			if errors.As(getErr, &apiErr) && apiErr.HTTPStatusCode == 404 {
+				continue
+			}
+		}
+		return nil
 	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "rudderstack_retl_connection" {
-			continue
-		}
-		// Expect 404 after delete; tolerant of any error (network blips,
-		// soft-delete) — we don't fail the test here.
-		_, getErr := store.GetConnection(context.Background(), rs.Primary.ID)
-		if getErr == nil {
-			// If it still exists, surface that — it's likely a real bug.
-			return fmt.Errorf("RETL connection %s still exists after destroy", rs.Primary.ID)
-		}
-		var apiErr *client.APIError
-		if errors.As(getErr, &apiErr) && apiErr.HTTPStatusCode == 404 {
-			continue
-		}
-	}
-	return nil
 }

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -1,0 +1,393 @@
+package acc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/rudder-iac/api/client/retl"
+)
+
+// retlAccountIDEnv names the env var that supplies a real warehouse account ID
+// for live RETL acceptance tests. When unset (and the test is not running in
+// plan-only mode) the helpers t.Skip — local runs without a workspace fixture
+// shouldn't fail. CI sets this from a GitHub Environment secret in the live phase.
+const retlAccountIDEnv = "RUDDERSTACK_RETL_TEST_ACCOUNT_ID"
+
+// planOnlyAccountID is a placeholder used in plan-only mode where no API call
+// is made; the value just has to satisfy the schema (non-empty string).
+const planOnlyAccountID = "acc-plan-only"
+
+// RETLSourceTestConfig is the shape consumed by AccAssertRETLSourceModel /
+// AccAssertRETLSourceTable. The Config / UpdateConfig fields are HCL fragments
+// that go inside the resource's `config { }` block.
+type RETLSourceTestConfig struct {
+	SourceDefinitionName string // e.g. "snowflake"
+	Config               string // HCL inside config { } block for the create step
+	UpdateConfig         string // HCL for the update step (omit to skip update)
+}
+
+// RETLConnectionTestConfig describes a connection variant. The helper builds
+// a complete pipeline (RETL source + webhook destination + connection) so
+// tests don't need to repeat the boilerplate.
+type RETLConnectionTestConfig struct {
+	// Variant is a short label included in the test resource names so
+	// concurrent runs don't collide.
+	Variant string
+
+	SyncBehaviour string // "upsert" | "mirror" | "full"
+	Schedule      string // HCL fragment for the schedule { } block body
+	Identifiers   string // HCL fragment for one or more identifiers { } blocks
+	Mappings      string // HCL fragment for mappings { } blocks (optional)
+	Event         string // HCL fragment for event { } block (optional)
+	CursorColumn  string // value for cursor_column (optional, requires upsert)
+
+	// UpdateMappings, when non-empty, runs an Update step replacing the
+	// connection's mappings { } blocks. Mappings are mutable across all flows,
+	// so this is the cheapest way to flex the Update path.
+	UpdateMappings string
+}
+
+// AccAssertRETLSourceModel runs the standard E2E lifecycle against
+// rudderstack_retl_source_model. In plan-only mode it validates HCL/schema only;
+// in live mode it runs Create → Update → Import → Destroy and verifies via the
+// RETL API.
+func AccAssertRETLSourceModel(t *testing.T, cfg RETLSourceTestConfig) {
+	t.Helper()
+	runRETLSourceLifecycle(t, "rudderstack_retl_source_model", cfg)
+}
+
+// AccAssertRETLSourceTable runs the standard E2E lifecycle against
+// rudderstack_retl_source_table. See AccAssertRETLSourceModel.
+func AccAssertRETLSourceTable(t *testing.T, cfg RETLSourceTestConfig) {
+	t.Helper()
+	runRETLSourceLifecycle(t, "rudderstack_retl_source_table", cfg)
+}
+
+func runRETLSourceLifecycle(t *testing.T, resourceType string, cfg RETLSourceTestConfig) {
+	t.Helper()
+
+	planOnly := PlanOnly()
+	if planOnly {
+		t.Parallel()
+	}
+
+	resourceName := fmt.Sprintf("%s.test", resourceType)
+	name := RandomName(resourceType)
+
+	accountID := planOnlyAccountID
+	if !planOnly {
+		accountID = os.Getenv(retlAccountIDEnv)
+		if accountID == "" {
+			t.Skipf("%s is not set; skipping live RETL source test (set it to a workspace warehouse account ID)", retlAccountIDEnv)
+		}
+	}
+
+	createHCL := retlSourceHCL(resourceType, name, cfg.SourceDefinitionName, accountID, cfg.Config)
+
+	if planOnly {
+		ensureDummyToken(t)
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             createHCL,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+		return
+	}
+
+	steps := []resource.TestStep{
+		{
+			Config: createHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLSourceExists(resourceName),
+				resource.TestCheckResourceAttr(resourceName, "name", name),
+				resource.TestCheckResourceAttr(resourceName, "source_definition_name", cfg.SourceDefinitionName),
+				resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
+				resource.TestCheckResourceAttrSet(resourceName, "id"),
+				resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+			),
+		},
+	}
+
+	if cfg.UpdateConfig != "" {
+		updateHCL := retlSourceHCL(resourceType, name+"-updated", cfg.SourceDefinitionName, accountID, cfg.UpdateConfig)
+		steps = append(steps, resource.TestStep{
+			Config: updateHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLSourceExists(resourceName),
+				resource.TestCheckResourceAttr(resourceName, "name", name+"-updated"),
+			),
+		})
+	}
+
+	steps = append(steps, resource.TestStep{
+		ResourceName:      resourceName,
+		ImportState:       true,
+		ImportStateVerify: true,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRETLSourceDestroy(resourceType),
+		Steps:             steps,
+	})
+}
+
+// AccAssertRETLConnection wires a model source + webhook destination +
+// rudderstack_retl_connection and runs the lifecycle. The webhook destination
+// is sufficient for the control-plane API (it doesn't validate downstream
+// connectivity) and avoids needing real warehouse credentials in CI.
+func AccAssertRETLConnection(t *testing.T, cfg RETLConnectionTestConfig) {
+	t.Helper()
+
+	planOnly := PlanOnly()
+	if planOnly {
+		t.Parallel()
+	}
+
+	connResource := "rudderstack_retl_connection.test"
+	srcResource := "rudderstack_retl_source_model.test"
+	dstResource := "rudderstack_destination_webhook.test"
+
+	suffix := cfg.Variant
+	if suffix == "" {
+		suffix = "conn"
+	}
+	srcName := RandomName("retl-src-" + suffix)
+	dstName := RandomName("retl-dst-" + suffix)
+
+	accountID := planOnlyAccountID
+	if !planOnly {
+		accountID = os.Getenv(retlAccountIDEnv)
+		if accountID == "" {
+			t.Skipf("%s is not set; skipping live RETL connection test", retlAccountIDEnv)
+		}
+	}
+
+	createHCL := retlConnectionHCL(srcName, dstName, accountID, cfg)
+
+	if planOnly {
+		ensureDummyToken(t)
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             createHCL,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+		return
+	}
+
+	steps := []resource.TestStep{
+		{
+			Config: createHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+				resource.TestCheckResourceAttrSet(connResource, "id"),
+				resource.TestCheckResourceAttr(connResource, "enabled", "true"),
+				resource.TestCheckResourceAttr(connResource, "sync_behaviour", cfg.SyncBehaviour),
+				resource.TestCheckResourceAttrPair(connResource, "source_id", srcResource, "id"),
+				resource.TestCheckResourceAttrPair(connResource, "destination_id", dstResource, "id"),
+			),
+		},
+	}
+
+	if cfg.UpdateMappings != "" {
+		updated := cfg
+		updated.Mappings = cfg.UpdateMappings
+		updated.UpdateMappings = ""
+		steps = append(steps, resource.TestStep{
+			Config: retlConnectionHCL(srcName, dstName, accountID, updated),
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+			),
+		})
+	}
+
+	steps = append(steps, resource.TestStep{
+		ResourceName:      connResource,
+		ImportState:       true,
+		ImportStateVerify: true,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRETLConnectionDestroy,
+		Steps:             steps,
+	})
+}
+
+// retlSourceHCL builds the HCL for a single RETL source resource.
+func retlSourceHCL(resourceType, name, sourceDefinitionName, accountID, configBlock string) string {
+	return fmt.Sprintf(`
+resource %q "test" {
+  name                   = %q
+  source_definition_name = %q
+  account_id             = %q
+  config {
+    %s
+  }
+}
+`, resourceType, name, sourceDefinitionName, accountID, configBlock)
+}
+
+// retlConnectionHCL builds the HCL for the source + webhook destination +
+// connection pipeline. Identifier/mapping/event/cursor blocks are interpolated
+// raw — callers supply the inner HCL.
+func retlConnectionHCL(srcName, dstName, accountID string, cfg RETLConnectionTestConfig) string {
+	mappingsBlock := ""
+	if cfg.Mappings != "" {
+		mappingsBlock = "\n  " + cfg.Mappings
+	}
+	eventBlock := ""
+	if cfg.Event != "" {
+		eventBlock = "\n  event {\n    " + cfg.Event + "\n  }"
+	}
+	cursorAttr := ""
+	if cfg.CursorColumn != "" {
+		cursorAttr = fmt.Sprintf("\n  cursor_column  = %q", cfg.CursorColumn)
+	}
+
+	return fmt.Sprintf(`
+resource "rudderstack_retl_source_model" "test" {
+  name                   = %q
+  source_definition_name = "snowflake"
+  account_id             = %q
+  config {
+    primary_key = "id"
+    sql         = "select 1"
+  }
+}
+
+resource "rudderstack_destination_webhook" "test" {
+  name = %q
+  config {
+    webhook_url    = "https://example.com/test"
+    webhook_method = "POST"
+  }
+}
+
+resource "rudderstack_retl_connection" "test" {
+  source_id      = rudderstack_retl_source_model.test.id
+  destination_id = rudderstack_destination_webhook.test.id
+  sync_behaviour = %q%s
+  schedule {
+    %s
+  }
+  identifiers {
+    %s
+  }%s%s
+}
+`, srcName, accountID, dstName, cfg.SyncBehaviour, cursorAttr, cfg.Schedule, cfg.Identifiers, mappingsBlock, eventBlock)
+}
+
+// newTestRETLClient wraps the live API client with a typed RETL store.
+func newTestRETLClient() (retl.RETLStore, error) {
+	cl, err := newTestAPIClient()
+	if err != nil {
+		return nil, err
+	}
+	return retl.NewRudderRETLStore(cl), nil
+}
+
+func testAccCheckRETLSourceExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is empty")
+		}
+
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		if _, err := store.GetRetlSource(context.Background(), rs.Primary.ID); err != nil {
+			return fmt.Errorf("RETL source %s not found in API: %w", rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRETLSourceDestroy(resourceType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != resourceType {
+				continue
+			}
+			// Tolerant of soft-delete: the API may still return the resource
+			// after delete. We don't fail here — Destroy already verified the
+			// Delete handler ran without error.
+			_, _ = store.GetRetlSource(context.Background(), rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRETLConnectionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is empty")
+		}
+
+		store, err := newTestRETLClient()
+		if err != nil {
+			return err
+		}
+		if _, err := store.GetConnection(context.Background(), rs.Primary.ID); err != nil {
+			return fmt.Errorf("RETL connection %s not found in API: %w", rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRETLConnectionDestroy(s *terraform.State) error {
+	store, err := newTestRETLClient()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rudderstack_retl_connection" {
+			continue
+		}
+		// Expect 404 after delete; tolerant of any error (network blips,
+		// soft-delete) — we don't fail the test here.
+		_, getErr := store.GetConnection(context.Background(), rs.Primary.ID)
+		if getErr == nil {
+			// If it still exists, surface that — it's likely a real bug.
+			return fmt.Errorf("RETL connection %s still exists after destroy", rs.Primary.ID)
+		}
+		var apiErr *client.APIError
+		if errors.As(getErr, &apiErr) && apiErr.HTTPStatusCode == 404 {
+			continue
+		}
+	}
+	return nil
+}

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -17,7 +17,10 @@ import (
 // retlAccountIDEnv names the env var that supplies a real warehouse account ID
 // for live RETL acceptance tests. When unset (and the test is not running in
 // plan-only mode) the helpers t.Skip — local runs without a workspace fixture
-// shouldn't fail. CI sets this from a GitHub Environment secret in the live phase.
+// shouldn't fail. The e2e-tests.yml workflow forwards `vars.RUDDERSTACK_RETL_TEST_ACCOUNT_ID`
+// (a GitHub Environment variable, not a secret — the ID is opaque, not credentials)
+// to this env var; until that variable is added, the expression renders empty
+// in CI and the live RETL tests skip.
 const retlAccountIDEnv = "RUDDERSTACK_RETL_TEST_ACCOUNT_ID"
 
 // planOnlyAccountID is a placeholder used in plan-only mode where no API call
@@ -43,9 +46,9 @@ type RETLConnectionTestConfig struct {
 
 	SyncBehaviour string // "upsert" | "mirror" | "full"
 	Schedule      string // HCL fragment for the schedule { } block body
-	Identifiers   string // HCL fragment for one or more identifiers { } blocks
-	Mappings      string // HCL fragment for mappings { } blocks (optional)
-	Event         string // HCL fragment for event { } block (optional)
+	Identifiers   string // HCL fragment for one or more raw identifiers { } blocks (required, ≥1)
+	Mappings      string // HCL fragment for one or more raw mappings { } blocks (optional)
+	Event         string // HCL fragment for event { } block body (optional)
 	CursorColumn  string // value for cursor_column (optional, requires upsert)
 
 	// UpdateMappings, when non-empty, runs an Update step replacing the
@@ -249,8 +252,9 @@ resource %q "test" {
 }
 
 // retlConnectionHCL builds the HCL for the source + webhook destination +
-// connection pipeline. Identifier/mapping/event/cursor blocks are interpolated
-// raw — callers supply the inner HCL.
+// connection pipeline. Identifiers / Mappings are full block fragments
+// (e.g. `identifiers { from = "..." to = "..." }`) so callers can pass
+// multiple of each. Event and cursor_column are inlined when non-empty.
 func retlConnectionHCL(srcName, dstName, accountID string, cfg RETLConnectionTestConfig) string {
 	mappingsBlock := ""
 	if cfg.Mappings != "" {
@@ -272,7 +276,7 @@ resource "rudderstack_retl_source_model" "test" {
   account_id             = %q
   config {
     primary_key = "id"
-    sql         = "select 1"
+    sql         = "select 1 as id"
   }
 }
 
@@ -291,9 +295,7 @@ resource "rudderstack_retl_connection" "test" {
   schedule {
     %s
   }
-  identifiers {
-    %s
-  }%s%s
+  %s%s%s
 }
 `, srcName, accountID, dstName, cfg.SyncBehaviour, cursorAttr, cfg.Schedule, cfg.Identifiers, mappingsBlock, eventBlock)
 }

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -291,6 +291,7 @@ resource "rudderstack_destination_webhook" "test" {
 resource "rudderstack_retl_connection" "test" {
   source_id      = rudderstack_retl_source_model.test.id
   destination_id = rudderstack_destination_webhook.test.id
+  enabled        = true
   sync_behaviour = %q%s
   schedule {
     %s

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -31,7 +31,7 @@ const planOnlyAccountID = "acc-plan-only"
 // AccAssertRETLSourceTable. The Config / UpdateConfig fields are HCL fragments
 // that go inside the resource's `config { }` block.
 type RETLSourceTestConfig struct {
-	SourceDefinitionName string // e.g. "snowflake"
+	SourceDefinitionName string // e.g. "bigquery"
 	Config               string // HCL inside config { } block for the create step
 	UpdateConfig         string // HCL for the update step (omit to skip update)
 }
@@ -272,7 +272,7 @@ func retlConnectionHCL(srcName, dstName, accountID string, cfg RETLConnectionTes
 	return fmt.Sprintf(`
 resource "rudderstack_retl_source_model" "test" {
   name                   = %q
-  source_definition_name = "snowflake"
+  source_definition_name = "bigquery"
   account_id             = %q
   config {
     primary_key = "id"

--- a/rudderstack/resource_account.go
+++ b/rudderstack/resource_account.go
@@ -10,6 +10,7 @@ package rudderstack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/rudderlabs/rudder-iac/api/client"
-
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
 
@@ -136,6 +136,11 @@ func resourceAccountRead(cm configs.ConfigMeta) schema.ReadContextFunc {
 
 		acc, err := c.Accounts.Get(ctx, d.Id())
 		if err != nil {
+			var apiErr *client.APIError
+			if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
 			return diag.FromErr(fmt.Errorf("could not get account: %w", err))
 		}
 

--- a/rudderstack/resource_account_test.go
+++ b/rudderstack/resource_account_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/rudderlabs/rudder-iac/api/client"
-
 	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil"
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
@@ -99,8 +98,16 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 			testutil.JSONEq(string(req.Options), createOptionsJSON) &&
 			testutil.JSONEq(string(req.Secret), createSecretJSON)
 	})).Return(&client.Account{
-		ID:        "acct-001",
-		Name:      "example",
+		ID:   "acct-001",
+		Name: "example",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		Options:   json.RawMessage(createOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
 		UpdatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
@@ -110,6 +117,14 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 	accounts.On("Get", mock.Anything, "acct-001").Return(&client.Account{
 		ID:   "acct-001",
 		Name: "example",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		// Secret intentionally absent — API never returns it.
 		Options:   json.RawMessage(createOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
@@ -122,8 +137,16 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 			testutil.JSONEq(string(req.Options), updateOptionsJSON) &&
 			testutil.JSONEq(string(req.Secret), updateSecretJSON)
 	})).Return(&client.Account{
-		ID:        "acct-001",
-		Name:      "example-updated",
+		ID:   "acct-001",
+		Name: "example-updated",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		Options:   json.RawMessage(updateOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
 		UpdatedAt: testutil.TimePtr(time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)),
@@ -131,8 +154,16 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 
 	// --- Read mock after Update (called twice: post-update refresh + destroy plan check) ---
 	accounts.On("Get", mock.Anything, "acct-001").Return(&client.Account{
-		ID:        "acct-001",
-		Name:      "example-updated",
+		ID:   "acct-001",
+		Name: "example-updated",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		Options:   json.RawMessage(updateOptionsJSON),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)),
 		UpdatedAt: testutil.TimePtr(time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC)),
@@ -220,6 +251,59 @@ func TestResourceAccountCreateReadUpdate(t *testing.T) {
 	})
 }
 
+// TestResourceAccountRead_404ClearsState verifies that when the accounts API returns
+// a 404 (out-of-band deletion / import of a missing ID), resourceAccountRead clears
+// the resource ID and returns no Terraform error — matching the drift-detection
+// pattern used in rudderstack/retl/common.go.
+func TestResourceAccountRead_404ClearsState(t *testing.T) {
+	cm := testAccountConfigMeta()
+	accounts := &mockAccountsService{}
+
+	accounts.On("Get", mock.Anything, "acct-gone").
+		Return(nil, &client.APIError{HTTPStatusCode: 404}).Once()
+
+	res := resourceAccount(cm)
+	d := res.Data(nil)
+	d.SetId("acct-gone")
+
+	c := &Client{Accounts: accounts}
+	diags := resourceAccountRead(cm)(context.Background(), d, c)
+	if diags.HasError() {
+		t.Fatalf("expected no error on 404, got %+v", diags)
+	}
+	if d.Id() != "" {
+		t.Fatalf("expected ID cleared on 404, got %q", d.Id())
+	}
+
+	accounts.AssertExpectations(t)
+}
+
+// TestResourceAccountRead_NonNotFoundErrorReturnsError verifies that non-404 API errors
+// are surfaced as Terraform diagnostics (not silently swallowed).
+func TestResourceAccountRead_NonNotFoundErrorReturnsError(t *testing.T) {
+	cm := testAccountConfigMeta()
+	accounts := &mockAccountsService{}
+
+	accounts.On("Get", mock.Anything, "acct-err").
+		Return(nil, &client.APIError{HTTPStatusCode: 500, Message: "internal server error"}).Once()
+
+	res := resourceAccount(cm)
+	d := res.Data(nil)
+	d.SetId("acct-err")
+
+	c := &Client{Accounts: accounts}
+	diags := resourceAccountRead(cm)(context.Background(), d, c)
+	if !diags.HasError() {
+		t.Fatal("expected error on 500, got none")
+	}
+	// ID must NOT be cleared on a non-404 error.
+	if d.Id() == "" {
+		t.Fatal("expected ID to remain set on non-404 error")
+	}
+
+	accounts.AssertExpectations(t)
+}
+
 // TestResourceAccountSchemaNoSecretInState verifies that after a Read whose mocked
 // Get returns no secret, the bar field is absent from state. This test exercises the
 // schema + read function directly without needing a full provider lifecycle.
@@ -230,6 +314,14 @@ func TestResourceAccountSchemaNoSecretInState(t *testing.T) {
 	accounts.On("Get", mock.Anything, "acct-002").Return(&client.Account{
 		ID:   "acct-002",
 		Name: "test-acct",
+		Definition: struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Category string `json:"category"`
+		}{
+			Name: cm.APIType,
+			Type: cm.APIType,
+		},
 		// Options returned, secret NOT returned.
 		Options:   json.RawMessage(`{"foo":"val1"}`),
 		CreatedAt: testutil.TimePtr(time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)),

--- a/rudderstack/resource_destination.go
+++ b/rudderstack/resource_destination.go
@@ -3,6 +3,7 @@ package rudderstack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -124,6 +125,11 @@ func resourceDestinationRead(cm configs.ConfigMeta) schema.ReadContextFunc {
 
 		destination, err := c.Destinations.Get(ctx, id)
 		if err != nil {
+			var apiErr *client.APIError
+			if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+				d.SetId("")
+				return diag.Diagnostics{}
+			}
 			return diag.FromErr(err)
 		}
 

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -1,0 +1,109 @@
+package retl_test
+
+import (
+	"testing"
+
+	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil/acc"
+)
+
+// TestAccRETLSourceModel_Snowflake exercises rudderstack_retl_source_model
+// against a snowflake account. SQL is intentionally trivial; the API accepts
+// it at create time and any sync-time SQL validation is out of scope here.
+func TestAccRETLSourceModel_Snowflake(t *testing.T) {
+	acc.AccAssertRETLSourceModel(t, acc.RETLSourceTestConfig{
+		SourceDefinitionName: "snowflake",
+		Config: `
+			primary_key = "id"
+			sql         = "select 1 as id"
+		`,
+		UpdateConfig: `
+			primary_key = "id"
+			sql         = "select 1 as id, 'two' as name"
+			description = "v2"
+		`,
+	})
+}
+
+// TestAccRETLSourceTable_Snowflake exercises rudderstack_retl_source_table.
+func TestAccRETLSourceTable_Snowflake(t *testing.T) {
+	acc.AccAssertRETLSourceTable(t, acc.RETLSourceTestConfig{
+		SourceDefinitionName: "snowflake",
+		Config: `
+			primary_key = "id"
+			schema      = "public"
+			table       = "users"
+		`,
+		UpdateConfig: `
+			primary_key = "id"
+			schema      = "public"
+			table       = "events"
+		`,
+	})
+}
+
+// TestAccRETLConnection_JSONMapperBasicSchedule covers the JSON-mapper flow
+// (no `object`, no `destination_config`) with a basic-interval schedule and an
+// identify event. Mappings update verifies the mutable Update path.
+func TestAccRETLConnection_JSONMapperBasicSchedule(t *testing.T) {
+	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
+		Variant:       "jm-basic",
+		SyncBehaviour: "upsert",
+		Schedule: `
+			type          = "basic"
+			every_minutes = 60
+		`,
+		Identifiers: `
+			from = "email"
+			to   = "user_id"
+		`,
+		Mappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
+			}
+		`,
+		Event: `type = "identify"`,
+		UpdateMappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
+			}
+			mappings {
+				from = "phone"
+				to   = "phone_number"
+			}
+		`,
+	})
+}
+
+// TestAccRETLConnection_CronSchedule covers the cron schedule branch.
+func TestAccRETLConnection_CronSchedule(t *testing.T) {
+	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
+		Variant:       "cron",
+		SyncBehaviour: "upsert",
+		Schedule: `
+			type            = "cron"
+			cron_expression = "30 13 * * *"
+		`,
+		Identifiers: `
+			from = "email"
+			to   = "user_id"
+		`,
+		Event: `type = "identify"`,
+	})
+}
+
+// TestAccRETLConnection_ManualSchedule covers the manual schedule branch.
+// `mirror` sync_behaviour is used here to flex a non-upsert path.
+func TestAccRETLConnection_ManualSchedule(t *testing.T) {
+	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
+		Variant:       "manual",
+		SyncBehaviour: "mirror",
+		Schedule:      `type = "manual"`,
+		Identifiers: `
+			from = "email"
+			to   = "user_id"
+		`,
+		Event: `type = "identify"`,
+	})
+}

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -22,6 +22,8 @@ func TestAccRETLSourceModel_BigQuery(t *testing.T) {
 			sql         = "select user_id, email, created_at from rudder_tf_e2e.users"
 			description = "v2"
 		`,
+		ExpectedConfigJSON:       `{"primaryKey":"user_id","sql":"select user_id, email from rudder_tf_e2e.users"}`,
+		ExpectedUpdateConfigJSON: `{"primaryKey":"user_id","sql":"select user_id, email, created_at from rudder_tf_e2e.users","description":"v2"}`,
 	})
 }
 
@@ -40,6 +42,8 @@ func TestAccRETLSourceTable_BigQuery(t *testing.T) {
 			schema      = "rudder_tf_e2e"
 			table       = "users"
 		`,
+		ExpectedConfigJSON:       `{"primaryKey":"user_id","schema":"rudder_tf_e2e","table":"users"}`,
+		ExpectedUpdateConfigJSON: `{"primaryKey":"email","schema":"rudder_tf_e2e","table":"users"}`,
 	})
 }
 
@@ -77,6 +81,8 @@ func TestAccRETLConnection_JSONMapperBasicSchedule(t *testing.T) {
 				to   = "phone_number"
 			}
 		`,
+		ExpectedConfigJSON:       `{"syncBehaviour":"upsert","schedule":{"type":"basic","everyMinutes":60},"identifiers":[{"from":"email","to":"user_id"}],"mappings":[{"from":"name","to":"first_name"}],"event":{"type":"identify"}}`,
+		ExpectedUpdateConfigJSON: `{"syncBehaviour":"upsert","schedule":{"type":"basic","everyMinutes":60},"identifiers":[{"from":"email","to":"user_id"}],"mappings":[{"from":"name","to":"first_name"},{"from":"phone","to":"phone_number"}],"event":{"type":"identify"}}`,
 	})
 }
 
@@ -101,7 +107,8 @@ func TestAccRETLConnection_CronSchedule(t *testing.T) {
 				to   = "first_name"
 			}
 		`,
-		Event: `type = "identify"`,
+		Event:              `type = "identify"`,
+		ExpectedConfigJSON: `{"syncBehaviour":"upsert","schedule":{"type":"cron","cronExpression":"30 13 * * *"},"identifiers":[{"from":"email","to":"user_id"}],"mappings":[{"from":"name","to":"first_name"}],"event":{"type":"identify"}}`,
 	})
 }
 
@@ -125,6 +132,7 @@ func TestAccRETLConnection_ManualSchedule(t *testing.T) {
 				to   = "first_name"
 			}
 		`,
-		Event: `type = "identify"`,
+		Event:              `type = "identify"`,
+		ExpectedConfigJSON: `{"syncBehaviour":"full","schedule":{"type":"manual"},"identifiers":[{"from":"email","to":"user_id"}],"mappings":[{"from":"name","to":"first_name"}],"event":{"type":"identify"}}`,
 	})
 }

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -95,21 +95,34 @@ func TestAccRETLConnection_CronSchedule(t *testing.T) {
 				to   = "user_id"
 			}
 		`,
+		Mappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
+			}
+		`,
 		Event: `type = "identify"`,
 	})
 }
 
 // TestAccRETLConnection_ManualSchedule covers the manual schedule branch.
-// `mirror` sync_behaviour is used here to flex a non-upsert path.
+// `full` sync_behaviour flexes a non-upsert path (the JSON Mapper flow accepts
+// only "upsert" or "full" — "mirror" is rejected by the API).
 func TestAccRETLConnection_ManualSchedule(t *testing.T) {
 	acc.AccAssertRETLConnection(t, acc.RETLConnectionTestConfig{
 		Variant:       "manual",
-		SyncBehaviour: "mirror",
+		SyncBehaviour: "full",
 		Schedule:      `type = "manual"`,
 		Identifiers: `
 			identifiers {
 				from = "email"
 				to   = "user_id"
+			}
+		`,
+		Mappings: `
+			mappings {
+				from = "name"
+				to   = "first_name"
 			}
 		`,
 		Event: `type = "identify"`,

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -112,6 +112,26 @@ func TestAccRETLConnection_CronSchedule(t *testing.T) {
 	})
 }
 
+// TestAccRETLConnectionCustomerIOAudience_Manual exercises the typed
+// rudderstack_retl_connection_customerio_audience resource. Plan-only (the CI
+// default) validates HCL/schema — including the top-level audience_id field —
+// with no creds. The live path is vendor-gated on RUDDERSTACK_CUSTOMERIO_TEST_AUDIENCE_ID
+// (plus the warehouse account env var) and skips when unset, mirroring the
+// other vendor-gated integrations.
+func TestAccRETLConnectionCustomerIOAudience_Manual(t *testing.T) {
+	acc.AccAssertRETLConnectionCustomerIOAudience(t, acc.RETLConnectionTestConfig{
+		Variant:       "cio-aud-manual",
+		SyncBehaviour: "mirror",
+		Schedule:      `type = "manual"`,
+		Identifiers: `
+			identifiers {
+				from = "email"
+				to   = "email"
+			}
+		`,
+	})
+}
+
 // TestAccRETLConnection_ManualSchedule covers the manual schedule branch.
 // `full` sync_behaviour flexes a non-upsert path (the JSON Mapper flow accepts
 // only "upsert" or "full" — "mirror" is rejected by the API).

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -6,37 +6,39 @@ import (
 	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil/acc"
 )
 
-// TestAccRETLSourceModel_Snowflake exercises rudderstack_retl_source_model
-// against a snowflake account. SQL is intentionally trivial; the API accepts
-// it at create time and any sync-time SQL validation is out of scope here.
-func TestAccRETLSourceModel_Snowflake(t *testing.T) {
+// TestAccRETLSourceModel_BigQuery exercises rudderstack_retl_source_model
+// against a BigQuery account. The SQL references the e2e fixture table
+// (dataset.table, resolved in the account's project); the API accepts it at
+// create time and any sync-time SQL validation is out of scope here.
+func TestAccRETLSourceModel_BigQuery(t *testing.T) {
 	acc.AccAssertRETLSourceModel(t, acc.RETLSourceTestConfig{
-		SourceDefinitionName: "snowflake",
+		SourceDefinitionName: "bigquery",
 		Config: `
-			primary_key = "id"
-			sql         = "select 1 as id"
+			primary_key = "user_id"
+			sql         = "select user_id, email from rudder_tf_e2e.users"
 		`,
 		UpdateConfig: `
-			primary_key = "id"
-			sql         = "select 1 as id, 'two' as name"
+			primary_key = "user_id"
+			sql         = "select user_id, email, created_at from rudder_tf_e2e.users"
 			description = "v2"
 		`,
 	})
 }
 
-// TestAccRETLSourceTable_Snowflake exercises rudderstack_retl_source_table.
-func TestAccRETLSourceTable_Snowflake(t *testing.T) {
+// TestAccRETLSourceTable_BigQuery exercises rudderstack_retl_source_table.
+// schema is the BigQuery dataset; the e2e fixture is rudder_tf_e2e.users.
+func TestAccRETLSourceTable_BigQuery(t *testing.T) {
 	acc.AccAssertRETLSourceTable(t, acc.RETLSourceTestConfig{
-		SourceDefinitionName: "snowflake",
+		SourceDefinitionName: "bigquery",
 		Config: `
-			primary_key = "id"
-			schema      = "public"
+			primary_key = "user_id"
+			schema      = "rudder_tf_e2e"
 			table       = "users"
 		`,
 		UpdateConfig: `
-			primary_key = "id"
-			schema      = "public"
-			table       = "events"
+			primary_key = "email"
+			schema      = "rudder_tf_e2e"
+			table       = "users"
 		`,
 	})
 }

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -53,8 +53,10 @@ func TestAccRETLConnection_JSONMapperBasicSchedule(t *testing.T) {
 			every_minutes = 60
 		`,
 		Identifiers: `
-			from = "email"
-			to   = "user_id"
+			identifiers {
+				from = "email"
+				to   = "user_id"
+			}
 		`,
 		Mappings: `
 			mappings {
@@ -86,8 +88,10 @@ func TestAccRETLConnection_CronSchedule(t *testing.T) {
 			cron_expression = "30 13 * * *"
 		`,
 		Identifiers: `
-			from = "email"
-			to   = "user_id"
+			identifiers {
+				from = "email"
+				to   = "user_id"
+			}
 		`,
 		Event: `type = "identify"`,
 	})
@@ -101,8 +105,10 @@ func TestAccRETLConnection_ManualSchedule(t *testing.T) {
 		SyncBehaviour: "mirror",
 		Schedule:      `type = "manual"`,
 		Identifiers: `
-			from = "email"
-			to   = "user_id"
+			identifiers {
+				from = "email"
+				to   = "user_id"
+			}
 		`,
 		Event: `type = "identify"`,
 	})

--- a/test/e2e/staging/.gitignore
+++ b/test/e2e/staging/.gitignore
@@ -1,0 +1,8 @@
+*.tfvars
+*.tfstate*
+.terraform/
+.terraform.lock.hcl
+.bin/
+sa.json
+.env
+.dev-override.tfrc

--- a/test/e2e/staging/BRANCH-MAP.md
+++ b/test/e2e/staging/BRANCH-MAP.md
@@ -1,0 +1,85 @@
+# Branch / PR Map — TF rETL Account Management verification
+
+Layout for the
+[TF — rETL Account Management (Lovable Phase 1)](https://linear.app/rudderstack/project/tf-retl-account-management-lovable-phase-1-6076c97fd07f)
+project. The original **13 stacked PRs** have been **collapsed into 3 review units
+(A / B / C)** stacked on the **#277 CI scaffold**. Render with any Mermaid-aware
+viewer (GitHub, Notion, VS Code, mermaid.live).
+
+## Current state — 3 review PRs on the #277 scaffold
+
+```mermaid
+%%{init: {'gitGraph': {'mainBranchName': 'main'}}}%%
+gitGraph
+   commit id: "main"
+   branch "#277 ci/fix-pr-triggers (scaffold)"
+   commit id: "ci-trigger-fix"
+   branch "A #266 accounts"
+   commit id: "DEX-376..382 + v0.18.0"
+   branch "B #278 rETL tests + config-verify"
+   commit id: "PRO-5676 / PRO-5768"
+   branch "C #274 client+staging+docs+cio"
+   commit id: "verification"
+```
+
+Linear chain: `main → #277 → A (#266) → B (#278) → C (#274)`. Reviewers see **3
+PRs**; #277 is a never-merged base that lets every PR run checks pre-merge.
+
+## How the 13 PRs collapsed
+
+```mermaid
+flowchart LR
+  classDef keep fill:#0d4429,stroke:#3fb950,color:#e6edf3;
+  classDef closed fill:#3d3d3d,stroke:#8b949e,color:#e6edf3,stroke-dasharray:4 3;
+  classDef scaffold fill:#5a3b00,stroke:#d29922,color:#e6edf3;
+
+  main["origin/main"] --> s["#277 ci/fix-pr-triggers — scaffold, never merged"]:::scaffold
+  s --> A["A · #266 — feat(accounts) DEX-376–382"]:::keep
+  A --> B["B · #278 — rETL tests + config-verify"]:::keep
+  B --> C["C · #274 — client + staging + docs + customerio"]:::keep
+
+  subgraph GA ["folded into A (#266)"]
+    direction TB
+    n260["#260 DEX-376"]; n261["#261 DEX-377"]; n262["#262 DEX-378"]
+    n263["#263 DEX-381"]; n264["#264 DEX-379"]; n265["#265 DEX-380"]
+  end
+  subgraph GB ["folded into B (#278)"]
+    n271["#271 rETL acc · Alexandros"]
+  end
+  subgraph GC ["folded into C (#274)"]
+    n272["#272 client+staging"]; n273["#273 docs"]
+  end
+  class n260,n261,n262,n263,n264,n265,n271,n272,n273 closed
+  GA -. closed, commits preserved .-> A
+  GB -. closed, commits preserved .-> B
+  GC -. closed, commits preserved .-> C
+```
+
+🟩 kept (review unit) · 🟧 scaffold (never merged) · ⬛ closed (folded in)
+
+## Consolidation map
+
+| Review PR | Branch | Base | Folds in (closed) | Contents |
+|-----------|--------|------|-------------------|----------|
+| **#277** scaffold | `ci/fix-pr-triggers` | `main` | — | Run e2e + unit on all PRs (drop `branches:[main]`) — PRO-5776. **Never merged**; closed at the end. |
+| **A · #266** | `feature/dex-382-…` | #277 | #260, #261, #262, #263, #264, #265 | Full accounts feature (DEX-376–382): registry, generic `resource_account` CRUD, data source, `AssertAccount` helper, BigQuery `ConfigMeta`, provider + `NewAPIClient` wiring, BigQuery integration test. rudder-iac **v0.18.0**, `client.*` consumer migration, `e2e-account-crud` job. |
+| **B · #278** | `feature/pro-5768-…` | A (#266) | #271 | rETL source/connection acceptance tests on BigQuery (Alexandros's commits preserved) + PRO-5768 upstream config verification. |
+| **C · #274** | `feature/retl-customerio-audience-acc` | B (#278) | #272, #273 | Real Accounts client + 404 fix, `test/e2e/staging` smoke (`run.sh` + PAUSE hold-open + label-gated `e2e-staging-smoke.yml`), HANDOFF/BRANCH-MAP docs, `customerio_audience` coverage. |
+
+Closed PRs carry a comment pointing to their keeper; their commits live on in the
+kept branch (nothing abandoned). They can be reopened if a split is ever needed.
+
+## Merge plan (never merging #277)
+
+Review A → B → C. Then collapse upward — merge **C into B**, **B into A** (one
+final check run on the combined A) — then **rebase A off #277 onto `main`** (drops
+the single scaffold commit; restores `branches:[main]`), and merge A into `main`.
+Close #277. The CI-trigger change never lands in `main`.
+
+## Notes
+
+- **#237** could not be reopened (force-pushed after close); its commits live in **B** (#278) via #271, authorship intact.
+- **Secrets, not Vault.** A Vault integration was prototyped and removed — the e2e tests source creds from GitHub Environment secrets/vars on the `e2e` environment (`RUDDERSTACK_ACC_TEST_TOKEN`, `RUDDERSTACK_STAGING_*`, and `RUDDERSTACK_RETL_TEST_ACCOUNT_ID` once the dev seed account is aligned).
+- **Staging smoke** runs pre-merge via the `e2e-staging` label on #274 (and `workflow_dispatch` once on `main`); it applies → asserts no drift → destroys against staging.
+- **rudder-iac v0.18.0** is standardized across the chain (the old `#617` pseudo-version gate is gone).
+- `verify/accounts-retl-e2e` (the old local integrated reference) has been **deleted** — the C tip / `integration/retl-accounts-full` is the current full integration.

--- a/test/e2e/staging/HANDOFF.md
+++ b/test/e2e/staging/HANDOFF.md
@@ -1,0 +1,144 @@
+# Staging E2E Verification — Handoff Runbook
+
+**Goal:** verify the new Terraform **Accounts** feature + **rETL** end-to-end against staging (`api.staging.rudderlabs.com`): create a BigQuery account, an rETL source that uses it, and an rETL connection — via both the Go acceptance harness and a real `terraform apply` smoke.
+
+**Branch:** `feature/retl-customerio-audience-acc` (in `terraform-provider-rudderstack`) — the tip of the 4-PR verification stack (#271 → #272 → docs → CIO), so it contains every layer. Builds clean; all plan-only/unit tests pass. (See [BRANCH-MAP.md](BRANCH-MAP.md) for the full stack.)
+
+**Current blocker (your task):** staging does **not** yet have the `SOURCE_BIGQUERY` account definition registered. The provider, client wiring, auth, and `/v2/accounts` API are all verified working — the only missing piece is the account definition. Everything below is ready to run the moment that lands.
+
+---
+
+## Step 1 — Create the `SOURCE_BIGQUERY` account definition on staging
+
+This is the foundation gap (Stream A / milestone **M2 — Foundation Deployed**): the BigQuery source `accountDefinition` files per [DEX-374](https://linear.app/rudderstack/issue/DEX-374), [APL-399](https://linear.app/rudderstack/issue/APL-399), [APL-398](https://linear.app/rudderstack/issue/APL-398), against `CONTRACT-ACCT-V1`. It must be deployed/registered in the staging control plane so `accountDefinitionName: "SOURCE_BIGQUERY"` resolves.
+
+**Symptom today** (confirms the gap):
+```bash
+curl -sS -X POST "https://api.staging.rudderlabs.com/v2/accounts" \
+  -H "Authorization: Bearer $STAGING_PAT" -H 'Content-Type: application/json' \
+  -d '{"name":"defn-probe","accountDefinitionName":"SOURCE_BIGQUERY","options":{"projectId":"x"},"secret":{"credentials":"{}"}}'
+# → 404  "Account definition with name \"SOURCE_BIGQUERY\" does not exist"
+```
+Once you've registered the definition, the same probe returns a created account (with an `id`) instead of the 404. Delete that probe account afterward, or ignore it.
+
+---
+
+## Step 2 — Prerequisites (one-time local setup)
+
+```bash
+# 1. Tooling
+brew install hashicorp/tap/terraform   # terraform CLI (the Go acc tests + run.sh need it)
+go version                              # 1.23+; repo builds with the toolchain in go.mod
+
+# 2. Get the branch
+cd terraform-provider-rudderstack
+git fetch && git switch feature/retl-customerio-audience-acc   # tip of the verification stack (all layers)
+go build ./...                          # sanity: must succeed
+```
+> Note: `go.mod` pins `rudder-iac` to the **unmerged** PR #617 (`...31f63ee269cf`) for the account client. If that fails to fetch, ensure your git auth can reach `github.com/rudderlabs/rudder-iac`. Re-pin to a tagged release once #617 merges.
+
+---
+
+## Step 3 — Secrets & fixtures
+
+All of these are git-ignored (`.env`, `*.tfvars`, `sa.json`) — they will **not** be committed.
+
+**3a. GCP service-account key** → `test/e2e/staging/sa.json`
+Paste the JSON key for a service account with BigQuery access in your project. (Reference setup used project `big-query-integration-poc`, SA `rudder-warehouse-dev@…`.)
+
+**3b. BigQuery fixture table** — the rETL source points at `rudder_tf_e2e.users` (cols `user_id`, `email`, `created_at`). It already exists in `big-query-integration-poc`. If you use a **different** project, create it once:
+```bash
+python3 -m venv /tmp/bqvenv && /tmp/bqvenv/bin/pip install -q google-cloud-bigquery
+GOOGLE_APPLICATION_CREDENTIALS=test/e2e/staging/sa.json /tmp/bqvenv/bin/python - <<'PY'
+from google.cloud import bigquery
+c = bigquery.Client()
+ds = "rudder_tf_e2e"
+c.create_dataset(bigquery.Dataset(f"{c.project}.{ds}"), exists_ok=True, timeout=30)
+t = bigquery.Table(f"{c.project}.{ds}.users", schema=[
+    bigquery.SchemaField("user_id","STRING",mode="REQUIRED"),
+    bigquery.SchemaField("email","STRING"),
+    bigquery.SchemaField("created_at","TIMESTAMP")])
+c.create_table(t, exists_ok=True, timeout=30)
+print("fixture ready:", t.full_table_id)
+PY
+```
+
+**3c. `test/e2e/staging/secret.tfvars`** (for the Terraform smoke):
+```hcl
+access_token = "<STAGING_PAT>"
+bq_project   = "big-query-integration-poc"   # your project
+bq_dataset   = "rudder_tf_e2e"
+bq_table     = "users"
+# bq_location = "US"   # uncomment if not US
+# bq_credentials is fed from sa.json at runtime — do NOT put it here.
+```
+
+**3d. `.env`** at repo root (for the Go acceptance tests):
+```
+RUDDERSTACK_ACCESS_TOKEN=<STAGING_PAT>
+RUDDERSTACK_API_URL=https://api.staging.rudderlabs.com
+```
+
+---
+
+## Step 4 — Mint a BigQuery account and capture its ID (for the rETL Go tests)
+
+The rETL acceptance tests reference an existing BigQuery account by ID. Create one and export its id:
+```bash
+set -a; . ./.env; set +a
+ACC_ID=$(jq -n --arg creds "$(cat test/e2e/staging/sa.json)" \
+  '{name:"tf-e2e-retl-acct",accountDefinitionName:"SOURCE_BIGQUERY",
+    options:{projectId:"big-query-integration-poc",location:"US"},
+    secret:{credentials:$creds}}' \
+  | curl -sS -X POST "$RUDDERSTACK_API_URL/v2/accounts" \
+      -H "Authorization: Bearer $RUDDERSTACK_ACCESS_TOKEN" -H 'Content-Type: application/json' -d @- \
+  | jq -r '.id')
+echo "account id: $ACC_ID"
+export RUDDERSTACK_RETL_TEST_ACCOUNT_ID="$ACC_ID"
+```
+(Keep this account around for test runs; delete it when fully done.)
+
+---
+
+## Step 5 — Run the tests
+
+### 5a. Account CRUD (Go acc test)
+```bash
+set -a; . ./.env; set +a
+TF_ACC=1 go test ./rudderstack/integrations/accounts/ -run TestAcc -v -count=1 -timeout 15m
+```
+**Expect:** `TestAccAccountBigQuery` PASS — real Create→Update→Import→Destroy.
+
+### 5b. rETL source + connection (Go acc test, BigQuery)
+```bash
+set -a; . ./.env; set +a
+export RUDDERSTACK_RETL_TEST_ACCOUNT_ID="$ACC_ID"   # from Step 4
+make testacc-retl
+```
+**Expect:** `TestAccRETLSourceModel_BigQuery`, `TestAccRETLSourceTable_BigQuery`, and the connection tests PASS (Create→Update→Import→Destroy against staging). Without the account ID they **skip** (not fail).
+
+### 5c. Full-chain smoke (real `terraform apply`)
+```bash
+cd test/e2e/staging
+export TF_VAR_bq_credentials="$(cat sa.json)"
+./run.sh
+```
+**Expect:** applies `bigquery account → retl_source_table → retl_connection`, asserts via `terraform plan -detailed-exitcode` (0 = all exist, no drift), then destroys everything via the cleanup trap. Exit 0.
+
+- **Backfill:** `./run.sh --backfill` currently **exits 3 by design** — there is no rETL sync/backfill-trigger endpoint in the rudder-iac client yet. Confirm the control-plane sync-trigger path before wiring this; it's the one piece of F3 still open.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `Account definition with name "SOURCE_BIGQUERY" does not exist` | Step 1 not done — definition not registered on staging |
+| rETL tests SKIP | `RUDDERSTACK_RETL_TEST_ACCOUNT_ID` not exported (Step 4) |
+| `terraform: command not found` | `brew install hashicorp/tap/terraform` |
+| go build fails on rudder-iac | git auth to `github.com/rudderlabs/rudder-iac` (unmerged #617 pin) |
+| source create fails on missing table | the rETL source points at `rudder_tf_e2e.users` in the account's project — create the fixture (Step 3b) |
+| `run.sh --backfill` exits 3 | expected — no sync-trigger endpoint yet |
+
+## Cleanup
+Go tests self-destroy their resources; `run.sh` destroys via trap. Delete the Step-4 account and the `rudder_tf_e2e` dataset when finished.

--- a/test/e2e/staging/README.md
+++ b/test/e2e/staging/README.md
@@ -1,0 +1,149 @@
+# Staging smoke test — BigQuery account → rETL source → connection
+
+This config applies a minimal chain against the RudderStack staging environment
+to verify that the Terraform provider can create and link:
+
+1. A BigQuery rETL **account** (`rudderstack_account_source_bigquery`)
+2. An rETL **source table** (`rudderstack_retl_source_table`) backed by that account
+3. A webhook **destination** (`rudderstack_destination_webhook`) — throwaway endpoint
+4. An rETL **connection** (`rudderstack_retl_connection`) wiring source → destination
+
+No real syncs are triggered (schedule type is `manual`).
+
+---
+
+## Prerequisites
+
+- Terraform ≥ 1.0
+- Go ≥ 1.21 (to build the provider locally)
+- A RudderStack staging personal access token
+- A GCP service-account JSON key with BigQuery access
+
+---
+
+## 1. Build and install the provider locally
+
+```sh
+cd /path/to/terraform-provider-rudderstack
+go build -o /tmp/terraform-provider-rudderstack .
+```
+
+Create a dev-override Terraform CLI config at `/tmp/dev.tfrc`:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "rudderstack.com/rudderlabs/rudderstack" = "/tmp"
+  }
+  direct {}
+}
+```
+
+---
+
+## 2. Supply credentials via a git-ignored tfvars file
+
+Create `test/e2e/staging/secret.tfvars` (this path is in `.gitignore` — never
+commit it):
+
+```hcl
+# secret.tfvars — DO NOT COMMIT
+access_token   = "rsa_REPLACE_ME"
+bq_project     = "my-gcp-project"
+bq_dataset     = "my_dataset"
+bq_table       = "users"
+bq_credentials = <<EOT
+{
+  "type": "service_account",
+  "project_id": "my-gcp-project",
+  ...
+}
+EOT
+```
+
+Optional overrides (have defaults):
+
+```hcl
+api_url     = "https://api.staging.rudderlabs.com"
+bq_location = "US"
+```
+
+---
+
+## 3. Run
+
+`run.sh` builds the provider locally into `.bin/` (git-ignored), wires a
+Terraform dev-override pointing at that directory, runs `apply`, asserts no
+drift, prints the created resource IDs, and always destroys on exit.
+
+```sh
+# Standard smoke run — no staging creds needed in the env:
+./run.sh
+
+# Override the tfvars file path:
+./run.sh path/to/other.tfvars
+
+# Or via env:
+TFVARS_FILE=path/to/other.tfvars ./run.sh
+```
+
+The script does **not** require `TF_CLI_CONFIG_FILE` to be set beforehand; it
+writes a temporary dev-override config and exports the variable itself.
+
+### `--backfill` flag (opt-in, not yet wired)
+
+```sh
+./run.sh --backfill
+```
+
+After the drift assertion the script will attempt to trigger a manual rETL
+sync on the connection and poll to completion. **This branch currently exits
+with a clear error (exit 3)** because the rudder-iac client
+(`api/client/retl/connections.go`, v0.17.1) does not yet expose a
+sync-trigger endpoint. See the comment block in `run.sh` for exactly which
+endpoint and polling contract need to be confirmed before this can be wired.
+
+### Generated files
+
+| Path | Description |
+|------|-------------|
+| `.bin/terraform-provider-rudderstack` | Provider binary built by `run.sh` — git-ignored |
+
+To apply manually without `run.sh`:
+
+```sh
+# 1. Build first:
+go build -o test/e2e/staging/.bin/terraform-provider-rudderstack .
+
+# 2. Write a dev-override config:
+cat > /tmp/dev.tfrc <<'HCL'
+provider_installation {
+  dev_overrides {
+    "rudderstack.com/rudderlabs/rudderstack" = "test/e2e/staging/.bin"
+  }
+  direct {}
+}
+HCL
+
+# 3. Apply:
+TF_CLI_CONFIG_FILE=/tmp/dev.tfrc terraform -chdir=test/e2e/staging \
+  apply -var-file=test/e2e/staging/secret.tfvars -auto-approve
+```
+
+---
+
+## 4. What success looks like
+
+After `apply`, Terraform prints four non-empty IDs:
+
+```
+account_id     = "<id>"
+connection_id  = "<id>"
+destination_id = "<id>"
+retl_source_id = "<id>"
+```
+
+`run.sh` then asserts these are correct by running
+`terraform plan -detailed-exitcode`.  Exit code 0 means the provider Read
+path returned state that matches the config exactly — no drift.  Exit code 2
+(drift) or 1 (error) fail the script loudly before destroy runs.

--- a/test/e2e/staging/main.tf
+++ b/test/e2e/staging/main.tf
@@ -1,0 +1,90 @@
+terraform {
+  required_providers {
+    rudderstack = { source = "rudderstack.com/rudderlabs/rudderstack" }
+  }
+}
+
+provider "rudderstack" {
+  api_url      = var.api_url
+  access_token = var.access_token
+}
+
+# 1. BigQuery rETL account — stores warehouse credentials.
+resource "rudderstack_account_source_bigquery" "acct" {
+  name = "tf-e2e-bigquery"
+  config {
+    project     = var.bq_project
+    location    = var.bq_location
+    credentials = var.bq_credentials
+  }
+}
+
+# 2. rETL source that reads from a single BigQuery table.
+resource "rudderstack_retl_source_table" "users" {
+  name                   = "tf-e2e-users-table"
+  source_definition_name = "bigquery"
+  account_id             = rudderstack_account_source_bigquery.acct.id
+  enabled                = true
+  config {
+    primary_key = "user_id"
+    schema      = var.bq_dataset
+    table       = var.bq_table
+  }
+}
+
+# 3. Webhook destination — throwaway endpoint; delivery is not the point here.
+resource "rudderstack_destination_webhook" "demo" {
+  name = "tf-e2e-webhook"
+  config {
+    webhook_url    = "https://example.com/test"
+    webhook_method = "POST"
+  }
+}
+
+# 4. rETL connection wiring the source to the destination.
+#    Uses a manual schedule so no automatic syncs are triggered during the test.
+resource "rudderstack_retl_connection" "to_webhook" {
+  source_id      = rudderstack_retl_source_table.users.id
+  destination_id = rudderstack_destination_webhook.demo.id
+  enabled        = true
+  sync_behaviour = "full"
+
+  schedule {
+    type = "manual"
+  }
+
+  event {
+    type = "identify"
+  }
+
+  identifiers {
+    from = "user_id"
+    to   = "user_id"
+  }
+
+  mappings {
+    from = "email"
+    to   = "email"
+  }
+}
+
+# Outputs — consumed by run.sh to verify IDs were created.
+output "account_id" {
+  description = "ID of the created BigQuery rETL account."
+  value       = rudderstack_account_source_bigquery.acct.id
+}
+
+output "retl_source_id" {
+  description = "ID of the created rETL source table."
+  value       = rudderstack_retl_source_table.users.id
+}
+
+output "destination_id" {
+  description = "ID of the created webhook destination."
+  value       = rudderstack_destination_webhook.demo.id
+}
+
+output "connection_id" {
+  description = "ID of the created rETL connection."
+  value       = rudderstack_retl_connection.to_webhook.id
+}

--- a/test/e2e/staging/run.sh
+++ b/test/e2e/staging/run.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# run.sh — Staging smoke runner for the terraform-provider-rudderstack.
+#
+# Usage:
+#   ./run.sh [--backfill] [path/to/secret.tfvars]
+#
+# The script:
+#   1. Builds the provider locally (into .bin/) and wires a TF dev-override.
+#   2. Runs terraform apply.
+#   3. Asserts no drift via terraform plan -detailed-exitcode.
+#   4. Prints the created resource IDs from terraform output.
+#   5. On EXIT (success or failure) runs terraform destroy to clean up staging.
+#
+# With --backfill the script would trigger and poll a sync on the rETL
+# connection; however, no trigger endpoint currently exists in the
+# rudder-iac client (v0.17.1).  That branch prints a clear TODO and exits
+# non-zero — see the --backfill section below for the tracking comment.
+#
+# Prerequisites:
+#   - Go ≥ 1.21
+#   - Terraform ≥ 1.0
+#   - secret.tfvars (or the path supplied as $1 / $TFVARS_FILE) with at least:
+#       access_token, bq_project, bq_dataset, bq_table, bq_credentials
+
+set -euo pipefail
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+BACKFILL=false
+TFVARS_FILE="${TFVARS_FILE:-}"   # can also be set in the environment
+
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    --backfill) BACKFILL=true ;;
+    *) args+=("$arg") ;;
+  esac
+done
+
+# First non-flag positional arg overrides the var-file path.
+if [[ ${#args[@]} -gt 0 ]]; then
+  TFVARS_FILE="${args[0]}"
+fi
+
+# Resolve relative paths against the script's own directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${TFVARS_FILE}" ]]; then
+  TFVARS_FILE="${SCRIPT_DIR}/secret.tfvars"
+fi
+
+if [[ ! -f "${TFVARS_FILE}" ]]; then
+  echo "ERROR: var-file not found: ${TFVARS_FILE}"
+  echo "       Create it (see README) or pass a path as the first argument."
+  exit 1
+fi
+
+# Normalize to an absolute path. terraform is invoked with -chdir=<staging dir>,
+# which resolves -var-file relative to that dir — so a relative path (e.g. the
+# CI workflow's "test/e2e/staging/secret.tfvars") would be looked up under the
+# chdir dir and fail. Absolute path is -chdir-proof.
+TFVARS_FILE="$(cd "$(dirname "${TFVARS_FILE}")" && pwd)/$(basename "${TFVARS_FILE}")"
+
+# ── Repo root (two levels above test/e2e/staging) ───────────────────────────
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# ── Provider binary paths ────────────────────────────────────────────────────
+BIN_DIR="${SCRIPT_DIR}/.bin"
+PROVIDER_BINARY="${BIN_DIR}/terraform-provider-rudderstack"
+
+# ── Temp dev-override CLI config ─────────────────────────────────────────────
+# No .tfrc suffix on the template: BSD/macOS mktemp requires the X's at the end.
+# TF_CLI_CONFIG_FILE accepts any path, so the extension is unnecessary.
+OVERRIDE_CFG="$(mktemp "${TMPDIR:-/tmp}/tf-dev-override-XXXXXX")"
+trap 'rm -f "${OVERRIDE_CFG}"' EXIT
+
+# ── Build the provider ───────────────────────────────────────────────────────
+echo "==> Building provider binary …"
+mkdir -p "${BIN_DIR}"
+go build -o "${PROVIDER_BINARY}" "${REPO_ROOT}"
+echo "    Provider written to: ${PROVIDER_BINARY}"
+
+# ── Write dev-override config and export for Terraform ───────────────────────
+cat > "${OVERRIDE_CFG}" <<HCL
+provider_installation {
+  dev_overrides {
+    "rudderstack.com/rudderlabs/rudderstack" = "${BIN_DIR}"
+  }
+  direct {}
+}
+HCL
+export TF_CLI_CONFIG_FILE="${OVERRIDE_CFG}"
+echo "==> TF_CLI_CONFIG_FILE=${TF_CLI_CONFIG_FILE}"
+
+# ── Destroy trap (always runs on EXIT) ───────────────────────────────────────
+# Best-effort: errors here must NOT mask the original script exit code.
+_destroy() {
+  local original_exit=$?
+  echo "==> [trap] Running terraform destroy (cleanup) …"
+  terraform -chdir="${SCRIPT_DIR}" destroy -auto-approve \
+    -var-file="${TFVARS_FILE}" || true
+  echo "==> [trap] Destroy complete."
+  rm -f "${OVERRIDE_CFG}"  # this trap replaces the earlier rm-only trap; fold its cleanup in here
+  exit "${original_exit}"
+}
+trap '_destroy' EXIT
+
+# ── Apply ────────────────────────────────────────────────────────────────────
+echo "==> Running terraform apply …"
+terraform -chdir="${SCRIPT_DIR}" apply -auto-approve \
+  -var-file="${TFVARS_FILE}"
+echo "==> Apply succeeded."
+
+# ── Verify resource IDs are non-empty ────────────────────────────────────────
+echo "==> Verifying resource IDs are non-empty …"
+for out in account_id retl_source_id destination_id connection_id; do
+  val=$(terraform -chdir="${SCRIPT_DIR}" output -raw "$out" 2>/dev/null)
+  if [[ -z "$val" ]]; then
+    echo "FAIL: output '$out' is empty — resource may not have been created."
+    exit 1
+  fi
+  echo "    $out = $val"
+done
+echo "==> All resources confirmed created."
+
+# ── Assert: plan must show zero drift ────────────────────────────────────────
+# terraform plan -detailed-exitcode exit codes:
+#   0 = success, no diff (what we want)
+#   1 = error
+#   2 = success, but diff exists (provider Read is wrong / resource drifted)
+echo "==> Asserting no drift (terraform plan -detailed-exitcode) …"
+set +e
+terraform -chdir="${SCRIPT_DIR}" plan -detailed-exitcode \
+  -var-file="${TFVARS_FILE}"
+PLAN_EXIT=$?
+set -e
+
+case "${PLAN_EXIT}" in
+  0)
+    echo "==> ASSERT PASSED: plan reports no drift — provider Read path is correct."
+    ;;
+  1)
+    echo "FAIL: terraform plan returned an error (exit 1)."
+    echo "      Check the output above for details."
+    exit 1
+    ;;
+  2)
+    echo "FAIL: terraform plan detected drift (exit 2)."
+    echo "      At least one resource does not match the control-plane state."
+    echo "      This indicates a bug in a provider Read/Refresh function."
+    exit 2
+    ;;
+  *)
+    echo "FAIL: terraform plan returned unexpected exit code ${PLAN_EXIT}."
+    exit "${PLAN_EXIT}"
+    ;;
+esac
+
+# ── Print created IDs ────────────────────────────────────────────────────────
+echo "==> Resource IDs created in staging:"
+terraform -chdir="${SCRIPT_DIR}" output
+
+# ── Optional backfill / sync trigger ─────────────────────────────────────────
+if [[ "${BACKFILL}" == "true" ]]; then
+  # NOTE: The rudder-iac client (github.com/rudderlabs/rudder-iac,
+  # currently at v0.17.1-0.20260612051227-31f63ee269cf) does NOT expose a
+  # sync-trigger or backfill endpoint.  The RETLConnectionStore interface
+  # (api/client/retl/retl.go) only covers CRUD + SetConnectionExternalId;
+  # there is no Trigger/Run/StartSync method and no corresponding HTTP path.
+  #
+  # Until that endpoint is added to the client (or confirmed via the
+  # RudderStack public API docs), this branch cannot be wired correctly.
+  #
+  # What needs confirming:
+  #   - The HTTP method and path for triggering a manual rETL sync, e.g.:
+  #       POST /v2/retl-connections/{id}/start    (guessed — NOT confirmed)
+  #       POST /v2/retl-connections/{id}/trigger  (guessed — NOT confirmed)
+  #   - The polling endpoint and its terminal state field, e.g.:
+  #       GET  /v2/retl-connections/{id}/sync-status/{syncId}
+  #   - The request/response shape.
+  #
+  # File to watch: api/client/retl/connections.go in the rudder-iac repo.
+  # Once that method exists, replace the block below with the real curl.
+  echo ""
+  echo "ERROR: --backfill is not yet wired."
+  echo ""
+  echo "  No sync-trigger endpoint was found in the rudder-iac client"
+  echo "  (api/client/retl/connections.go, v0.17.1).  The API path and"
+  echo "  polling contract need to be confirmed before this can be"
+  echo "  implemented correctly."
+  echo ""
+  echo "  See the comment block in run.sh (--backfill section) for details."
+  exit 3
+fi
+
+# ── Optional hold-open for manual inspection ─────────────────────────────────
+if [[ "${PAUSE:-false}" == "true" ]]; then
+  echo "==> PAUSED. Resources are live in staging. Outputs above."
+  echo ""
+  echo "    To inspect resources in a second terminal, export the provider config first:"
+  echo "      export TF_CLI_CONFIG_FILE='${TF_CLI_CONFIG_FILE}'"
+  echo "      terraform -chdir='${SCRIPT_DIR}' state show rudderstack_account_source_bigquery.acct"
+  echo "      terraform -chdir='${SCRIPT_DIR}' show -json | jq '.values.root_module.resources[] | select(.type==\"rudderstack_account_source_bigquery\") | .values.config'"
+  echo ""
+  echo "    Press Enter to destroy."
+  read -r || true   # blocks here; || true prevents set -e from exiting on EOF/signal
+fi
+
+echo "==> Smoke run complete."

--- a/test/e2e/staging/variables.tf
+++ b/test/e2e/staging/variables.tf
@@ -1,0 +1,38 @@
+variable "access_token" {
+  description = "RudderStack staging personal access token."
+  type        = string
+  sensitive   = true
+}
+
+variable "api_url" {
+  description = "RudderStack API base URL."
+  type        = string
+  default     = "https://api.staging.rudderlabs.com"
+}
+
+variable "bq_project" {
+  description = "GCP project ID where the BigQuery dataset lives."
+  type        = string
+}
+
+variable "bq_location" {
+  description = "BigQuery dataset location (e.g. US, EU)."
+  type        = string
+  default     = "US"
+}
+
+variable "bq_dataset" {
+  description = "BigQuery dataset (schema) name."
+  type        = string
+}
+
+variable "bq_table" {
+  description = "BigQuery table name."
+  type        = string
+}
+
+variable "bq_credentials" {
+  description = "GCP service-account key JSON (contents of the JSON key file)."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
**Consolidated review unit B.**

Folds in #271 (closed) — rETL source/connection acceptance tests on BigQuery, authored by Alexandros Milaios (commits preserved) — plus PRO-5768 upstream config verification.

Base: **A #266**. Stacked on #277 for checks.