### PR TITLE
fix(accounts): BigQuery account uses options.project (not projectId)

### DIFF
--- a/rudderstack/accounts/account_bigquery.go
+++ b/rudderstack/accounts/account_bigquery.go
@@ -7,7 +7,7 @@ import (
 
 func init() {
 	properties := []c.ConfigProperty{
-		c.Simple("options.projectId", "project"),
+		c.Simple("options.project", "project"),
 		c.Simple("options.location", "location", c.SkipZeroValue),
 		c.Simple("secret.credentials", "credentials"),
 	}

--- a/rudderstack/accounts/account_bigquery_test.go
+++ b/rudderstack/accounts/account_bigquery_test.go
@@ -20,7 +20,7 @@ var bigqueryAccountTestConfigs = []c.TestConfig{
 		APICreate: `{
 			"name": "example",
 			"accountDefinitionName": "SOURCE_BIGQUERY",
-			"options": { "projectId": "my-gcp-project" },
+			"options": { "project": "my-gcp-project" },
 			"secret":  { "credentials": "{\"type\":\"service_account\"}" }
 		}`,
 		TerraformUpdate: `
@@ -31,7 +31,7 @@ var bigqueryAccountTestConfigs = []c.TestConfig{
 		APIUpdate: `{
 			"name": "example-updated",
 			"accountDefinitionName": "SOURCE_BIGQUERY",
-			"options": { "projectId": "my-gcp-project", "location": "EU" },
+			"options": { "project": "my-gcp-project", "location": "EU" },
 			"secret":  { "credentials": "{\"type\":\"service_account\"}" }
 		}`,
 	},


### PR DESCRIPTION
**Draft — blocked on the config-backend SOURCE_BIGQUERY schema fix.**

Flips the provider mapping `options.projectId` → `options.project` (+ test). `project` is canonical (webapp, integrations-config source def, and the rETL connector all use it).

⚠️ Currently `/v2/accounts` validates SOURCE_BIGQUERY options and **requires `projectId`** — verified: creating with `project` returns `400 "must have required property 'projectId'"`. So this must merge **together with** the config-backend account-definition change (projectId→project). Until then it stays draft.

Verifies green once the backend accepts `project`; rudder-api-test rudderlabs/rudder-api-test#842 also flips green at that point.