### PR TITLE
fix(e2e-staging): BQ account 404 handling, PAUSE fix, and run.sh diagnostics

### DIFF
--- a/rudderstack/resource_destination.go
+++ b/rudderstack/resource_destination.go
@@ -3,6 +3,7 @@ package rudderstack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -124,6 +125,11 @@ func resourceDestinationRead(cm configs.ConfigMeta) schema.ReadContextFunc {
 
 		destination, err := c.Destinations.Get(ctx, id)
 		if err != nil {
+			var apiErr *client.APIError
+			if errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404 {
+				d.SetId("")
+				return diag.Diagnostics{}
+			}
 			return diag.FromErr(err)
 		}
 

--- a/test/e2e/staging/.gitignore
+++ b/test/e2e/staging/.gitignore
@@ -5,3 +5,4 @@
 .bin/
 sa.json
 .env
+.dev-override.tfrc

--- a/test/e2e/staging/run.sh
+++ b/test/e2e/staging/run.sh
@@ -195,7 +195,13 @@ fi
 # ── Optional hold-open for manual inspection ─────────────────────────────────
 if [[ "${PAUSE:-false}" == "true" ]]; then
   echo "==> PAUSED. Resources are live in staging. Outputs above."
-  echo "    Run the rETL sync manually in the workspace, then press Enter to destroy."
+  echo ""
+  echo "    To inspect resources in a second terminal, export the provider config first:"
+  echo "      export TF_CLI_CONFIG_FILE='${TF_CLI_CONFIG_FILE}'"
+  echo "      terraform -chdir='${SCRIPT_DIR}' state show rudderstack_account_source_bigquery.acct"
+  echo "      terraform -chdir='${SCRIPT_DIR}' show -json | jq '.values.root_module.resources[] | select(.type==\"rudderstack_account_source_bigquery\") | .values.config'"
+  echo ""
+  echo "    Press Enter to destroy."
   read -r || true   # blocks here; || true prevents set -e from exiting on EOF/signal
 fi
 

--- a/test/e2e/staging/run.sh
+++ b/test/e2e/staging/run.sh
@@ -110,6 +110,18 @@ terraform -chdir="${SCRIPT_DIR}" apply -auto-approve \
   -var-file="${TFVARS_FILE}"
 echo "==> Apply succeeded."
 
+# ── Verify resource IDs are non-empty ────────────────────────────────────────
+echo "==> Verifying resource IDs are non-empty …"
+for out in account_id retl_source_id destination_id connection_id; do
+  val=$(terraform -chdir="${SCRIPT_DIR}" output -raw "$out" 2>/dev/null)
+  if [[ -z "$val" ]]; then
+    echo "FAIL: output '$out' is empty — resource may not have been created."
+    exit 1
+  fi
+  echo "    $out = $val"
+done
+echo "==> All resources confirmed created."
+
 # ── Assert: plan must show zero drift ────────────────────────────────────────
 # terraform plan -detailed-exitcode exit codes:
 #   0 = success, no diff (what we want)
@@ -184,7 +196,7 @@ fi
 if [[ "${PAUSE:-false}" == "true" ]]; then
   echo "==> PAUSED. Resources are live in staging. Outputs above."
   echo "    Run the rETL sync manually in the workspace, then press Enter to destroy."
-  read -r   # ponytail: blocks here; trap destroys on exit. Ctrl-C also triggers destroy.
+  read -r || true   # blocks here; || true prevents set -e from exiting on EOF/signal
 fi
 
 echo "==> Smoke run complete."


### PR DESCRIPTION
## Summary

Fixes and improvements discovered during the BigQuery rETL e2e staging smoke run.

- **Fix destination 404 → graceful state removal**: `resourceDestinationRead` was returning a hard error on HTTP 404, which caused the smoke test to fail during `apply` when a stale destination existed in state. Now clears `SetId("")` and returns empty diagnostics so Terraform recreates the resource on the next apply.
- **Fix `PAUSE=true` script exit**: `read -r` returns exit code 1 on EOF (e.g. piped input). Under `set -euo pipefail` this killed the script before destroy ran. Fixed with `read -r || true`.
- **Improve PAUSE diagnostics**: When `PAUSE=true`, the script now prints the exact `export TF_CLI_CONFIG_FILE` command and `terraform state show` / `show -json` commands needed to inspect live staging resources in a second terminal — without having to know the temp override path.
- **Gitignore `.dev-override.tfrc`**: Local convenience tfrc file (hardcoded absolute path) was untracked and at risk of being committed accidentally. Added to `test/e2e/staging/.gitignore`.

## Context

The `projectId` vs `project` field name inconsistency between the `/v2/accounts` API schema and the rETL runtime is a **backend issue** — tracked separately via Slack. This PR contains only the provider-side and test-harness fixes.

Related: [QA-2471 — Test consolidated rETL account management PRs](https://linear.app/rudderstack/issue/QA-2471/test-consolidated-retl-account-management-prs)

Fixes QA-2471

## Test plan

- [ ] `PAUSE=true bash run.sh secret.tfvars` — confirm script pauses, prints diagnostic commands, and resumes/destroys on Enter
- [ ] Verify a stale destination in state no longer blocks `apply` (clears and recreates)
- [ ] Confirm `.dev-override.tfrc` is ignored by git after adding

🤖 Generated with [Claude Code](https://claude.com/claude-code)