### PR TITLE
test(retl): add acceptance test for rudderstack_retl_connection_customerio

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,7 @@ jobs:
       has_affected_sources: ${{ steps.detect.outputs.has_affected_sources }}
       has_affected_connections: ${{ steps.detect.outputs.has_affected_connections }}
       has_affected_accounts: ${{ steps.detect.outputs.has_affected_accounts }}
+      has_affected_retl: ${{ steps.detect.outputs.has_affected_retl }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -95,6 +96,13 @@ jobs:
             echo "has_affected_connections=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_affected_connections=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # RETL detection: run RETL tests if retl/ or core files changed.
+          if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -q "rudderstack/retl/"; then
+            echo "has_affected_retl=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_affected_retl=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Account detection: run account acceptance tests if accounts/ or core files changed.
@@ -298,8 +306,48 @@ jobs:
             -timeout 10m \
             -count=1
 
+  e2e-retl-crud:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_affected_retl == 'true'
+    runs-on: ubuntu-latest
+    environment: e2e
+    timeout-minutes: 15
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+
+      - name: Run E2E RETL CRUD tests
+        env:
+          TF_ACC: "1"
+          RUDDERSTACK_ACCESS_TOKEN: ${{ secrets.RUDDERSTACK_ACC_TEST_TOKEN }}
+          RUDDERSTACK_API_URL: ${{ vars.RUDDERSTACK_ACC_TEST_API_URL }}
+          RUDDERSTACK_RETL_TEST_ACCOUNT_ID: ${{ vars.RUDDERSTACK_RETL_TEST_ACCOUNT_ID }}
+          RUDDERSTACK_CUSTOMERIO_TEST_AUDIENCE_ID: ${{ vars.RUDDERSTACK_CUSTOMERIO_TEST_AUDIENCE_ID }}
+        run: |
+          go test \
+            ./rudderstack/retl/ \
+            -v \
+            -run "TestAccRETL" \
+            -timeout 10m \
+            -count=1
+
   e2e-summary:
-    needs: [detect-changes, plan-only, e2e-crud, e2e-source-crud, e2e-conn-crud, e2e-account-crud]
+    needs: [detect-changes, plan-only, e2e-crud, e2e-source-crud, e2e-conn-crud, e2e-account-crud, e2e-retl-crud]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -315,10 +363,12 @@ jobs:
           SOURCE_CRUD_RESULT: ${{ needs.e2e-source-crud.result }}
           CONN_CRUD_RESULT: ${{ needs.e2e-conn-crud.result }}
           ACCOUNT_CRUD_RESULT: ${{ needs.e2e-account-crud.result }}
+          RETL_CRUD_RESULT: ${{ needs.e2e-retl-crud.result }}
           HAS_AFFECTED: ${{ needs.detect-changes.outputs.has_affected }}
           HAS_AFFECTED_SOURCES: ${{ needs.detect-changes.outputs.has_affected_sources }}
           HAS_AFFECTED_CONNECTIONS: ${{ needs.detect-changes.outputs.has_affected_connections }}
           HAS_AFFECTED_ACCOUNTS: ${{ needs.detect-changes.outputs.has_affected_accounts }}
+          HAS_AFFECTED_RETL: ${{ needs.detect-changes.outputs.has_affected_retl }}
         run: |
           if [ "$PLAN_RESULT" != "success" ]; then
             echo "Plan-only validation failed."
@@ -338,6 +388,10 @@ jobs:
           fi
           if [ "$HAS_AFFECTED_ACCOUNTS" = "true" ] && [ "$ACCOUNT_CRUD_RESULT" != "success" ]; then
             echo "E2E account CRUD tests failed."
+            exit 1
+          fi
+          if [ "$HAS_AFFECTED_RETL" = "true" ] && [ "$RETL_CRUD_RESULT" != "success" ]; then
+            echo "E2E RETL CRUD tests failed."
             exit 1
           fi
           echo "All E2E tests passed."

--- a/internal/testutil/acc/retl.go
+++ b/internal/testutil/acc/retl.go
@@ -418,6 +418,128 @@ resource "rudderstack_retl_connection_customerio_audience" "test" {
 `, srcName, accountID, dstName, cfg.SyncBehaviour, audienceID, cfg.Schedule, cfg.Identifiers, mappingsBlock)
 }
 
+// AccAssertRETLConnectionCustomerIO wires a model source + Customer.io
+// destination + rudderstack_retl_connection_customerio and runs the lifecycle.
+// The typed connection carries `object` as a top-level field; VDM v2 does not
+// support field mappings.
+//
+// Plan-only (CI default): validates HCL/schema with placeholder creds, zero API
+// calls. Live: gated on retlAccountIDEnv; skips when unset.
+func AccAssertRETLConnectionCustomerIO(t *testing.T, cfg RETLConnectionTestConfig) {
+	t.Helper()
+
+	planOnly := PlanOnly()
+	if planOnly {
+		t.Parallel()
+	}
+
+	connResource := "rudderstack_retl_connection_customerio.test"
+	srcResource := "rudderstack_retl_source_model.test"
+	dstResource := "rudderstack_destination_customerio.test"
+
+	suffix := cfg.Variant
+	if suffix == "" {
+		suffix = "cio"
+	}
+	srcName := RandomName("retl-src-" + suffix)
+	dstName := RandomName("retl-dst-" + suffix)
+
+	accountID := planOnlyAccountID
+	if !planOnly {
+		accountID = os.Getenv(retlAccountIDEnv)
+		if accountID == "" {
+			t.Skipf("%s is not set; skipping live Customer.io connection test", retlAccountIDEnv)
+		}
+	}
+
+	createHCL := retlCustomerIOHCL(srcName, dstName, accountID, cfg)
+
+	if planOnly {
+		ensureDummyToken(t)
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: TestAccProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             createHCL,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+		return
+	}
+
+	steps := []resource.TestStep{
+		{
+			Config: createHCL,
+			Check: resource.ComposeTestCheckFunc(
+				testAccCheckRETLConnectionExists(connResource),
+				resource.TestCheckResourceAttrSet(connResource, "id"),
+				resource.TestCheckResourceAttr(connResource, "object", "person"),
+				resource.TestCheckResourceAttr(connResource, "sync_behaviour", cfg.SyncBehaviour),
+				resource.TestCheckResourceAttrPair(connResource, "source_id", srcResource, "id"),
+				resource.TestCheckResourceAttrPair(connResource, "destination_id", dstResource, "id"),
+			),
+		},
+	}
+
+	steps = append(steps, resource.TestStep{
+		ResourceName:      connResource,
+		ImportState:       true,
+		ImportStateVerify: true,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRETLConnectionDestroy("rudderstack_retl_connection_customerio"),
+		Steps:             steps,
+	})
+}
+
+// retlCustomerIOHCL builds the source + Customer.io destination + typed
+// connection pipeline. Destination creds are placeholders — the control-plane
+// API stores them without validating against Customer.io, so live runs only need
+// a warehouse account.
+func retlCustomerIOHCL(srcName, dstName, accountID string, cfg RETLConnectionTestConfig) string {
+	cursorAttr := ""
+	if cfg.CursorColumn != "" {
+		cursorAttr = fmt.Sprintf("\n  cursor_column  = %q", cfg.CursorColumn)
+	}
+
+	return fmt.Sprintf(`
+resource "rudderstack_retl_source_model" "test" {
+  name                   = %q
+  source_definition_name = "bigquery"
+  account_id             = %q
+  config {
+    primary_key = "id"
+    sql         = "select 1 as id"
+  }
+}
+
+resource "rudderstack_destination_customerio" "test" {
+  name = %q
+  config {
+    site_id = "tf-acc-site"
+    api_key = "tf-acc-api-key"
+  }
+}
+
+resource "rudderstack_retl_connection_customerio" "test" {
+  source_id      = rudderstack_retl_source_model.test.id
+  destination_id = rudderstack_destination_customerio.test.id
+  enabled        = true
+  sync_behaviour = %q
+  object         = "person"%s
+  schedule {
+    %s
+  }
+  %s
+}
+`, srcName, accountID, dstName, cfg.SyncBehaviour, cursorAttr, cfg.Schedule, cfg.Identifiers)
+}
+
 // retlSourceHCL builds the HCL for a single RETL source resource.
 func retlSourceHCL(resourceType, name, sourceDefinitionName, accountID, configBlock string) string {
 	return fmt.Sprintf(`

--- a/rudderstack/retl/retl_acc_test.go
+++ b/rudderstack/retl/retl_acc_test.go
@@ -132,6 +132,25 @@ func TestAccRETLConnectionCustomerIOAudience_Manual(t *testing.T) {
 	})
 }
 
+// TestAccRETLConnectionCustomerIO_Manual exercises the typed
+// rudderstack_retl_connection_customerio resource (VDM v2 flow). Plan-only (the
+// CI default) validates HCL/schema — including the top-level object field — with
+// no creds. The live path is gated on RUDDERSTACK_RETL_TEST_ACCOUNT_ID and
+// skips when unset.
+func TestAccRETLConnectionCustomerIO_Manual(t *testing.T) {
+	acc.AccAssertRETLConnectionCustomerIO(t, acc.RETLConnectionTestConfig{
+		Variant:       "cio-manual",
+		SyncBehaviour: "upsert",
+		Schedule:      `type = "manual"`,
+		Identifiers: `
+			identifiers {
+				from = "email"
+				to   = "email"
+			}
+		`,
+	})
+}
+
 // TestAccRETLConnection_ManualSchedule covers the manual schedule branch.
 // `full` sync_behaviour flexes a non-upsert path (the JSON Mapper flow accepts
 // only "upsert" or "full" — "mirror" is rejected by the API).


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

## Description of the change

Adds AccAssertRETLConnectionCustomerIO helper and TestAccRETLConnectionCustomerIO_Manual, mirroring the existing customerio_audience pattern. Plan-only path (CI default) validates HCL/schema with no creds; live path gates on RUDDERSTACK_RETL_TEST_ACCOUNT_ID.

## What is the related Linear task?

Resolves XXX-XXX

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
