### PR TITLE
feat: destination version scaffolding for ConfigMeta and generatetf (INT-6494)

### DIFF
--- a/.specs/terraform-provider-destination-version-support.md
+++ b/.specs/terraform-provider-destination-version-support.md
@@ -36,6 +36,7 @@ Refinement of the original story. All decisions below were validated against the
 * `configMetaByVersion(entries, apiType, version int)` — **new**, mandatory version filter. Used by destination callers (lines 67, 162). Signature: `func configMetaByVersion(entries map[string]configs.ConfigMeta, apiType string, version int) (string, *configs.ConfigMeta)`.
 * `configMetaByVersion` matches strictly on `e.APIType == apiType && e.Version == version`. **No coercion of** `version == 0` — see §6.
 * Destination call sites become `configMetaByVersion(destinationConfigs, dst.Type, dst.Version)`.
+* When lookup fails, both `GenerateTerraform` and `GenerateImportScript` log a shared reason from `unsupportedDestinationReason`: unknown API type vs known API type with unsupported/absent version (lists sorted available versions). Import generation must not skip destinations silently.
 * Source call sites stay `configMeta(sourceConfigs, src.Type)`.
 
 ## 6\. `absent version on the wire` — owned by [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and), not this story
@@ -64,8 +65,9 @@ Refinement of the original story. All decisions below were validated against the
   ```go
   func ComposeConfigMeta(base c.ConfigMeta, delta Delta, version int) c.ConfigMeta
   ```
-  * Clones `base.ConfigSchema` (shallow map copy) and `base.Properties` (slice copy).
-  * Applies `Renamed` (delete old key, insert under new key — safe on shallow-copied map), `Added` (insert new `*schema.Schema`), `Removed` (delete keys) to the schema map.
+  * Clones `base.ConfigSchema` (shallow map copy) and `base.Properties` (slice copy). `SettingsSchema` / `Settings` are shared with base (destinations do not use them today; cloning them is out of scope).
+  * Validates the full delta before mutation and panics with a deterministic message on invalid input (unknown Removed/Renamed/RemovedProperties keys, Removed/Renamed source overlap, chained renames, duplicate rename targets, collisions with retained or Added keys) — same class of fail-fast as `Destinations.Register`.
+  * Applies `Renamed` from original base values in sorted old-key order (delete old key, insert under new key), then `Added`, then `Removed` (Removed applied before Renamed in the helper). Map iteration order must not affect the result.
   * Applies `AddedProperties` / `RemovedProperties` to the Properties slice.
   * Sets `result.Version = version`.
   * Returns `ConfigMeta` by value (matches `Registry.Register` signature).
@@ -90,7 +92,9 @@ Refinement of the original story. All decisions below were validated against the
 | Existing `generator_test.go` destination fixtures bumped to `Version: 1` | `cmd/generatetf/generator/generator_test.go` | Unit (edit existing) | Blocker A |
 | `populateDestinationFromState` sets `destination.Version = cm.Version` | `rudderstack/resource_destination_test.go` (new case) | Unit | Blocker A |
 | `Destinations.Register` panics on `Version == 0` and on duplicate `(apiType, version)` | `rudderstack/configs/registries_test.go` (new cases) | Unit | Blocker A |
-| `ComposeConfigMeta`: base + delta → expected ConfigMeta; base unchanged after | `rudderstack/integrations/destinations/compose_test.go` (new) | Unit | Blocker A |
+| `ComposeConfigMeta`: base + delta → expected ConfigMeta; base unchanged after; invalid deltas panic | `rudderstack/integrations/destinations/compose_test.go` (new) | Unit | Blocker A |
+| `unsupportedDestinationReason` + skip logs in HCL/import generators | `cmd/generatetf/generator/generator_version_test.go` | Unit | Blocker A |
+| Acc destination version check uses registered `ConfigMeta.Version` (exact) | `internal/testutil/acc/destinations.go` | Acceptance helper | Blocker B |
 | Braze applies with `version: 1` in request body, no plan diff before/after provider upgrade | `rudderstack/resource_destination_test.go` | Acceptance, `RUDDERSTACK_ACCESS_TOKEN`-gated | Blocker B |
 
 ## 10\. Updated acceptance criteria

--- a/.specs/terraform-provider-destination-version-support.md
+++ b/.specs/terraform-provider-destination-version-support.md
@@ -1,0 +1,124 @@
+# Technical Refinement Spec — [INT-6494](https://linear.app/rudderstack/issue/INT-6494/terraform-provider-rudderstack-codegen-resolve-by-apitype-version)
+
+Refinement of the original story. All decisions below were validated against the current codebase (`91b4919`) and rudder-iac `feat/rud-2864-destination-resource-handler-updated` (PR #625). Open items listed at the bottom.
+
+## 1\. Type & wire format
+
+* `ConfigMeta.Version` is `int` (aligns with `client.Destination.Version int` in rudder-iac).
+* Wire sends `version: 1` (numeric, not string). Matches ` Destination.Version` `json:"version,omitempty"`.
+* Backfill value across the existing fleet is `1` (int), not `"1"`.
+
+## 2\. State schema — no `version` field
+
+* The destination Terraform resource schema is **unchanged**. No `version` attribute is added to state.
+* Version is encoded purely by the resource type name (`rudderstack_destination_braze` vs `rudderstack_destination_braze_v2`).
+* `populateDestinationFromState` writes `destination.Version = cm.Version` on create/update (wire-only).
+* `storeDestinationToState` does **not** read `destination.Version` back — there is no state field to write into.
+* Rationale: adding any version field (Required / Optional / Computed) causes a one-time plan diff across the entire existing fleet on upgrade. The story's "behaviorally a no-op, no plan diff" guarantee only holds if the schema is untouched.
+* Known gap (deferred to rollout milestone): if the backend ever migrates a v1 instance to v2 in place, the provider cannot detect it (no state field to diff). Out of scope here.
+
+## 3\. Backfill strategy — explicit, all 47 destinations
+
+* Every existing bare (suffix-less) `Destinations.Register` call site in `rudderstack/integrations/destinations/destination_*.go` is edited to set `Version: 1` on its `ConfigMeta` literal.
+* 47 files touched (one registration per file).
+* Sources and Accounts are **not** versioned in this story. Their `ConfigMeta.Version` stays at the zero value; their registries keep the current name-only uniqueness check.
+
+## 4\. Registry guards
+
+* `Destinations.Register` gains two new panic guards (sources/accounts unaffected):
+  1. **Presence**: panic if `cm.Version == 0` — forces every destination registration to declare an explicit version.
+  2. **Uniqueness on** `(apiType, version)`: panic if another entry with the same `(APIType, Version)` is already registered. Requires a secondary index in `Registry` keyed by `(apiType, version)`, scoped to the destinations registry.
+* These guards replace the "ambiguous match" risk inside the codegen resolver: failures happen at provider init (loud, early) rather than at codegen lookup time (silent, late).
+
+## 5\. `generatetf` codegen resolver — two functions
+
+* `configMeta(entries, apiType)` — **unchanged**, first-match on `APIType`. Used by source and account callers (lines 59, 143 — sources; accounts have no codegen path).
+* `configMetaByVersion(entries, apiType, version int)` — **new**, mandatory version filter. Used by destination callers (lines 67, 162). Signature: `func configMetaByVersion(entries map[string]configs.ConfigMeta, apiType string, version int) (string, *configs.ConfigMeta)`.
+* `configMetaByVersion` matches strictly on `e.APIType == apiType && e.Version == version`. **No coercion of** `version == 0` — see §6.
+* Destination call sites become `configMetaByVersion(destinationConfigs, dst.Type, dst.Version)`.
+* Source call sites stay `configMeta(sourceConfigs, src.Type)`.
+
+## 6\. `absent version on the wire` — owned by [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and), not this story
+
+* Q4 decision: this provider **relies on the backend (**[INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and)**) to always send a real** `version` on every destination response.
+* `configMetaByVersion` does **not** coerce `0 → 1`. If `dst.Version == 0`, no entry matches → the destination is skipped in codegen output.
+* Consequence: the original story AC bullet *"absent* `version` *round-trips as v1"* and the corresponding test *"a* `null`*/absent version resolves to the v1 entry"* are **moved to** [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and) (backend concern: backfill `version: 1` on all existing records, default on create).
+* This story's provider-side AC for absent version is replaced with: *"provider assumes backend always sends* `version`*; verified via mocked-API unit tests, gated on* [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and) *backend rollout for the live acceptance test."*
+
+## 7\. Shared-base composition helper — scaffolding
+
+* **Location**: `rudderstack/integrations/destinations/compose.go` (next to `common_config_meta.go`). Destinations-only for now.
+* **Delta struct** (typed, compile-checked):
+
+  ```go
+  type Delta struct {
+      Renamed           map[string]string          // old schema key -> new schema key
+      Added             map[string]*schema.Schema   // new top-level schema fields
+      Removed           []string                    // dropped schema keys
+      AddedProperties   []c.ConfigProperty          // appended to Properties
+      RemovedProperties []string                    // removed from Properties (by name)
+  }
+  ```
+* **Helper signature**:
+
+  ```go
+  func ComposeConfigMeta(base c.ConfigMeta, delta Delta, version int) c.ConfigMeta
+  ```
+  * Clones `base.ConfigSchema` (shallow map copy) and `base.Properties` (slice copy).
+  * Applies `Renamed` (delete old key, insert under new key — safe on shallow-copied map), `Added` (insert new `*schema.Schema`), `Removed` (delete keys) to the schema map.
+  * Applies `AddedProperties` / `RemovedProperties` to the Properties slice.
+  * Sets `result.Version = version`.
+  * Returns `ConfigMeta` by value (matches `Registry.Register` signature).
+* **Shallow-copy constraint (documented)**: `Renamed` / `Removed` operate by map-key delete+insert only. Callers must **not** mutate nested `*schema.Schema` fields in place — those pointers are shared with the base. Documented at the helper and enforced by the unit test (assert base unchanged after composing a v2).
+* No real v2 destination is registered in this story. The helper exists + is unit-tested + sits ready for the rollout milestone.
+
+## 8\. Dependency sequencing — rudder-iac SHA pin + split blockers
+
+* `go.mod` currently pins `github.com/rudderlabs/rudder-iac v0.18.0`, which does **not** have `Destination.Version`. Confirmed by `git show v0.18.0:api/client/destinations.go`.
+* The `Version` field lands in rudder-iac PR #625 (branch `feat/rud-2864-destination-resource-handler-updated`).
+* **This story's PR pins rudder-iac to PR #625's merge SHA** via a pseudo-version: `go get github.com/rudderlabs/rudder-iac@<merge-sha> && go mod tidy` → `require github.com/rudderlabs/rudder-iac v0.18.1-0.<timestamp>-<sha12>`. Only valid after PR #625 **merges** (not while open — SHA must be reachable from a merged branch).
+* [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and) is split into two blockers for this story:
+  1. **Blocker A (rudder-iac client struct)**: PR #625 merge. Unblocks provider code + unit tests. This story can merge on this.
+  2. **Blocker B (backend wire guarantee)**: backend always sends `version` on every destination response. Unblocks the live env-gated acceptance test (braze no-plan-diff). The acceptance test is written in this PR but skipped in CI until Blocker B is rolled out.
+* Follow-up trivial PR (separate): once rudder-iac cuts a real tag, swap the pseudo-version → tag. No code change.
+
+## 9\. Tests
+
+| Test | File | Type | Gated on |
+| -- | -- | -- | -- |
+| `configMetaByVersion` resolution: v1, v2, mismatch → skip | `cmd/generatetf/generator/generator_version_test.go` (new) | Unit, table-driven | Blocker A |
+| Existing `generator_test.go` destination fixtures bumped to `Version: 1` | `cmd/generatetf/generator/generator_test.go` | Unit (edit existing) | Blocker A |
+| `populateDestinationFromState` sets `destination.Version = cm.Version` | `rudderstack/resource_destination_test.go` (new case) | Unit | Blocker A |
+| `Destinations.Register` panics on `Version == 0` and on duplicate `(apiType, version)` | `rudderstack/configs/registries_test.go` (new cases) | Unit | Blocker A |
+| `ComposeConfigMeta`: base + delta → expected ConfigMeta; base unchanged after | `rudderstack/integrations/destinations/compose_test.go` (new) | Unit | Blocker A |
+| Braze applies with `version: 1` in request body, no plan diff before/after provider upgrade | `rudderstack/resource_destination_test.go` | Acceptance, `RUDDERSTACK_ACCESS_TOKEN`-gated | Blocker B |
+
+## 10\. Updated acceptance criteria
+
+- [ ] `Version int` added to `ConfigMeta`; `populateDestinationFromState` sets `destination.Version = cm.Version` (depends on rudder-iac PR #625 / [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and) Blocker A).
+- [ ] All 47 existing bare destination registrations carry `ConfigMeta.Version = 1`.
+- [ ] `Destinations.Register` panics on `Version == 0` and on duplicate `(apiType, version)`.
+- [ ] `generatetf` has a new `configMetaByVersion(entries, apiType, version int)`; destination callers thread `dst.Version`; source/account callers unchanged.
+- [ ] `generatetf` `configMeta(entries, apiType)` (first-match) retained for sources.
+- [ ] Shared-base composition helper `ComposeConfigMeta(base, delta, version)` available in `integrations/destinations/compose.go` with typed `Delta` struct; unit-tested.
+- [ ] No `_vX` resource type / registry double-registration (deferred to rollout milestone).
+- [ ] Destination resource schema unchanged — no `version` field in state.
+- [ ] "absent `version` ⇒ v1" handling moved to [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and) (backend); this provider relies on backend always sending `version`.
+- [ ] `go.mod` pinned to rudder-iac PR #625 merge SHA via pseudo-version.
+- [ ] All unit tests above pass on Blocker A; env-gated acceptance test written and skipped until Blocker B.
+- [ ] Existing single-version HCL (`rudderstack_destination_braze`) plans/applies with no diff.
+
+## 11\. Out of scope (explicit)
+
+* Sources and Accounts versioning.
+* The actual `_v2` destination registration (e.g. `rudderstack_destination_braze_v2`) — deferred to rollout milestone.
+* Registry double-registration of `<name>_v2` resource types.
+* Backend-driven v1→v2 in-place migration detection.
+* rudder-iac tag release (follow-up trivial PR swaps SHA → tag).
+* Backfill verification mechanism (see Open items).
+
+## 12\. Open items
+
+* **Backfill verification** (deferred): how to prove none of the 47 `Version: 1` edits were missed — options were (a) a unit test iterating `configs.Destinations.Entries()` asserting `Version == 1` for all bare names, (b) PR review + grep, (c) a static check. Decision deferred. Recommend (a) as a cheap belt-and-suspenders test regardless of review.
+* `common_config_meta.go` **interaction**: the existing consent-management helper returns `([]ConfigProperty, map[string]*schema.Schema})` fragments composed by callers into a `ConfigMeta`. It does not need to know about `Version` — callers set `Version` on the assembled `ConfigMeta`. To be confirmed during implementation that no `common_config_meta` caller breaks.
+* **PR #625 merge target**: confirm it merges into a branch the provider can consume (main or a release branch) before pinning the SHA.

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -64,7 +64,7 @@ func GenerateImportScript(
 	}
 
 	for _, dst := range destinations {
-		t, cm := configMeta(destinationConfigs, dst.Type)
+		t, cm := configMetaByVersion(destinationConfigs, dst.Type, dst.Version)
 		if cm != nil {
 			foundDestinations[dst.ID] = true
 			destinationTerraformTypes[dst.ID] = t
@@ -159,7 +159,7 @@ func GenerateTerraform(
 	destinationConfigs := configs.Destinations.Entries()
 	generatedDestinationEntries := map[string]*destinationEntry{}
 	for _, dst := range destinations {
-		terraformType, cm := configMeta(destinationConfigs, dst.Type)
+		terraformType, cm := configMetaByVersion(destinationConfigs, dst.Type, dst.Version)
 		if cm != nil {
 			b, err := generateDestination(dst, terraformType, cm)
 			if err != nil {
@@ -433,9 +433,31 @@ func destinationName(destination client.Destination) string {
 
 // configMeta finds a ConfigMeta of a specific api type. Returns the terraform type and the ConfigMeta if found.
 // if not, it returns an empty string and nil.
+//
+// This resolves on APIType alone (first match) and is used for registries that don't
+// carry a meaningful Version yet (sources, accounts). For destinations, use
+// configMetaByVersion instead, since two entries can share an APIType once a second
+// version of the same integration is registered.
 func configMeta(entries map[string]configs.ConfigMeta, apiType string) (string, *configs.ConfigMeta) {
 	for r, e := range entries {
 		if e.APIType == apiType {
+			return r, &e
+		}
+	}
+
+	return "", nil
+}
+
+// configMetaByVersion finds a ConfigMeta matching both apiType and version. Returns the
+// terraform type and the ConfigMeta if found. If not, it returns an empty string and nil.
+//
+// version is mandatory and matched strictly (no coercion of an absent/zero version to v1):
+// this provider relies on the API always reporting a real version on every destination
+// (see INT-6489). A destination whose reported version has no matching registry entry is
+// treated the same as an unsupported apiType: it's skipped by the caller.
+func configMetaByVersion(entries map[string]configs.ConfigMeta, apiType string, version int) (string, *configs.ConfigMeta) {
+	for r, e := range entries {
+		if e.APIType == apiType && e.Version == version {
 			return r, &e
 		}
 	}

--- a/cmd/generatetf/generator/generator.go
+++ b/cmd/generatetf/generator/generator.go
@@ -69,6 +69,8 @@ func GenerateImportScript(
 			foundDestinations[dst.ID] = true
 			destinationTerraformTypes[dst.ID] = t
 			lines = append(lines, fmt.Sprintf(`terraform import "rudderstack_destination_%s.%s" "%s"`, t, destinationName(dst), dst.ID))
+		} else {
+			logger.Printf("skipping destination '%s': %s", dst.ID, unsupportedDestinationReason(destinationConfigs, dst.Type, dst.Version))
 		}
 	}
 
@@ -170,7 +172,7 @@ func GenerateTerraform(
 				generatedDestinationEntries[dst.ID] = &destinationEntry{terraformType: terraformType, destination: dst}
 			}
 		} else {
-			logger.Printf("could not generate resource block for destination '%s': type '%s' is not supported", dst.ID, dst.Type)
+			logger.Printf("could not generate resource block for destination '%s': %s", dst.ID, unsupportedDestinationReason(destinationConfigs, dst.Type, dst.Version))
 		}
 	}
 
@@ -454,7 +456,7 @@ func configMeta(entries map[string]configs.ConfigMeta, apiType string) (string, 
 // version is mandatory and matched strictly (no coercion of an absent/zero version to v1):
 // this provider relies on the API always reporting a real version on every destination
 // (see INT-6489). A destination whose reported version has no matching registry entry is
-// treated the same as an unsupported apiType: it's skipped by the caller.
+// skipped by the caller; use unsupportedDestinationReason to explain why.
 func configMetaByVersion(entries map[string]configs.ConfigMeta, apiType string, version int) (string, *configs.ConfigMeta) {
 	for r, e := range entries {
 		if e.APIType == apiType && e.Version == version {
@@ -463,6 +465,33 @@ func configMetaByVersion(entries map[string]configs.ConfigMeta, apiType string, 
 	}
 
 	return "", nil
+}
+
+// unsupportedDestinationReason explains why configMetaByVersion returned no match.
+// It distinguishes an unknown API type from a known API type whose reported version
+// has no registry entry, and lists the sorted versions that are registered.
+func unsupportedDestinationReason(entries map[string]configs.ConfigMeta, apiType string, version int) string {
+	available := make([]int, 0)
+	seen := make(map[int]bool)
+	for _, e := range entries {
+		if e.APIType != apiType {
+			continue
+		}
+		if seen[e.Version] {
+			continue
+		}
+		seen[e.Version] = true
+		available = append(available, e.Version)
+	}
+	if len(available) == 0 {
+		return fmt.Sprintf("type '%s' is not supported", apiType)
+	}
+	sort.Ints(available)
+	parts := make([]string, len(available))
+	for i, v := range available {
+		parts[i] = fmt.Sprintf("%d", v)
+	}
+	return fmt.Sprintf("type '%s' version %d is not supported (available versions: %s)", apiType, version, strings.Join(parts, ", "))
 }
 
 // generateConfigBlock generate a source or destination config block from an API config JSON

--- a/cmd/generatetf/generator/generator_test.go
+++ b/cmd/generatetf/generator/generator_test.go
@@ -38,9 +38,10 @@ func TestGeneratorTerraform(t *testing.T) {
 
 	destinations := []client.Destination{
 		{
-			ID:   "id-redshift",
-			Name: "name-redshift",
-			Type: "RS",
+			ID:      "id-redshift",
+			Name:    "name-redshift",
+			Type:    "RS",
+			Version: 1,
 			Config: json.RawMessage(`{
 				"host": "example.com",
 				"port": "5439",
@@ -56,9 +57,10 @@ func TestGeneratorTerraform(t *testing.T) {
 			}`),
 		},
 		{
-			ID:   "id-facebook-pixel",
-			Name: "name-facebook-pixel",
-			Type: "FACEBOOK_PIXEL",
+			ID:      "id-facebook-pixel",
+			Name:    "name-facebook-pixel",
+			Type:    "FACEBOOK_PIXEL",
+			Version: 1,
 			Config: json.RawMessage(`{
 				"pixelId": "facebook pixel id",
 				"accessToken": "facebook access token",
@@ -259,9 +261,10 @@ func TestGeneratorTerraformNestedListInListOfObjects(t *testing.T) {
 	t.Run("all items have empty nested list", func(t *testing.T) {
 		destinations := []client.Destination{
 			{
-				ID:   "id-dst-1",
-				Name: "dest-1",
-				Type: "HS",
+				ID:      "id-dst-1",
+				Name:    "dest-1",
+				Type:    "HS",
+				Version: 1,
 				Config: json.RawMessage(`{
 					"authorizationType": "newPrivateAppApi",
 					"apiVersion": "newApi",
@@ -282,9 +285,10 @@ func TestGeneratorTerraformNestedListInListOfObjects(t *testing.T) {
 	t.Run("all items have non-empty nested list", func(t *testing.T) {
 		destinations := []client.Destination{
 			{
-				ID:   "id-dst-2",
-				Name: "dest-2",
-				Type: "HS",
+				ID:      "id-dst-2",
+				Name:    "dest-2",
+				Type:    "HS",
+				Version: 1,
 				Config: json.RawMessage(`{
 					"authorizationType": "newPrivateAppApi",
 					"apiVersion": "newApi",
@@ -311,9 +315,10 @@ func TestGeneratorTerraformNestedListInListOfObjects(t *testing.T) {
 	t.Run("mixed: some items have empty nested list and some have non-empty", func(t *testing.T) {
 		destinations := []client.Destination{
 			{
-				ID:   "id-dst-3",
-				Name: "dest-3",
-				Type: "HS",
+				ID:      "id-dst-3",
+				Name:    "dest-3",
+				Type:    "HS",
+				Version: 1,
 				Config: json.RawMessage(`{
 					"authorizationType": "newPrivateAppApi",
 					"apiVersion": "newApi",
@@ -357,14 +362,16 @@ func TestGeneratorImportScript(t *testing.T) {
 
 	destinations := []client.Destination{
 		{
-			ID:   "id-destination-1",
-			Name: "name-redshift",
-			Type: "RS",
+			ID:      "id-destination-1",
+			Name:    "name-redshift",
+			Type:    "RS",
+			Version: 1,
 		},
 		{
-			ID:   "id-destination-2",
-			Name: "name-facebook-pixel",
-			Type: "FACEBOOK_PIXEL",
+			ID:      "id-destination-2",
+			Name:    "name-facebook-pixel",
+			Type:    "FACEBOOK_PIXEL",
+			Version: 1,
 		},
 		{
 			ID:   "unknown",
@@ -586,21 +593,24 @@ func retlEventStreamingFixtures() ([]client.Source, []client.Destination) {
 	return []client.Source{},
 		[]client.Destination{
 			{
-				ID:     "id-redshift",
-				Name:   "name-redshift",
-				Type:   "RS",
-				Config: json.RawMessage(`{}`),
+				ID:      "id-redshift",
+				Name:    "name-redshift",
+				Type:    "RS",
+				Version: 1,
+				Config:  json.RawMessage(`{}`),
 			},
 			{
-				ID:     "id-facebook-pixel",
-				Name:   "name-facebook-pixel",
-				Type:   "FACEBOOK_PIXEL",
-				Config: json.RawMessage(`{}`),
+				ID:      "id-facebook-pixel",
+				Name:    "name-facebook-pixel",
+				Type:    "FACEBOOK_PIXEL",
+				Version: 1,
+				Config:  json.RawMessage(`{}`),
 			},
 			{
-				ID:   "id-cio-audience",
-				Name: "name-cio-audience",
-				Type: "CUSTOMERIO_AUDIENCE",
+				ID:      "id-cio-audience",
+				Name:    "name-cio-audience",
+				Type:    "CUSTOMERIO_AUDIENCE",
+				Version: 1,
 				// Minimal valid config for the destination_customerio_audience
 				// resource — generator only needs enough to emit *something*.
 				Config: json.RawMessage(`{

--- a/cmd/generatetf/generator/generator_version_test.go
+++ b/cmd/generatetf/generator/generator_version_test.go
@@ -1,0 +1,94 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+)
+
+// These tests exercise configMeta and configMetaByVersion directly (whitebox,
+// package generator) against small, self-contained registries — not the real,
+// process-global configs.Destinations/configs.Sources populated by every
+// integration's init().
+
+func TestConfigMeta_FirstMatchOnAPIType(t *testing.T) {
+	entries := map[string]configs.ConfigMeta{
+		"javascript": {APIType: "Javascript"},
+		"http":       {APIType: "HTTP"},
+	}
+
+	terraformType, cm := configMeta(entries, "HTTP")
+	require.NotNil(t, cm)
+	assert.Equal(t, "http", terraformType)
+	assert.Equal(t, "HTTP", cm.APIType)
+}
+
+func TestConfigMeta_NoMatch(t *testing.T) {
+	entries := map[string]configs.ConfigMeta{
+		"http": {APIType: "HTTP"},
+	}
+
+	terraformType, cm := configMeta(entries, "Unknown")
+	assert.Nil(t, cm)
+	assert.Empty(t, terraformType)
+}
+
+func TestConfigMetaByVersion_MatchesExactAPITypeAndVersion(t *testing.T) {
+	entries := map[string]configs.ConfigMeta{
+		"braze":    {APIType: "BRAZE", Version: 1},
+		"braze_v2": {APIType: "BRAZE", Version: 2},
+	}
+
+	t.Run("v1", func(t *testing.T) {
+		terraformType, cm := configMetaByVersion(entries, "BRAZE", 1)
+		require.NotNil(t, cm)
+		assert.Equal(t, "braze", terraformType)
+		assert.Equal(t, 1, cm.Version)
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		terraformType, cm := configMetaByVersion(entries, "BRAZE", 2)
+		require.NotNil(t, cm)
+		assert.Equal(t, "braze_v2", terraformType)
+		assert.Equal(t, 2, cm.Version)
+	})
+}
+
+func TestConfigMetaByVersion_MismatchedVersionIsSkipped(t *testing.T) {
+	// A destination reporting a version with no matching registry entry is
+	// treated the same as an unsupported apiType by the caller (skipped) —
+	// this provider relies on the API always reporting a real version
+	// (INT-6489); it does not coerce an absent/zero version to v1.
+	entries := map[string]configs.ConfigMeta{
+		"braze": {APIType: "BRAZE", Version: 1},
+	}
+
+	terraformType, cm := configMetaByVersion(entries, "BRAZE", 3)
+	assert.Nil(t, cm)
+	assert.Empty(t, terraformType)
+}
+
+func TestConfigMetaByVersion_ZeroVersionDoesNotCoerceToV1(t *testing.T) {
+	entries := map[string]configs.ConfigMeta{
+		"braze": {APIType: "BRAZE", Version: 1},
+	}
+
+	// dst.Version == 0 (e.g. an old API record that hasn't been backfilled by
+	// the backend yet) does not match the v1 entry: no implicit coercion.
+	terraformType, cm := configMetaByVersion(entries, "BRAZE", 0)
+	assert.Nil(t, cm)
+	assert.Empty(t, terraformType)
+}
+
+func TestConfigMetaByVersion_UnknownAPIType(t *testing.T) {
+	entries := map[string]configs.ConfigMeta{
+		"braze": {APIType: "BRAZE", Version: 1},
+	}
+
+	terraformType, cm := configMetaByVersion(entries, "UNKNOWN", 1)
+	assert.Nil(t, cm)
+	assert.Empty(t, terraformType)
+}

--- a/cmd/generatetf/generator/generator_version_test.go
+++ b/cmd/generatetf/generator/generator_version_test.go
@@ -1,11 +1,14 @@
 package generator
 
 import (
+	"bytes"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 )
 
@@ -59,9 +62,8 @@ func TestConfigMetaByVersion_MatchesExactAPITypeAndVersion(t *testing.T) {
 
 func TestConfigMetaByVersion_MismatchedVersionIsSkipped(t *testing.T) {
 	// A destination reporting a version with no matching registry entry is
-	// treated the same as an unsupported apiType by the caller (skipped) —
-	// this provider relies on the API always reporting a real version
-	// (INT-6489); it does not coerce an absent/zero version to v1.
+	// skipped by the caller — this provider relies on the API always reporting
+	// a real version (INT-6489); it does not coerce an absent/zero version to v1.
 	entries := map[string]configs.ConfigMeta{
 		"braze": {APIType: "BRAZE", Version: 1},
 	}
@@ -91,4 +93,61 @@ func TestConfigMetaByVersion_UnknownAPIType(t *testing.T) {
 	terraformType, cm := configMetaByVersion(entries, "UNKNOWN", 1)
 	assert.Nil(t, cm)
 	assert.Empty(t, terraformType)
+}
+
+func TestUnsupportedDestinationReason(t *testing.T) {
+	entries := map[string]configs.ConfigMeta{
+		"braze":    {APIType: "BRAZE", Version: 1},
+		"braze_v2": {APIType: "BRAZE", Version: 2},
+	}
+
+	t.Run("unknown api type", func(t *testing.T) {
+		got := unsupportedDestinationReason(entries, "UNKNOWN", 1)
+		assert.Equal(t, "type 'UNKNOWN' is not supported", got)
+	})
+
+	t.Run("unsupported nonzero version", func(t *testing.T) {
+		got := unsupportedDestinationReason(entries, "BRAZE", 3)
+		assert.Equal(t, "type 'BRAZE' version 3 is not supported (available versions: 1, 2)", got)
+	})
+
+	t.Run("zero version", func(t *testing.T) {
+		got := unsupportedDestinationReason(entries, "BRAZE", 0)
+		assert.Equal(t, "type 'BRAZE' version 0 is not supported (available versions: 1, 2)", got)
+	})
+}
+
+func TestGenerateTerraform_LogsVersionMismatch(t *testing.T) {
+	buf := captureLogger(t)
+
+	destinations := []client.Destination{
+		{ID: "id-braze", Name: "braze", Type: "BRAZE", Version: 0},
+	}
+
+	data, err := GenerateTerraform(nil, destinations, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, string(data))
+	assert.Contains(t, buf.String(), "could not generate resource block for destination 'id-braze': type 'BRAZE' version 0 is not supported (available versions: 1)")
+}
+
+func TestGenerateImportScript_LogsVersionMismatch(t *testing.T) {
+	buf := captureLogger(t)
+
+	destinations := []client.Destination{
+		{ID: "id-braze", Name: "braze", Type: "BRAZE", Version: 3},
+	}
+
+	data, err := GenerateImportScript(nil, destinations, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, string(data))
+	assert.Contains(t, buf.String(), "skipping destination 'id-braze': type 'BRAZE' version 3 is not supported (available versions: 1)")
+}
+
+func captureLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := logger
+	logger = log.New(&buf, "", 0)
+	t.Cleanup(func() { logger = prev })
+	return &buf
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/rudderlabs/rudder-iac v0.18.0
+	github.com/rudderlabs/rudder-iac v0.18.1-0.20260625093635-9da6a973d89c
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rudderlabs/rudder-iac v0.18.0 h1:+PAqG0haoojekZt3xb10JOb8laRTeq0Pr7BTFMh+yf0=
-github.com/rudderlabs/rudder-iac v0.18.0/go.mod h1:eHiIfNM1vNHoAy6wgeDYeVLssXwdvCO9NS4hJgu20+8=
+github.com/rudderlabs/rudder-iac v0.18.1-0.20260625093635-9da6a973d89c h1:j9UiYkWBGyP03mTRbpsg7cZn765CjZY9VbeadhZMS/4=
+github.com/rudderlabs/rudder-iac v0.18.1-0.20260625093635-9da6a973d89c/go.mod h1:eHiIfNM1vNHoAy6wgeDYeVLssXwdvCO9NS4hJgu20+8=
+github.com/samber/lo v1.52.0 h1:Rvi+3BFHES3A8meP33VPAxiBZX/Aws5RxrschYGjomw=
+github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=

--- a/internal/testutil/acc/destinations.go
+++ b/internal/testutil/acc/destinations.go
@@ -28,6 +28,7 @@ func AccAssertDestination(t *testing.T, destination string, testConfigs []config
 	resourceName := fmt.Sprintf("rudderstack_destination_%s.test", destination)
 	name := RandomName(destination)
 	cfg := testConfigs[0]
+	wantVersion := registeredDestinationVersion(t, destination)
 
 	if PlanOnly() {
 		t.Parallel()
@@ -59,15 +60,13 @@ func AccAssertDestination(t *testing.T, destination string, testConfigs []config
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					testAccCheckDestinationAPIConfig(resourceName, cfg.APICreate),
-					// INT-6494: every bare (suffix-less) destination is registered
-					// with ConfigMeta.Version = 1, so it must send version:1 on the
-					// wire. This test step's automatic post-apply plan check (part
-					// of resource.Test) also asserts there's no plan diff, so this
-					// exercises both halves of the story's "whole-fleet v1" AC.
-					// Requires the backend to echo `version` back on read (INT-6489
-					// Blocker B) — until then this assertion will fail loudly rather
-					// than silently pass.
-					testAccCheckDestinationVersion(resourceName, 1),
+					// Exact wire version must match the destination's registered
+					// ConfigMeta.Version (v1 today; future _v2 resources expect 2).
+					// The automatic post-apply plan check also asserts no plan
+					// diff. Requires the backend to echo version on read
+					// (Blocker B) — until then this fails loudly rather than
+					// silently passing.
+					testAccCheckDestinationVersion(resourceName, wantVersion),
 				),
 			},
 			{
@@ -164,6 +163,21 @@ func testAccCheckDestinationAPIConfig(resourceName, expectedJSON string) resourc
 
 		return compareConfig(dest.Config, expectedJSON)
 	}
+}
+
+// registeredDestinationVersion returns ConfigMeta.Version for the terraform
+// destination type name. Exact match (not >= 1) keeps future _v2 resources
+// correct while still failing if the API returns the wrong version.
+func registeredDestinationVersion(t *testing.T, destination string) int {
+	t.Helper()
+	cm, ok := configs.Destinations.Entries()[destination]
+	if !ok {
+		t.Fatalf("destination %q is not registered", destination)
+	}
+	if cm.Version < 1 {
+		t.Fatalf("destination %q has invalid ConfigMeta.Version %d", destination, cm.Version)
+	}
+	return cm.Version
 }
 
 // testAccCheckDestinationVersion fetches the destination from the API and verifies

--- a/internal/testutil/acc/destinations.go
+++ b/internal/testutil/acc/destinations.go
@@ -59,6 +59,15 @@ func AccAssertDestination(t *testing.T, destination string, testConfigs []config
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					testAccCheckDestinationAPIConfig(resourceName, cfg.APICreate),
+					// INT-6494: every bare (suffix-less) destination is registered
+					// with ConfigMeta.Version = 1, so it must send version:1 on the
+					// wire. This test step's automatic post-apply plan check (part
+					// of resource.Test) also asserts there's no plan diff, so this
+					// exercises both halves of the story's "whole-fleet v1" AC.
+					// Requires the backend to echo `version` back on read (INT-6489
+					// Blocker B) — until then this assertion will fail loudly rather
+					// than silently pass.
+					testAccCheckDestinationVersion(resourceName, 1),
 				),
 			},
 			{
@@ -154,6 +163,34 @@ func testAccCheckDestinationAPIConfig(resourceName, expectedJSON string) resourc
 		}
 
 		return compareConfig(dest.Config, expectedJSON)
+	}
+}
+
+// testAccCheckDestinationVersion fetches the destination from the API and verifies
+// its reported version matches wantVersion. This depends on the backend always
+// reporting a real version on every destination (INT-6489); the provider does not
+// coerce an absent/zero version to v1 (see cmd/generatetf/generator.configMetaByVersion).
+func testAccCheckDestinationVersion(resourceName string, wantVersion int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		cl, err := newTestAPIClient()
+		if err != nil {
+			return err
+		}
+
+		dest, err := cl.Destinations.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get destination from API: %w", err)
+		}
+
+		if dest.Version != wantVersion {
+			return fmt.Errorf("destination %s: got version %d, want %d", rs.Primary.ID, dest.Version, wantVersion)
+		}
+		return nil
 	}
 }
 

--- a/rudderstack/configs/configmeta.go
+++ b/rudderstack/configs/configmeta.go
@@ -5,7 +5,12 @@ import (
 )
 
 type ConfigMeta struct {
-	APIType        string
+	APIType string
+	// Version is the major version of the underlying integration definition
+	// (e.g. 1, 2, ...). It is only meaningful for destinations today; sources
+	// and accounts leave it at the zero value. See rudderstack/configs/registries.go
+	// for the registration-time guards enforced on this field for destinations.
+	Version        int
 	SkipConfig     bool
 	ConfigSchema   map[string]*schema.Schema
 	Properties     []ConfigProperty

--- a/rudderstack/configs/configproperty.go
+++ b/rudderstack/configs/configproperty.go
@@ -13,6 +13,12 @@ import (
 type ConfigProperty struct {
 	ToStateFunc   ToStateFunc
 	FromStateFunc FromStateFunc
+	// Name is an optional, stable identifier for this property, used by
+	// destinations.ComposeConfigMeta to remove a property when composing a new
+	// version's ConfigMeta from a base. It has no effect on state/API mapping.
+	// Existing constructors (Simple, Conditional, ...) leave it unset; set it
+	// explicitly on properties you may need to remove in a future version.
+	Name string
 }
 
 // FromStateFunc modifies am API config json object using terraform state information

--- a/rudderstack/configs/registries.go
+++ b/rudderstack/configs/registries.go
@@ -4,13 +4,24 @@ import "fmt"
 
 var (
 	Sources      *Registry = &Registry{name: "sources"}
-	Destinations *Registry = &Registry{name: "destinations"}
+	Destinations *Registry = &Registry{name: "destinations", versioned: true}
 	Accounts     *Registry = &Registry{name: "accounts"}
 )
+
+type apiTypeVersion struct {
+	apiType string
+	version int
+}
 
 type Registry struct {
 	name    string
 	entries map[string]ConfigMeta
+
+	// versioned enables the (APIType, Version) uniqueness guard and the
+	// Version-must-be-set guard below. Only Destinations is versioned today;
+	// Sources and Accounts don't carry a meaningful Version yet.
+	versioned bool
+	byVersion map[apiTypeVersion]string // (apiType, version) -> name, only populated when versioned
 }
 
 func (r *Registry) Register(name string, cm ConfigMeta) {
@@ -20,6 +31,22 @@ func (r *Registry) Register(name string, cm ConfigMeta) {
 
 	if _, ok := r.entries[name]; ok {
 		panic(fmt.Errorf("name '%s' is already registered with %s", name, r.name))
+	}
+
+	if r.versioned {
+		if cm.Version == 0 {
+			panic(fmt.Errorf("'%s' must set ConfigMeta.Version when registering with %s", name, r.name))
+		}
+
+		if r.byVersion == nil {
+			r.byVersion = map[apiTypeVersion]string{}
+		}
+
+		key := apiTypeVersion{apiType: cm.APIType, version: cm.Version}
+		if existing, ok := r.byVersion[key]; ok {
+			panic(fmt.Errorf("apiType '%s' version %d is already registered as '%s' in %s", cm.APIType, cm.Version, existing, r.name))
+		}
+		r.byVersion[key] = name
 	}
 
 	r.entries[name] = cm

--- a/rudderstack/configs/registries_internal_test.go
+++ b/rudderstack/configs/registries_internal_test.go
@@ -1,0 +1,59 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests exercise the versioned-registry guards (Version presence and
+// (APIType, Version) uniqueness) via the unexported `versioned` field on a
+// throwaway Registry, rather than mutating the shared, process-global
+// Destinations registry (which every destination's init() registers into and
+// must not be reset or polluted from tests).
+
+func newVersionedRegistryForTest(name string) *Registry {
+	return &Registry{name: name, versioned: true}
+}
+
+func TestVersionedRegistry_RequiresExplicitVersion(t *testing.T) {
+	r := newVersionedRegistryForTest("destinations under test")
+
+	assert.PanicsWithError(t, "'test' must set ConfigMeta.Version when registering with destinations under test", func() {
+		r.Register("test", ConfigMeta{APIType: "APIType"})
+	})
+}
+
+func TestVersionedRegistry_AllowsDistinctVersionsOfSameAPIType(t *testing.T) {
+	r := newVersionedRegistryForTest("destinations under test")
+
+	assert.NotPanics(t, func() {
+		r.Register("braze", ConfigMeta{APIType: "BRAZE", Version: 1})
+		r.Register("braze_v2", ConfigMeta{APIType: "BRAZE", Version: 2})
+	})
+
+	e := r.Entries()
+	assert.Len(t, e, 2)
+	assert.Equal(t, 1, e["braze"].Version)
+	assert.Equal(t, 2, e["braze_v2"].Version)
+}
+
+func TestVersionedRegistry_RejectsDuplicateAPITypeVersion(t *testing.T) {
+	r := newVersionedRegistryForTest("destinations under test")
+	r.Register("braze", ConfigMeta{APIType: "BRAZE", Version: 1})
+
+	assert.PanicsWithError(t, "apiType 'BRAZE' version 1 is already registered as 'braze' in destinations under test", func() {
+		r.Register("braze_dup", ConfigMeta{APIType: "BRAZE", Version: 1})
+	})
+}
+
+func TestVersionedRegistry_RejectsDuplicateNameRegardlessOfVersion(t *testing.T) {
+	// Name-uniqueness (pre-existing behavior) still applies independently of
+	// the (APIType, Version) guard.
+	r := newVersionedRegistryForTest("destinations under test")
+	r.Register("braze", ConfigMeta{APIType: "BRAZE", Version: 1})
+
+	assert.PanicsWithError(t, "name 'braze' is already registered with destinations under test", func() {
+		r.Register("braze", ConfigMeta{APIType: "BRAZE_OTHER", Version: 2})
+	})
+}

--- a/rudderstack/configs/registries_test.go
+++ b/rudderstack/configs/registries_test.go
@@ -16,3 +16,13 @@ func TestRegistries(t *testing.T) {
 	assert.Len(t, e, 1)
 	assert.Equal(t, "APIType", e["test"].APIType)
 }
+
+func TestRegistries_UnversionedAllowsZeroVersion(t *testing.T) {
+	// Sources/Accounts-style registries aren't versioned: Version 0 (the zero
+	// value) is allowed and there's no (APIType, Version) uniqueness guard.
+	r := &configs.Registry{}
+	assert.NotPanics(t, func() {
+		r.Register("a", configs.ConfigMeta{APIType: "SAME"})
+		r.Register("b", configs.ConfigMeta{APIType: "SAME"})
+	})
+}

--- a/rudderstack/integrations/destinations/compose.go
+++ b/rudderstack/integrations/destinations/compose.go
@@ -1,6 +1,10 @@
 package destinations
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
@@ -36,14 +40,23 @@ type Delta struct {
 // (typically v1) and a Delta describing what changed, so a new version isn't a
 // full copy-paste of the base's schema. version is stamped onto the result.
 //
+// Invalid deltas panic with a deterministic message (programmer/config error),
+// matching Destinations.Register guards: unknown Removed/Renamed/RemovedProperties
+// keys, Removed/Renamed source overlap, chained renames, duplicate rename
+// targets, and collisions with retained or Added keys.
+//
 // The clone is shallow: ConfigSchema and Properties get new backing map/slice,
 // but *schema.Schema values for keys that are neither renamed, removed, nor
-// added are shared pointers with base. Callers must not mutate a *schema.Schema
-// obtained from base.ConfigSchema in place (e.g. flipping Required/Optional on
-// a renamed field) — build a new *schema.Schema and put it in delta.Added (or
-// Renamed + a follow-up overwrite) instead. Mutating a shared *schema.Schema
-// in place would leak the change back into base's ConfigMeta.
+// added are shared pointers with base. SettingsSchema and Settings are shared
+// with base (destinations do not use them today). Callers must not mutate a
+// *schema.Schema obtained from base.ConfigSchema in place (e.g. flipping
+// Required/Optional on a renamed field) — build a new *schema.Schema and put
+// it in delta.Added (or Renamed + a follow-up overwrite) instead. Mutating a
+// shared *schema.Schema in place would leak the change back into base's
+// ConfigMeta.
 func ComposeConfigMeta(base c.ConfigMeta, delta Delta, version int) c.ConfigMeta {
+	validateDelta(base, delta)
+
 	schemaClone := make(map[string]*schema.Schema, len(base.ConfigSchema)+len(delta.Added))
 	for k, v := range base.ConfigSchema {
 		schemaClone[k] = v
@@ -52,12 +65,20 @@ func ComposeConfigMeta(base c.ConfigMeta, delta Delta, version int) c.ConfigMeta
 	for _, key := range delta.Removed {
 		delete(schemaClone, key)
 	}
-	for oldKey, newKey := range delta.Renamed {
-		if s, ok := schemaClone[oldKey]; ok {
-			delete(schemaClone, oldKey)
-			schemaClone[newKey] = s
-		}
+
+	// Apply renames from original base values in sorted old-key order so the
+	// result never depends on map iteration order.
+	oldKeys := make([]string, 0, len(delta.Renamed))
+	for oldKey := range delta.Renamed {
+		oldKeys = append(oldKeys, oldKey)
 	}
+	sort.Strings(oldKeys)
+	for _, oldKey := range oldKeys {
+		newKey := delta.Renamed[oldKey]
+		delete(schemaClone, oldKey)
+		schemaClone[newKey] = base.ConfigSchema[oldKey]
+	}
+
 	for key, s := range delta.Added {
 		schemaClone[key] = s
 	}
@@ -85,4 +106,110 @@ func ComposeConfigMeta(base c.ConfigMeta, delta Delta, version int) c.ConfigMeta
 		SettingsSchema: base.SettingsSchema,
 		Settings:       base.Settings,
 	}
+}
+
+func validateDelta(base c.ConfigMeta, delta Delta) {
+	var errs []string
+
+	removed := make(map[string]bool, len(delta.Removed))
+	for _, key := range delta.Removed {
+		if removed[key] {
+			continue
+		}
+		removed[key] = true
+		if _, ok := base.ConfigSchema[key]; !ok {
+			errs = append(errs, fmt.Sprintf("Removed schema key %q does not exist on base", key))
+		}
+	}
+
+	renameOldKeys := make([]string, 0, len(delta.Renamed))
+	for oldKey := range delta.Renamed {
+		renameOldKeys = append(renameOldKeys, oldKey)
+	}
+	sort.Strings(renameOldKeys)
+
+	renameSources := make(map[string]bool, len(delta.Renamed))
+	renameTargets := make(map[string]string, len(delta.Renamed)) // newKey -> oldKey
+	for _, oldKey := range renameOldKeys {
+		newKey := delta.Renamed[oldKey]
+		renameSources[oldKey] = true
+
+		if _, ok := base.ConfigSchema[oldKey]; !ok {
+			errs = append(errs, fmt.Sprintf("Renamed schema key %q does not exist on base", oldKey))
+		}
+		if removed[oldKey] {
+			errs = append(errs, fmt.Sprintf("schema key %q cannot be both Removed and Renamed", oldKey))
+		}
+		if otherOld, ok := renameTargets[newKey]; ok {
+			errs = append(errs, fmt.Sprintf("duplicate Renamed target %q from %q and %q", newKey, otherOld, oldKey))
+		} else {
+			renameTargets[newKey] = oldKey
+		}
+	}
+
+	// Chained renames (A→B and B→C) are rejected: B would be both a source and a target.
+	for _, oldKey := range renameOldKeys {
+		newKey := delta.Renamed[oldKey]
+		if renameSources[newKey] {
+			errs = append(errs, fmt.Sprintf("chained Renamed is not supported: %q -> %q is also a Renamed source", oldKey, newKey))
+		}
+	}
+
+	// Rename into a retained base key (present after removals, not itself renamed away).
+	for _, oldKey := range renameOldKeys {
+		newKey := delta.Renamed[oldKey]
+		if _, exists := base.ConfigSchema[newKey]; !exists {
+			continue
+		}
+		if removed[newKey] || renameSources[newKey] {
+			continue
+		}
+		errs = append(errs, fmt.Sprintf("Renamed target %q collides with retained base schema key", newKey))
+	}
+
+	addedKeys := make([]string, 0, len(delta.Added))
+	for key := range delta.Added {
+		addedKeys = append(addedKeys, key)
+	}
+	sort.Strings(addedKeys)
+	for _, key := range addedKeys {
+		if removed[key] {
+			continue
+		}
+		if renameSources[key] {
+			continue
+		}
+		if _, ok := renameTargets[key]; ok {
+			errs = append(errs, fmt.Sprintf("Added schema key %q collides with Renamed target", key))
+			continue
+		}
+		if _, ok := base.ConfigSchema[key]; ok {
+			errs = append(errs, fmt.Sprintf("Added schema key %q already exists on base", key))
+		}
+	}
+
+	namedProps := make(map[string]bool)
+	for _, p := range base.Properties {
+		if p.Name != "" {
+			namedProps[p.Name] = true
+		}
+	}
+	removedPropNames := append([]string(nil), delta.RemovedProperties...)
+	sort.Strings(removedPropNames)
+	seenProp := make(map[string]bool, len(removedPropNames))
+	for _, name := range removedPropNames {
+		if seenProp[name] {
+			continue
+		}
+		seenProp[name] = true
+		if !namedProps[name] {
+			errs = append(errs, fmt.Sprintf("RemovedProperties name %q does not match a named base property", name))
+		}
+	}
+
+	if len(errs) == 0 {
+		return
+	}
+	sort.Strings(errs)
+	panic(fmt.Errorf("invalid ComposeConfigMeta delta: %s", strings.Join(errs, "; ")))
 }

--- a/rudderstack/integrations/destinations/compose.go
+++ b/rudderstack/integrations/destinations/compose.go
@@ -1,0 +1,88 @@
+package destinations
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+)
+
+// Delta describes how a new destination version's ConfigMeta differs from a
+// base ConfigMeta (typically v1). It's consumed by ComposeConfigMeta, which
+// clones the base and applies the delta, so a new version isn't a full
+// copy-paste of the base's schema.
+type Delta struct {
+	// Renamed maps an existing ConfigSchema key to its new key. The
+	// *schema.Schema value is carried over unchanged under the new key.
+	Renamed map[string]string
+	// Added introduces new top-level ConfigSchema fields.
+	Added map[string]*schema.Schema
+	// Removed drops existing ConfigSchema keys (and, if present, their renamed
+	// equivalents are unaffected — Removed is matched against the base's
+	// original keys, applied before Renamed... see ComposeConfigMeta ordering).
+	Removed []string
+
+	// AddedProperties is appended to the cloned Properties slice.
+	AddedProperties []c.ConfigProperty
+	// RemovedProperties drops entries from the cloned Properties slice whose
+	// ConfigProperty.Name matches. ConfigProperty has no identity beyond an
+	// optional Name (see configs.ConfigProperty): properties built by today's
+	// constructors (Simple, Conditional, ArrayWithObjects, ...) don't set
+	// Name, so they can't be targeted for removal until the base explicitly
+	// tags them with a Name.
+	RemovedProperties []string
+}
+
+// ComposeConfigMeta builds a new version's ConfigMeta from a base ConfigMeta
+// (typically v1) and a Delta describing what changed, so a new version isn't a
+// full copy-paste of the base's schema. version is stamped onto the result.
+//
+// The clone is shallow: ConfigSchema and Properties get new backing map/slice,
+// but *schema.Schema values for keys that are neither renamed, removed, nor
+// added are shared pointers with base. Callers must not mutate a *schema.Schema
+// obtained from base.ConfigSchema in place (e.g. flipping Required/Optional on
+// a renamed field) — build a new *schema.Schema and put it in delta.Added (or
+// Renamed + a follow-up overwrite) instead. Mutating a shared *schema.Schema
+// in place would leak the change back into base's ConfigMeta.
+func ComposeConfigMeta(base c.ConfigMeta, delta Delta, version int) c.ConfigMeta {
+	schemaClone := make(map[string]*schema.Schema, len(base.ConfigSchema)+len(delta.Added))
+	for k, v := range base.ConfigSchema {
+		schemaClone[k] = v
+	}
+
+	for _, key := range delta.Removed {
+		delete(schemaClone, key)
+	}
+	for oldKey, newKey := range delta.Renamed {
+		if s, ok := schemaClone[oldKey]; ok {
+			delete(schemaClone, oldKey)
+			schemaClone[newKey] = s
+		}
+	}
+	for key, s := range delta.Added {
+		schemaClone[key] = s
+	}
+
+	removedProps := make(map[string]bool, len(delta.RemovedProperties))
+	for _, name := range delta.RemovedProperties {
+		removedProps[name] = true
+	}
+
+	propsClone := make([]c.ConfigProperty, 0, len(base.Properties)+len(delta.AddedProperties))
+	for _, p := range base.Properties {
+		if p.Name != "" && removedProps[p.Name] {
+			continue
+		}
+		propsClone = append(propsClone, p)
+	}
+	propsClone = append(propsClone, delta.AddedProperties...)
+
+	return c.ConfigMeta{
+		APIType:        base.APIType,
+		Version:        version,
+		SkipConfig:     base.SkipConfig,
+		ConfigSchema:   schemaClone,
+		Properties:     propsClone,
+		SettingsSchema: base.SettingsSchema,
+		Settings:       base.Settings,
+	}
+}

--- a/rudderstack/integrations/destinations/compose_test.go
+++ b/rudderstack/integrations/destinations/compose_test.go
@@ -110,7 +110,8 @@ func TestComposeConfigMeta_AddsAndRemovesProperties(t *testing.T) {
 func TestComposeConfigMeta_PropertiesWithoutNameCannotBeRemoved(t *testing.T) {
 	// Known limitation (documented on Delta.RemovedProperties): properties
 	// built by today's constructors (Simple, Conditional, ...) don't set
-	// Name, so RemovedProperties can't target them.
+	// Name, so RemovedProperties can't target them. Targeting a missing Name
+	// is a hard validation error rather than a silent no-op.
 	base := c.ConfigMeta{
 		APIType: "BASE_TYPE",
 		Version: 1,
@@ -119,11 +120,106 @@ func TestComposeConfigMeta_PropertiesWithoutNameCannotBeRemoved(t *testing.T) {
 		},
 	}
 
-	v2 := ComposeConfigMeta(base, Delta{
-		RemovedProperties: []string{"unnamedField"},
-	}, 2)
+	assert.Panics(t, func() {
+		ComposeConfigMeta(base, Delta{
+			RemovedProperties: []string{"unnamedField"},
+		}, 2)
+	})
 
-	assert.Len(t, v2.Properties, 1, "property without a Name is not removable and must be carried over unchanged")
+	v2 := ComposeConfigMeta(base, Delta{}, 2)
+	assert.Len(t, v2.Properties, 1)
+}
+
+func TestComposeConfigMeta_InvalidDeltaPanics(t *testing.T) {
+	base := baseConfigMetaForComposeTest()
+
+	tests := []struct {
+		name  string
+		delta Delta
+		msg   string
+	}{
+		{
+			name:  "unknown removed key",
+			delta: Delta{Removed: []string{"missing_field"}},
+			msg:   `Removed schema key "missing_field" does not exist on base`,
+		},
+		{
+			name:  "unknown renamed key",
+			delta: Delta{Renamed: map[string]string{"missing_field": "x"}},
+			msg:   `Renamed schema key "missing_field" does not exist on base`,
+		},
+		{
+			name: "removed and renamed overlap",
+			delta: Delta{
+				Removed: []string{"renamed_field"},
+				Renamed: map[string]string{"renamed_field": "renamed_field_v2"},
+			},
+			msg: `schema key "renamed_field" cannot be both Removed and Renamed`,
+		},
+		{
+			name: "chained renames",
+			delta: Delta{
+				Renamed: map[string]string{
+					"kept_field":    "renamed_field",
+					"renamed_field": "renamed_field_v2",
+				},
+			},
+			msg: "chained Renamed is not supported",
+		},
+		{
+			name: "duplicate rename targets",
+			delta: Delta{
+				Renamed: map[string]string{
+					"kept_field":    "shared_target",
+					"renamed_field": "shared_target",
+				},
+			},
+			msg: `duplicate Renamed target "shared_target"`,
+		},
+		{
+			name: "rename into retained key",
+			delta: Delta{
+				Renamed: map[string]string{"renamed_field": "kept_field"},
+			},
+			msg: `Renamed target "kept_field" collides with retained base schema key`,
+		},
+		{
+			name: "added key already exists",
+			delta: Delta{
+				Added: map[string]*schema.Schema{
+					"kept_field": {Type: schema.TypeBool, Optional: true},
+				},
+			},
+			msg: `Added schema key "kept_field" already exists on base`,
+		},
+		{
+			name: "added key collides with rename target",
+			delta: Delta{
+				Renamed: map[string]string{"renamed_field": "renamed_field_v2"},
+				Added: map[string]*schema.Schema{
+					"renamed_field_v2": {Type: schema.TypeBool, Optional: true},
+				},
+			},
+			msg: `Added schema key "renamed_field_v2" collides with Renamed target`,
+		},
+		{
+			name:  "unknown removed property",
+			delta: Delta{RemovedProperties: []string{"no_such_prop"}},
+			msg:   `RemovedProperties name "no_such_prop" does not match a named base property`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var panicked any
+			func() {
+				defer func() { panicked = recover() }()
+				ComposeConfigMeta(base, tt.delta, 2)
+			}()
+			require.NotNil(t, panicked, "expected panic")
+			assert.Contains(t, fmtPanic(panicked), tt.msg)
+		})
+	}
 }
 
 func TestAllRegisteredDestinationsHaveExplicitVersion(t *testing.T) {
@@ -154,4 +250,15 @@ func propertyNames(props []c.ConfigProperty) []string {
 		}
 	}
 	return names
+}
+
+func fmtPanic(p any) string {
+	switch v := p.(type) {
+	case error:
+		return v.Error()
+	case string:
+		return v
+	default:
+		return ""
+	}
 }

--- a/rudderstack/integrations/destinations/compose_test.go
+++ b/rudderstack/integrations/destinations/compose_test.go
@@ -1,0 +1,157 @@
+package destinations
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	c "github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+)
+
+func baseConfigMetaForComposeTest() c.ConfigMeta {
+	return c.ConfigMeta{
+		APIType: "BASE_TYPE",
+		Version: 1,
+		ConfigSchema: map[string]*schema.Schema{
+			"kept_field":    {Type: schema.TypeString, Optional: true},
+			"renamed_field": {Type: schema.TypeString, Optional: true},
+			"removed_field": {Type: schema.TypeString, Optional: true},
+		},
+		Properties: []c.ConfigProperty{
+			c.Simple("keptField", "kept_field"),
+		},
+	}
+}
+
+func TestComposeConfigMeta_SetsVersionAndAPIType(t *testing.T) {
+	base := baseConfigMetaForComposeTest()
+
+	v2 := ComposeConfigMeta(base, Delta{}, 2)
+
+	assert.Equal(t, base.APIType, v2.APIType)
+	assert.Equal(t, 2, v2.Version)
+	assert.Equal(t, 1, base.Version, "base.Version must be untouched")
+}
+
+func TestComposeConfigMeta_AddsRenamesAndRemovesSchemaFields(t *testing.T) {
+	base := baseConfigMetaForComposeTest()
+
+	v2 := ComposeConfigMeta(base, Delta{
+		Renamed: map[string]string{"renamed_field": "renamed_field_v2"},
+		Removed: []string{"removed_field"},
+		Added: map[string]*schema.Schema{
+			"new_field": {Type: schema.TypeBool, Optional: true},
+		},
+	}, 2)
+
+	require.Contains(t, v2.ConfigSchema, "kept_field")
+	require.Contains(t, v2.ConfigSchema, "renamed_field_v2")
+	require.Contains(t, v2.ConfigSchema, "new_field")
+	assert.NotContains(t, v2.ConfigSchema, "renamed_field")
+	assert.NotContains(t, v2.ConfigSchema, "removed_field")
+
+	// base must be entirely unaffected by composing v2.
+	require.Contains(t, base.ConfigSchema, "renamed_field")
+	require.Contains(t, base.ConfigSchema, "removed_field")
+	assert.NotContains(t, base.ConfigSchema, "renamed_field_v2")
+	assert.NotContains(t, base.ConfigSchema, "new_field")
+	assert.Len(t, base.ConfigSchema, 3)
+}
+
+func TestComposeConfigMeta_RenamedFieldKeepsSameSchemaPointer(t *testing.T) {
+	base := baseConfigMetaForComposeTest()
+	originalSchema := base.ConfigSchema["renamed_field"]
+
+	v2 := ComposeConfigMeta(base, Delta{
+		Renamed: map[string]string{"renamed_field": "renamed_field_v2"},
+	}, 2)
+
+	assert.Same(t, originalSchema, v2.ConfigSchema["renamed_field_v2"])
+}
+
+func TestComposeConfigMeta_UnrelatedFieldsShareSchemaPointerWithBase(t *testing.T) {
+	// Documents the shallow-copy contract: fields untouched by the delta are
+	// the *same* *schema.Schema pointer as base's. Callers must not mutate
+	// v2.ConfigSchema["kept_field"] in place.
+	base := baseConfigMetaForComposeTest()
+
+	v2 := ComposeConfigMeta(base, Delta{}, 2)
+
+	assert.Same(t, base.ConfigSchema["kept_field"], v2.ConfigSchema["kept_field"])
+}
+
+func TestComposeConfigMeta_AddsAndRemovesProperties(t *testing.T) {
+	base := c.ConfigMeta{
+		APIType: "BASE_TYPE",
+		Version: 1,
+		Properties: []c.ConfigProperty{
+			namedProperty("keep_me", c.Simple("keptField", "kept_field")),
+			namedProperty("drop_me", c.Simple("droppedField", "dropped_field")),
+		},
+	}
+
+	added := c.Simple("newField", "new_field")
+	v2 := ComposeConfigMeta(base, Delta{
+		AddedProperties:   []c.ConfigProperty{added},
+		RemovedProperties: []string{"drop_me"},
+	}, 2)
+
+	assert.Len(t, v2.Properties, 2)
+	names := propertyNames(v2.Properties)
+	assert.Contains(t, names, "keep_me")
+	assert.NotContains(t, names, "drop_me")
+
+	// base is untouched.
+	assert.Len(t, base.Properties, 2)
+}
+
+func TestComposeConfigMeta_PropertiesWithoutNameCannotBeRemoved(t *testing.T) {
+	// Known limitation (documented on Delta.RemovedProperties): properties
+	// built by today's constructors (Simple, Conditional, ...) don't set
+	// Name, so RemovedProperties can't target them.
+	base := c.ConfigMeta{
+		APIType: "BASE_TYPE",
+		Version: 1,
+		Properties: []c.ConfigProperty{
+			c.Simple("unnamedField", "unnamed_field"),
+		},
+	}
+
+	v2 := ComposeConfigMeta(base, Delta{
+		RemovedProperties: []string{"unnamedField"},
+	}, 2)
+
+	assert.Len(t, v2.Properties, 1, "property without a Name is not removable and must be carried over unchanged")
+}
+
+func TestAllRegisteredDestinationsHaveExplicitVersion(t *testing.T) {
+	// Fleet-wide backfill verification (see the story's Open Items): every
+	// destination registered via this package's init() functions must carry a
+	// non-zero Version. Register itself already enforces this (it panics
+	// during init() otherwise, which would fail the whole test binary), so
+	// this test mostly documents and locks in the invariant; it also gives a
+	// single readable assertion point if that guard is ever relaxed.
+	entries := c.Destinations.Entries()
+	require.NotEmpty(t, entries, "expected destinations to have registered via init()")
+
+	for name, cm := range entries {
+		assert.NotZero(t, cm.Version, "destination '%s' must have a non-zero Version", name)
+	}
+}
+
+func namedProperty(name string, p c.ConfigProperty) c.ConfigProperty {
+	p.Name = name
+	return p
+}
+
+func propertyNames(props []c.ConfigProperty) []string {
+	names := make([]string, 0, len(props))
+	for _, p := range props {
+		if p.Name != "" {
+			names = append(names, p.Name)
+		}
+	}
+	return names
+}

--- a/rudderstack/integrations/destinations/destination_active_campaign.go
+++ b/rudderstack/integrations/destinations/destination_active_campaign.go
@@ -53,6 +53,7 @@ func init() {
 
 	c.Destinations.Register("active_campaign", c.ConfigMeta{
 		APIType:      "ACTIVE_CAMPAIGN",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_adjust.go
+++ b/rudderstack/integrations/destinations/destination_adjust.go
@@ -225,6 +225,7 @@ func init() {
 
 	c.Destinations.Register("adjust", c.ConfigMeta{
 		APIType:      "ADJ",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_adobe_analytics.go
+++ b/rudderstack/integrations/destinations/destination_adobe_analytics.go
@@ -594,6 +594,7 @@ func init() {
 
 	c.Destinations.Register("adobe_analytics", c.ConfigMeta{
 		APIType:      "ADOBE_ANALYTICS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_amplitude.go
+++ b/rudderstack/integrations/destinations/destination_amplitude.go
@@ -503,6 +503,7 @@ func init() {
 
 	c.Destinations.Register("amplitude", c.ConfigMeta{
 		APIType:      "AM",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_attentive_tag.go
+++ b/rudderstack/integrations/destinations/destination_attentive_tag.go
@@ -134,6 +134,7 @@ func init() {
 
 	c.Destinations.Register("attentive_tag", c.ConfigMeta{
 		APIType:      "ATTENTIVE_TAG",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_bigquery.go
+++ b/rudderstack/integrations/destinations/destination_bigquery.go
@@ -260,6 +260,7 @@ func init() {
 
 	c.Destinations.Register("bigquery", c.ConfigMeta{
 		APIType:      "BQ",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_bqstream.go
+++ b/rudderstack/integrations/destinations/destination_bqstream.go
@@ -144,6 +144,7 @@ func init() {
 
 	c.Destinations.Register("bqstream", c.ConfigMeta{
 		APIType:      "BQSTREAM",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_braze.go
+++ b/rudderstack/integrations/destinations/destination_braze.go
@@ -261,6 +261,7 @@ func init() {
 
 	c.Destinations.Register("braze", c.ConfigMeta{
 		APIType:      "BRAZE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_confluent_cloud.go
+++ b/rudderstack/integrations/destinations/destination_confluent_cloud.go
@@ -142,6 +142,7 @@ func init() {
 
 	c.Destinations.Register("confluent_cloud", c.ConfigMeta{
 		APIType:      "CONFLUENT_CLOUD",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: destinationSchema,
 	})

--- a/rudderstack/integrations/destinations/destination_customerio.go
+++ b/rudderstack/integrations/destinations/destination_customerio.go
@@ -194,6 +194,7 @@ func init() {
 
 	c.Destinations.Register("customerio", c.ConfigMeta{
 		APIType:      "CUSTOMERIO",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_customerio_audience.go
+++ b/rudderstack/integrations/destinations/destination_customerio_audience.go
@@ -70,6 +70,7 @@ func init() {
 
 	c.Destinations.Register("customerio_audience", c.ConfigMeta{
 		APIType:      "CUSTOMERIO_AUDIENCE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: s,
 	})

--- a/rudderstack/integrations/destinations/destination_facebook_conversions.go
+++ b/rudderstack/integrations/destinations/destination_facebook_conversions.go
@@ -140,6 +140,7 @@ func init() {
 
 	c.Destinations.Register("facebook_conversions", c.ConfigMeta{
 		APIType:      "FACEBOOK_CONVERSIONS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_facebook_pixel.go
+++ b/rudderstack/integrations/destinations/destination_facebook_pixel.go
@@ -204,6 +204,7 @@ func init() {
 
 	c.Destinations.Register("facebook_pixel", c.ConfigMeta{
 		APIType:      "FACEBOOK_PIXEL",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_firebase.go
+++ b/rudderstack/integrations/destinations/destination_firebase.go
@@ -111,6 +111,7 @@ func init() {
 
 	c.Destinations.Register("firebase", c.ConfigMeta{
 		APIType:      "FIREBASE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_gcs.go
+++ b/rudderstack/integrations/destinations/destination_gcs.go
@@ -46,6 +46,7 @@ func init() {
 
 	c.Destinations.Register("gcs", c.ConfigMeta{
 		APIType:      "GCS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_google_ads.go
+++ b/rudderstack/integrations/destinations/destination_google_ads.go
@@ -174,6 +174,7 @@ func init() {
 
 	c.Destinations.Register("google_ads", c.ConfigMeta{
 		APIType:      "GOOGLEADS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_google_analytics.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics.go
@@ -352,6 +352,7 @@ func init() {
 
 	c.Destinations.Register("google_analytics", c.ConfigMeta{
 		APIType:      "GA",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_google_analytics4.go
+++ b/rudderstack/integrations/destinations/destination_google_analytics4.go
@@ -218,6 +218,7 @@ func init() {
 
 	c.Destinations.Register("google_analytics4", c.ConfigMeta{
 		APIType:      "GA4",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_google_pubsub.go
+++ b/rudderstack/integrations/destinations/destination_google_pubsub.go
@@ -175,6 +175,7 @@ func init() {
 
 	c.Destinations.Register("google_pubsub", c.ConfigMeta{
 		APIType:      "GOOGLEPUBSUB",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_google_sheets.go
+++ b/rudderstack/integrations/destinations/destination_google_sheets.go
@@ -65,6 +65,7 @@ func init() {
 
 	c.Destinations.Register("google_sheets", c.ConfigMeta{
 		APIType:      "GOOGLESHEETS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_google_tag_manager.go
+++ b/rudderstack/integrations/destinations/destination_google_tag_manager.go
@@ -87,6 +87,7 @@ func init() {
 
 	c.Destinations.Register("google_tag_manager", c.ConfigMeta{
 		APIType:      "GTM",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_hs.go
+++ b/rudderstack/integrations/destinations/destination_hs.go
@@ -256,6 +256,7 @@ func init() {
 
 	c.Destinations.Register("hs", c.ConfigMeta{
 		APIType:      "HS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: destinationSchema,
 	})

--- a/rudderstack/integrations/destinations/destination_http.go
+++ b/rudderstack/integrations/destinations/destination_http.go
@@ -345,6 +345,7 @@ func init() {
 
 	c.Destinations.Register("http", c.ConfigMeta{
 		APIType:      "HTTP",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_intercom.go
+++ b/rudderstack/integrations/destinations/destination_intercom.go
@@ -130,6 +130,7 @@ func init() {
 
 	c.Destinations.Register("intercom", c.ConfigMeta{
 		APIType:      "INTERCOM",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_iterable.go
+++ b/rudderstack/integrations/destinations/destination_iterable.go
@@ -382,6 +382,7 @@ func init() {
 
 	c.Destinations.Register("iterable", c.ConfigMeta{
 		APIType:      "ITERABLE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_kafka.go
+++ b/rudderstack/integrations/destinations/destination_kafka.go
@@ -175,6 +175,7 @@ func init() {
 
 	c.Destinations.Register("kafka", c.ConfigMeta{
 		APIType:      "KAFKA",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_kinesis.go
+++ b/rudderstack/integrations/destinations/destination_kinesis.go
@@ -92,6 +92,7 @@ func init() {
 
 	c.Destinations.Register("kinesis", c.ConfigMeta{
 		APIType:      "KINESIS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_linkedin_ads.go
+++ b/rudderstack/integrations/destinations/destination_linkedin_ads.go
@@ -163,6 +163,7 @@ func init() {
 
 	c.Destinations.Register("linkedin_ads", c.ConfigMeta{
 		APIType:      "LINKEDIN_ADS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_linkedin_insight_tag.go
+++ b/rudderstack/integrations/destinations/destination_linkedin_insight_tag.go
@@ -103,6 +103,7 @@ func init() {
 
 	c.Destinations.Register("LINKEDIN_INSIGHT_TAG", c.ConfigMeta{
 		APIType:      "LINKEDIN_INSIGHT_TAG",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_marketo.go
+++ b/rudderstack/integrations/destinations/destination_marketo.go
@@ -217,6 +217,7 @@ func init() {
 
 	c.Destinations.Register("marketo", c.ConfigMeta{
 		APIType:      "MARKETO",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_mixpanel.go
+++ b/rudderstack/integrations/destinations/destination_mixpanel.go
@@ -416,6 +416,7 @@ func init() {
 
 	c.Destinations.Register("mixpanel", c.ConfigMeta{
 		APIType:      "MP",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_postgres.go
+++ b/rudderstack/integrations/destinations/destination_postgres.go
@@ -121,6 +121,7 @@ func init() {
 
 	c.Destinations.Register("postgres", c.ConfigMeta{
 		APIType:      "POSTGRES",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_posthog.go
+++ b/rudderstack/integrations/destinations/destination_posthog.go
@@ -325,6 +325,7 @@ func init() {
 
 	c.Destinations.Register("posthog", c.ConfigMeta{
 		APIType:      "POSTHOG",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_qualtrics.go
+++ b/rudderstack/integrations/destinations/destination_qualtrics.go
@@ -103,6 +103,7 @@ func init() {
 
 	c.Destinations.Register("qualtrics", c.ConfigMeta{
 		APIType:      "QUALTRICS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_redis.go
+++ b/rudderstack/integrations/destinations/destination_redis.go
@@ -78,6 +78,7 @@ func init() {
 
 	c.Destinations.Register("redis", c.ConfigMeta{
 		APIType:      "REDIS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_redshift.go
+++ b/rudderstack/integrations/destinations/destination_redshift.go
@@ -152,6 +152,7 @@ func init() {
 
 	c.Destinations.Register("redshift", c.ConfigMeta{
 		APIType:      "RS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_s3.go
+++ b/rudderstack/integrations/destinations/destination_s3.go
@@ -59,6 +59,7 @@ func init() {
 
 	c.Destinations.Register("s3", c.ConfigMeta{
 		APIType:      "S3",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_s3_datalake.go
+++ b/rudderstack/integrations/destinations/destination_s3_datalake.go
@@ -129,6 +129,7 @@ func init() {
 
 	c.Destinations.Register("s3_datalake", c.ConfigMeta{
 		APIType:      "S3_DATALAKE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_salesforce.go
+++ b/rudderstack/integrations/destinations/destination_salesforce.go
@@ -66,6 +66,7 @@ func init() {
 
 	c.Destinations.Register("salesforce", c.ConfigMeta{
 		APIType:      "SALESFORCE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_sentry.go
+++ b/rudderstack/integrations/destinations/destination_sentry.go
@@ -153,6 +153,7 @@ func init() {
 
 	c.Destinations.Register("sentry", c.ConfigMeta{
 		APIType:      "SENTRY",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_slack.go
+++ b/rudderstack/integrations/destinations/destination_slack.go
@@ -107,6 +107,7 @@ func init() {
 
 	c.Destinations.Register("slack", c.ConfigMeta{
 		APIType:      "SLACK",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_snowflake.go
+++ b/rudderstack/integrations/destinations/destination_snowflake.go
@@ -441,6 +441,7 @@ func init() {
 
 	c.Destinations.Register("snowflake", c.ConfigMeta{
 		APIType:      "SNOWFLAKE",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_snowflake_streaming.go
+++ b/rudderstack/integrations/destinations/destination_snowflake_streaming.go
@@ -216,6 +216,7 @@ func init() {
 
 	c.Destinations.Register("snowflake_streaming", c.ConfigMeta{
 		APIType:      "SNOWPIPE_STREAMING",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_statsig.go
+++ b/rudderstack/integrations/destinations/destination_statsig.go
@@ -120,6 +120,7 @@ func init() {
 
 	c.Destinations.Register("statsig", c.ConfigMeta{
 		APIType:      "STATSIG",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_tiktok_ads.go
+++ b/rudderstack/integrations/destinations/destination_tiktok_ads.go
@@ -222,6 +222,7 @@ func init() {
 
 	c.Destinations.Register("tiktok_ads", c.ConfigMeta{
 		APIType:      "TIKTOK_ADS",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_vwo.go
+++ b/rudderstack/integrations/destinations/destination_vwo.go
@@ -118,6 +118,7 @@ func init() {
 
 	c.Destinations.Register("vwo", c.ConfigMeta{
 		APIType:      "VWO",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_webhook.go
+++ b/rudderstack/integrations/destinations/destination_webhook.go
@@ -60,6 +60,7 @@ func init() {
 
 	c.Destinations.Register("webhook", c.ConfigMeta{
 		APIType:      "WEBHOOK",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/integrations/destinations/destination_zendesk.go
+++ b/rudderstack/integrations/destinations/destination_zendesk.go
@@ -70,6 +70,7 @@ func init() {
 
 	c.Destinations.Register("zendesk", c.ConfigMeta{
 		APIType:      "ZENDESK",
+		Version:      1,
 		Properties:   properties,
 		ConfigSchema: schema,
 	})

--- a/rudderstack/resource_destination.go
+++ b/rudderstack/resource_destination.go
@@ -203,6 +203,7 @@ func resourceDestinationImportState(cm configs.ConfigMeta) schema.StateContextFu
 func populateDestinationFromState(cm configs.ConfigMeta, destination *client.Destination, d *schema.ResourceData) error {
 	destination.ID = d.Id()
 	destination.Type = cm.APIType
+	destination.Version = cm.Version
 	destination.Name = d.Get("name").(string)
 	destination.IsEnabled = d.Get("enabled").(bool)
 

--- a/rudderstack/resource_destination_test.go
+++ b/rudderstack/resource_destination_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/rudderlabs/rudder-iac/api/client"
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
 	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/integrations/destinations"
 )
@@ -216,4 +219,46 @@ func TestResourceDestinationConsentManagementAllowsDistinctAndPerSourceType(t *t
 			},
 		},
 	})
+}
+
+func TestPopulateDestinationFromState_SetsVersionFromConfigMeta(t *testing.T) {
+	cm := configs.ConfigMeta{
+		APIType:    "TEST",
+		Version:    2,
+		SkipConfig: true,
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceDestinationSchema(cm), map[string]interface{}{
+		"name":    "test-destination",
+		"enabled": true,
+	})
+
+	destination := &client.Destination{}
+	require.NoError(t, populateDestinationFromState(cm, destination, d))
+
+	assert.Equal(t, "TEST", destination.Type)
+	assert.Equal(t, 2, destination.Version)
+}
+
+func TestPopulateDestinationFromState_NoVersionSetsZero(t *testing.T) {
+	// A destination registered without an explicit Version can't actually
+	// exist in the real Destinations registry (Register panics on Version==0,
+	// see rudderstack/configs/registries.go), but populateDestinationFromState
+	// itself has no opinion on that — it just forwards cm.Version verbatim.
+	// This documents that behavior for a directly-constructed ConfigMeta, as
+	// used by other tests in this file (e.g. consent-management tests above).
+	cm := configs.ConfigMeta{
+		APIType:    "TEST",
+		SkipConfig: true,
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceDestinationSchema(cm), map[string]interface{}{
+		"name":    "test-destination",
+		"enabled": true,
+	})
+
+	destination := &client.Destination{}
+	require.NoError(t, populateDestinationFromState(cm, destination, d))
+
+	assert.Equal(t, 0, destination.Version)
 }


### PR DESCRIPTION
## Summary

- Add `ConfigMeta.Version` and populate `destination.Version` on create/update so the provider sends explicit `version: 1` for the existing destination fleet without adding a Terraform state field.
- Fix `generatetf` to resolve destinations by `(apiType, version)` via new `configMetaByVersion`, with registry guards that require explicit versions and reject duplicate `(apiType, version)` pairs.
- Backfill `Version: 1` across all 47 bare destination registrations and scaffold `ComposeConfigMeta` for future v2+ schema composition.
- Pin `rudder-iac` to the merge commit from PR #625 that adds `client.Destination.Version`.

## Test plan

- [x] `go test ./...` passes locally
- [x] Unit tests for `configMetaByVersion`, registry guards, `populateDestinationFromState`, and `ComposeConfigMeta`
- [x] Fleet-wide check that all registered destinations have `Version != 0`
- [ ] Env-gated acceptance test (`TF_ACC=1`, `RUDDERSTACK_ACCESS_TOKEN`) verifies braze sends `version: 1` on the wire — requires INT-6489 backend rollout (Blocker B)

## References

- Linear: [INT-6494](https://linear.app/rudderstack/issue/INT-6494/terraform-provider-rudderstack-codegen-resolve-by-apitype-version)
- Depends on: [INT-6489](https://linear.app/rudderstack/issue/INT-6489/public-api-contract-version-on-rudder-api-dtos-migrate-proxy-and) (rudder-iac client + backend wire guarantee)

Made with [Cursor](https://cursor.com)