### PR TITLE
feat(amplitude): add Browser SDK v2 auto_capture fields

### DIFF
--- a/docs/resources/destination_amplitude.md
+++ b/docs/resources/destination_amplitude.md
@@ -12,6 +12,8 @@ https://www.rudderstack.com/docs/destinations/analytics/amplitude
 
 Omit the `sdk_version` block to keep existing Amplitude behavior (version `1`), or set `sdk_version.web` to `2` to opt into version 2. The provider sets no Terraform default — version `1` is applied by the control plane when the field is absent.
 
+When using Amplitude Browser SDK v2, the web-only AutoCapture sub-feature blocks (`page_views`, `page_url_enrichment`, `web_vitals`, `file_downloads`, `frustration_interactions`, `network_tracking`, `element_interactions`, and `form_interactions`) inside the `auto_capture` block expose the corresponding Browser SDK v2 controls. Omit these blocks to preserve existing control-plane defaults.
+
 ## Example Usage
 
 ```terraform
@@ -44,6 +46,7 @@ resource "rudderstack_destination_amplitude" "example" {
     # }
 
     # track_session_events {
+    #   web          = true
     #   android      = true
     #   ios          = true
     #   react_native = true
@@ -82,6 +85,40 @@ resource "rudderstack_destination_amplitude" "example" {
 
     # batch_events {
     #   web = true
+    # }
+
+    # auto_capture {
+    #   page_views {
+    #     web = true
+    #   }
+
+    #   page_url_enrichment {
+    #     web = true
+    #   }
+
+    #   web_vitals {
+    #     web = true
+    #   }
+
+    #   file_downloads {
+    #     web = true
+    #   }
+
+    #   frustration_interactions {
+    #     web = true
+    #   }
+
+    #   network_tracking {
+    #     web = true
+    #   }
+
+    #   element_interactions {
+    #     web = true
+    #   }
+
+    #   form_interactions {
+    #     web = true
+    #   }
     # }
 
     # map_device_brand = true
@@ -248,6 +285,7 @@ Required:
 Optional:
 
 - `api_secret` (String, Sensitive) Enter the Amplitude API Secret key required for user deletion.
+- `auto_capture` (Block List, Max: 1) Configure the AutoCapture settings of Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture))
 - `batch_events` (Block List, Max: 1) If this setting is enabled, the events are batched together and uploaded by the Amplitude SDK. (see [below for nested schema](#nestedblock--config--batch_events))
 - `consent_management` (Block List, Max: 1) Allows you to specify consent configuration data for multiple providers for each source type. (see [below for nested schema](#nestedblock--config--consent_management))
 - `device_id_from_url_param` (Block List, Max: 1) If this setting is enabled, the Amplitude SDK will parse the URL parameter and set the device ID from `amp_device_id`. (see [below for nested schema](#nestedblock--config--device_id_from_url_param))
@@ -281,6 +319,85 @@ Optional:
 - `use_idfa_as_device_id` (Block List, Max: 1) Enable this setting to set the IDFA as the device ID. (see [below for nested schema](#nestedblock--config--use_idfa_as_device_id))
 - `use_native_sdk` (Block List, Max: 1) Enable this setting to send events to Amplitude via the device mode. (see [below for nested schema](#nestedblock--config--use_native_sdk))
 - `version_name` (String) The value of this field is set as the `versionName` of the Amplitude SDK.
+
+<a id="nestedblock--config--auto_capture"></a>
+### Nested Schema for `config.auto_capture`
+
+Optional:
+
+- `element_interactions` (Block List, Max: 1) Enable this setting to capture element interactions automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--element_interactions))
+- `file_downloads` (Block List, Max: 1) Enable this setting to capture file downloads automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--file_downloads))
+- `form_interactions` (Block List, Max: 1) Enable this setting to capture form interactions automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--form_interactions))
+- `frustration_interactions` (Block List, Max: 1) Enable this setting to capture frustration interactions automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--frustration_interactions))
+- `network_tracking` (Block List, Max: 1) Enable this setting to capture network requests automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--network_tracking))
+- `page_url_enrichment` (Block List, Max: 1) Enable this setting to enrich page view events with URL properties using Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--page_url_enrichment))
+- `page_views` (Block List, Max: 1) Enable this setting to track page views automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--page_views))
+- `web_vitals` (Block List, Max: 1) Enable this setting to capture web vitals automatically with Amplitude Browser SDK v2 for web sources. (see [below for nested schema](#nestedblock--config--auto_capture--web_vitals))
+
+<a id="nestedblock--config--auto_capture--element_interactions"></a>
+### Nested Schema for `config.auto_capture.element_interactions`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--file_downloads"></a>
+### Nested Schema for `config.auto_capture.file_downloads`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--form_interactions"></a>
+### Nested Schema for `config.auto_capture.form_interactions`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--frustration_interactions"></a>
+### Nested Schema for `config.auto_capture.frustration_interactions`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--network_tracking"></a>
+### Nested Schema for `config.auto_capture.network_tracking`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--page_url_enrichment"></a>
+### Nested Schema for `config.auto_capture.page_url_enrichment`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--page_views"></a>
+### Nested Schema for `config.auto_capture.page_views`
+
+Optional:
+
+- `web` (Boolean)
+
+
+<a id="nestedblock--config--auto_capture--web_vitals"></a>
+### Nested Schema for `config.auto_capture.web_vitals`
+
+Optional:
+
+- `web` (Boolean)
+
+
 
 <a id="nestedblock--config--batch_events"></a>
 ### Nested Schema for `config.batch_events`
@@ -544,6 +661,7 @@ Optional:
 - `android` (Boolean)
 - `ios` (Boolean)
 - `react_native` (Boolean)
+- `web` (Boolean)
 
 
 <a id="nestedblock--config--track_utm_properties"></a>

--- a/examples/destination_amplitude.tf
+++ b/examples/destination_amplitude.tf
@@ -27,6 +27,7 @@ resource "rudderstack_destination_amplitude" "example" {
     # }
 
     # track_session_events {
+    #   web          = true
     #   android      = true
     #   ios          = true
     #   react_native = true
@@ -65,6 +66,40 @@ resource "rudderstack_destination_amplitude" "example" {
 
     # batch_events {
     #   web = true
+    # }
+
+    # auto_capture {
+    #   page_views {
+    #     web = true
+    #   }
+
+    #   page_url_enrichment {
+    #     web = true
+    #   }
+
+    #   web_vitals {
+    #     web = true
+    #   }
+
+    #   file_downloads {
+    #     web = true
+    #   }
+
+    #   frustration_interactions {
+    #     web = true
+    #   }
+
+    #   network_tracking {
+    #     web = true
+    #   }
+
+    #   element_interactions {
+    #     web = true
+    #   }
+
+    #   form_interactions {
+    #     web = true
+    #   }
     # }
 
     # map_device_brand = true

--- a/rudderstack/integrations/destinations/destination_amplitude.go
+++ b/rudderstack/integrations/destinations/destination_amplitude.go
@@ -40,6 +40,14 @@ func init() {
 		c.Simple("trackUtmProperties.web", "track_utm_properties.0.web"),
 		c.Simple("unsetParamsReferrerOnNewSession.web", "unset_params_referrer_on_new_session.0.web"),
 		c.Simple("batchEvents.web", "batch_events.0.web"),
+		c.Simple("enablePageViewsAutoCapture.web", "auto_capture.0.page_views.0.web"),
+		c.Simple("enablePageUrlEnrichmentAutoCapture.web", "auto_capture.0.page_url_enrichment.0.web"),
+		c.Simple("enableWebVitalsAutoCapture.web", "auto_capture.0.web_vitals.0.web"),
+		c.Simple("enableFileDownloadsAutoCapture.web", "auto_capture.0.file_downloads.0.web"),
+		c.Simple("enableFrustrationInteractionsAutoCapture.web", "auto_capture.0.frustration_interactions.0.web"),
+		c.Simple("enableNetworkTrackingAutoCapture.web", "auto_capture.0.network_tracking.0.web"),
+		c.Simple("enableElementInteractionsAutoCapture.web", "auto_capture.0.element_interactions.0.web"),
+		c.Simple("enableFormInteractionsAutoCapture.web", "auto_capture.0.form_interactions.0.web"),
 		c.ArrayWithStrings("whitelistedEvents", "eventName", "event_filtering.0.whitelist"),
 		c.ArrayWithStrings("blacklistedEvents", "eventName", "event_filtering.0.blacklist"),
 		c.Discriminator("eventFilteringOption", c.DiscriminatorValues{
@@ -57,6 +65,7 @@ func init() {
 		c.Simple("mapDeviceBrand", "map_device_brand", c.SkipZeroValue),
 		c.Simple("enableLocationListening.android", "enable_location_listening.0.android"),
 		c.Simple("enableLocationListening.reactnative", "enable_location_listening.0.react_native"),
+		c.Simple("trackSessionEvents.web", "track_session_events.0.web"),
 		c.Simple("trackSessionEvents.android", "track_session_events.0.android"),
 		c.Simple("trackSessionEvents.ios", "track_session_events.0.ios"),
 		c.Simple("trackSessionEvents.reactnative", "track_session_events.0.react_native"),
@@ -334,6 +343,128 @@ func init() {
 				},
 			},
 		},
+		"auto_capture": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Configure the AutoCapture settings of Amplitude Browser SDK v2 for web sources.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"page_views": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to track page views automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"page_url_enrichment": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to enrich page view events with URL properties using Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"web_vitals": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to capture web vitals automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"file_downloads": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to capture file downloads automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"frustration_interactions": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to capture frustration interactions automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"network_tracking": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to capture network requests automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"element_interactions": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to capture element interactions automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+					"form_interactions": {
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Description: "Enable this setting to capture form interactions automatically with Amplitude Browser SDK v2 for web sources.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"web": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"event_filtering": {
 			Type:        schema.TypeList,
 			MaxItems:    1,
@@ -444,6 +575,10 @@ func init() {
 			Description: "Enable this setting to track the session events.",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
+					"web": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 					"ios": {
 						Type:     schema.TypeBool,
 						Optional: true,

--- a/rudderstack/integrations/destinations/destination_amplitude_test.go
+++ b/rudderstack/integrations/destinations/destination_amplitude_test.go
@@ -47,6 +47,7 @@ var amplitudeTestConfigs = []c.TestConfig{
 				}
 			
 				track_session_events {
+				  web          = true
 				  android      = true
 				  ios          = true
 				  react_native = true
@@ -85,6 +86,40 @@ var amplitudeTestConfigs = []c.TestConfig{
 			
 				batch_events {
 				  web = true
+				}
+
+				auto_capture {
+				  page_views {
+				    web = true
+				  }
+
+				  page_url_enrichment {
+				    web = true
+				  }
+
+				  web_vitals {
+				    web = true
+				  }
+
+				  file_downloads {
+				    web = true
+				  }
+
+				  frustration_interactions {
+				    web = true
+				  }
+
+				  network_tracking {
+				    web = true
+				  }
+
+				  element_interactions {
+				    web = true
+				  }
+
+				  form_interactions {
+				    web = true
+				  }
 				}
 							
 				map_device_brand = true
@@ -258,6 +293,14 @@ var amplitudeTestConfigs = []c.TestConfig{
 				"trackUtmProperties": { "web": true },
 				"unsetParamsReferrerOnNewSession": { "web": true },
 				"batchEvents": { "web": true },
+				"enablePageViewsAutoCapture": { "web": true },
+				"enablePageUrlEnrichmentAutoCapture": { "web": true },
+				"enableWebVitalsAutoCapture": { "web": true },
+				"enableFileDownloadsAutoCapture": { "web": true },
+				"enableFrustrationInteractionsAutoCapture": { "web": true },
+				"enableNetworkTrackingAutoCapture": { "web": true },
+				"enableElementInteractionsAutoCapture": { "web": true },
+				"enableFormInteractionsAutoCapture": { "web": true },
 				"eventFilteringOption": "blacklistedEvents",
 				"blacklistedEvents": [
 				  { "eventName": "one" },
@@ -278,7 +321,7 @@ var amplitudeTestConfigs = []c.TestConfig{
 				},
 				"mapDeviceBrand": true,
 				"enableLocationListening": { "android": true, "reactnative": true },
-				"trackSessionEvents": { "android": true, "ios": true, "reactnative": true },
+				"trackSessionEvents": { "web": true, "android": true, "ios": true, "reactnative": true },
 				"useAdvertisingIdForDeviceId": { "android": true, "reactnative": true },
 				"useIdfaAsDeviceId": { "ios": true, "reactnative": true },
 				"consentManagement": {

--- a/templates/resources/destination_amplitude.md.tmpl
+++ b/templates/resources/destination_amplitude.md.tmpl
@@ -12,6 +12,8 @@ https://www.rudderstack.com/docs/destinations/analytics/amplitude
 
 Omit the `sdk_version` block to keep existing Amplitude behavior (version `1`), or set `sdk_version.web` to `2` to opt into version 2. The provider sets no Terraform default — version `1` is applied by the control plane when the field is absent.
 
+When using Amplitude Browser SDK v2, the web-only AutoCapture sub-feature blocks (`page_views`, `page_url_enrichment`, `web_vitals`, `file_downloads`, `frustration_interactions`, `network_tracking`, `element_interactions`, and `form_interactions`) inside the `auto_capture` block expose the corresponding Browser SDK v2 controls. Omit these blocks to preserve existing control-plane defaults.
+
 ## Example Usage
 
 {{tffile "examples/destination_amplitude.tf"}}


### PR DESCRIPTION
## Description of the change

Adds support for the Amplitude Browser SDK v2 AutoCapture settings to the `rudderstack_destination_amplitude` resource. A new optional `auto_capture` block groups the eight per-setting toggles, each scoped to web:

- `page_views`
- `page_url_enrichment`
- `web_vitals`
- `file_downloads`
- `frustration_interactions`
- `network_tracking`
- `element_interactions`
- `form_interactions`

Each maps to the corresponding `enable*AutoCapture.web` key in the destination config (e.g. `auto_capture.0.page_views.0.web` → `enablePageViewsAutoCapture.web`). These settings apply to web sources in device mode using the Amplitude Browser SDK v2.

Changes:
- `rudderstack/integrations/destinations/destination_amplitude.go` — new `auto_capture` schema block and config mappings
- `rudderstack/integrations/destinations/destination_amplitude_test.go` — create/update coverage for all eight toggles
- `examples/destination_amplitude.tf`, `templates/resources/destination_amplitude.md.tmpl`, `docs/resources/destination_amplitude.md` — example and regenerated docs

## What is the related Linear task?

Resolves SDK-5015

**Fixes** — no linked GitHub issue

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests for the code
- [x] I have made corresponding changes to the documentation