### PR TITLE
feat: attach a transformation to a destination via transformation_id

### DIFF
--- a/docs/resources/destination_LINKEDIN_INSIGHT_TAG.md
+++ b/docs/resources/destination_LINKEDIN_INSIGHT_TAG.md
@@ -76,6 +76,7 @@ resource "rudderstack_destination_linkedin_insight_tag" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_active_campaign.md
+++ b/docs/resources/destination_active_campaign.md
@@ -124,6 +124,7 @@ resource "rudderstack_destination_active_campaign" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_adjust.md
+++ b/docs/resources/destination_adjust.md
@@ -122,6 +122,7 @@ resource "rudderstack_destination_adjust" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_adobe_analytics.md
+++ b/docs/resources/destination_adobe_analytics.md
@@ -206,6 +206,7 @@ resource "rudderstack_destination_adobe_analytics" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_amplitude.md
+++ b/docs/resources/destination_amplitude.md
@@ -231,6 +231,7 @@ resource "rudderstack_destination_amplitude" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_attentive_tag.md
+++ b/docs/resources/destination_attentive_tag.md
@@ -127,6 +127,7 @@ resource "rudderstack_destination_attentive_tag" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_bigquery.md
+++ b/docs/resources/destination_bigquery.md
@@ -146,6 +146,7 @@ resource "rudderstack_destination_bigquery" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_bqstream.md
+++ b/docs/resources/destination_bqstream.md
@@ -102,6 +102,7 @@ resource "rudderstack_destination_bqstream" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_braze.md
+++ b/docs/resources/destination_braze.md
@@ -153,6 +153,7 @@ resource "rudderstack_destination_braze" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_confluent_cloud.md
+++ b/docs/resources/destination_confluent_cloud.md
@@ -36,6 +36,7 @@ resource "rudderstack_destination_confluent_cloud" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_customerio.md
+++ b/docs/resources/destination_customerio.md
@@ -102,6 +102,7 @@ resource "rudderstack_destination_customerio" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_customerio_audience.md
+++ b/docs/resources/destination_customerio_audience.md
@@ -40,6 +40,7 @@ resource "rudderstack_destination_customerio_audience" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_facebook_conversions.md
+++ b/docs/resources/destination_facebook_conversions.md
@@ -64,6 +64,7 @@ resource "rudderstack_destination_facebook_conversions" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_facebook_pixel.md
+++ b/docs/resources/destination_facebook_pixel.md
@@ -169,6 +169,7 @@ resource "rudderstack_destination_facebook_pixel" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_firebase.md
+++ b/docs/resources/destination_firebase.md
@@ -42,6 +42,7 @@ resource "rudderstack_destination_firebase" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_gcs.md
+++ b/docs/resources/destination_gcs.md
@@ -123,6 +123,7 @@ resource "rudderstack_destination_gcs" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_google_ads.md
+++ b/docs/resources/destination_google_ads.md
@@ -94,6 +94,7 @@ resource "rudderstack_destination_google_ads" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_google_analytics.md
+++ b/docs/resources/destination_google_analytics.md
@@ -193,6 +193,7 @@ resource "rudderstack_destination_google_analytics" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_google_analytics4.md
+++ b/docs/resources/destination_google_analytics4.md
@@ -130,6 +130,7 @@ resource "rudderstack_destination_google_analytics4" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_google_pubsub.md
+++ b/docs/resources/destination_google_pubsub.md
@@ -149,6 +149,7 @@ resource "rudderstack_destination_google_pubsub" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_google_sheets.md
+++ b/docs/resources/destination_google_sheets.md
@@ -134,6 +134,7 @@ resource "rudderstack_destination_google_sheets" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_google_tag_manager.md
+++ b/docs/resources/destination_google_tag_manager.md
@@ -72,6 +72,7 @@ resource "rudderstack_destination_google_tag_manager" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_hs.md
+++ b/docs/resources/destination_hs.md
@@ -59,6 +59,7 @@ resource "rudderstack_destination_hs" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_http.md
+++ b/docs/resources/destination_http.md
@@ -40,6 +40,7 @@ resource "rudderstack_destination_http" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_intercom.md
+++ b/docs/resources/destination_intercom.md
@@ -130,6 +130,7 @@ resource "rudderstack_destination_intercom" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_iterable.md
+++ b/docs/resources/destination_iterable.md
@@ -188,6 +188,7 @@ resource "rudderstack_destination_iterable" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_kafka.md
+++ b/docs/resources/destination_kafka.md
@@ -135,6 +135,7 @@ resource "rudderstack_destination_kafka" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_kinesis.md
+++ b/docs/resources/destination_kinesis.md
@@ -131,6 +131,7 @@ resource "rudderstack_destination_kinesis" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_linkedin_ads.md
+++ b/docs/resources/destination_linkedin_ads.md
@@ -64,6 +64,7 @@ resource "rudderstack_destination_linkedin_ads" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_marketo.md
+++ b/docs/resources/destination_marketo.md
@@ -146,6 +146,7 @@ resource "rudderstack_destination_marketo" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_mixpanel.md
+++ b/docs/resources/destination_mixpanel.md
@@ -184,6 +184,7 @@ resource "rudderstack_destination_mixpanel" example{
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_postgres.md
+++ b/docs/resources/destination_postgres.md
@@ -125,6 +125,7 @@ resource "rudderstack_destination_postgres" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_posthog.md
+++ b/docs/resources/destination_posthog.md
@@ -72,6 +72,7 @@ resource "rudderstack_destination_posthog" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_qualtrics.md
+++ b/docs/resources/destination_qualtrics.md
@@ -82,6 +82,7 @@ resource "rudderstack_destination_qualtrics" example{
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_redis.md
+++ b/docs/resources/destination_redis.md
@@ -128,6 +128,7 @@ resource "rudderstack_destination_redis" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_redshift.md
+++ b/docs/resources/destination_redshift.md
@@ -144,6 +144,7 @@ resource "rudderstack_destination_redshift" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_s3.md
+++ b/docs/resources/destination_s3.md
@@ -126,6 +126,7 @@ resource "rudderstack_destination_s3" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_s3_datalake.md
+++ b/docs/resources/destination_s3_datalake.md
@@ -140,6 +140,7 @@ resource "rudderstack_destination_s3_datalake" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_salesforce.md
+++ b/docs/resources/destination_salesforce.md
@@ -125,6 +125,7 @@ resource "rudderstack_destination_salesforce" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_sentry.md
+++ b/docs/resources/destination_sentry.md
@@ -82,6 +82,7 @@ resource "rudderstack_destination_sentry" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_slack.md
+++ b/docs/resources/destination_slack.md
@@ -141,6 +141,7 @@ resource "rudderstack_destination_slack" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_snowflake.md
+++ b/docs/resources/destination_snowflake.md
@@ -186,6 +186,7 @@ resource "rudderstack_destination_snowflake" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_snowflake_streaming.md
+++ b/docs/resources/destination_snowflake_streaming.md
@@ -70,6 +70,7 @@ EOT
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_statsig.md
+++ b/docs/resources/destination_statsig.md
@@ -123,6 +123,7 @@ resource "rudderstack_destination_statsig" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_tiktok_ads.md
+++ b/docs/resources/destination_tiktok_ads.md
@@ -34,6 +34,7 @@ resource "rudderstack_destination_tiktok_ads" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_vwo.md
+++ b/docs/resources/destination_vwo.md
@@ -79,6 +79,7 @@ resource "rudderstack_destination_vwo" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_webhook.md
+++ b/docs/resources/destination_webhook.md
@@ -133,6 +133,7 @@ resource "rudderstack_destination_webhook" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/docs/resources/destination_zendesk.md
+++ b/docs/resources/destination_zendesk.md
@@ -127,6 +127,7 @@ resource "rudderstack_destination_zendesk" "example" {
 ### Optional
 
 - `enabled` (Boolean) An enabled destination allows data to be sent to it.
+- `transformation_id` (String) ID of a published transformation to attach to this destination. The transformation must be published before it can be attached. A destination can have at most one transformation. Omit or clear the value to detach.
 
 ### Read-Only
 

--- a/examples/destination_with_transformation.tf
+++ b/examples/destination_with_transformation.tf
@@ -1,0 +1,20 @@
+# Attach a published transformation to a destination. The transformation must be
+# published before it can be attached, and a destination can have at most one.
+resource "rudderstack_destination_http" "example" {
+  name = "my-filtered-http-webhook"
+
+  config {
+    api_url = "https://example.com/webhooks/events"
+
+    auth          = "apiKeyAuth"
+    api_key_name  = "x-api-key"
+    api_key_value = "your-api-key"
+
+    method = "POST"
+    format = "JSON"
+  }
+
+  # ID of a published transformation (e.g. one that filters out events that must
+  # not reach this destination). Omit or clear to detach.
+  transformation_id = "2abcTRANSFORMATIONid"
+}

--- a/internal/testutil/cm/destinations.go
+++ b/internal/testutil/cm/destinations.go
@@ -173,3 +173,20 @@ func (m *mockDestinationsService) Delete(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
+
+func (m *mockDestinationsService) GetTransformation(ctx context.Context, destinationID string) (*client.DestinationTransformation, error) {
+	args := m.Called(ctx, destinationID)
+	t, _ := args.Get(0).(*client.DestinationTransformation)
+	return t, args.Error(1)
+}
+
+func (m *mockDestinationsService) ConnectTransformation(ctx context.Context, destinationID, transformationID string) (*client.DestinationTransformation, error) {
+	args := m.Called(ctx, destinationID, transformationID)
+	t, _ := args.Get(0).(*client.DestinationTransformation)
+	return t, args.Error(1)
+}
+
+func (m *mockDestinationsService) DisconnectTransformation(ctx context.Context, destinationID string) error {
+	args := m.Called(ctx, destinationID)
+	return args.Error(0)
+}

--- a/rudderstack/client.go
+++ b/rudderstack/client.go
@@ -36,6 +36,14 @@ type DestinationsService interface {
 	Get(ctx context.Context, id string) (*client.Destination, error)
 	Update(ctx context.Context, destination *client.Destination) (*client.Destination, error)
 	Delete(ctx context.Context, id string) error
+
+	// Destination-side transformation link (rudder-iac >= v0.19.0). A destination
+	// has at most one attached transformation; ConnectTransformation replaces any
+	// existing link. GetTransformation returns client.ErrResourceNotFound when
+	// nothing is attached.
+	GetTransformation(ctx context.Context, destinationID string) (*client.DestinationTransformation, error)
+	ConnectTransformation(ctx context.Context, destinationID, transformationID string) (*client.DestinationTransformation, error)
+	DisconnectTransformation(ctx context.Context, destinationID string) error
 }
 
 type ConnectionsService interface {

--- a/rudderstack/resource_destination.go
+++ b/rudderstack/resource_destination.go
@@ -71,6 +71,13 @@ func resourceDestinationSchema(cm configs.ConfigMeta) map[string]*schema.Schema 
 			Computed:    true,
 			Description: "Time when the resource was last updated, in ISO 8601 format.",
 		},
+		"transformation_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "ID of a published transformation to attach to this destination. " +
+				"The transformation must be published before it can be attached. A destination " +
+				"can have at most one transformation. Omit or clear the value to detach.",
+		},
 	}
 
 	if !cm.SkipConfig {
@@ -110,8 +117,36 @@ func resourceDestinationCreate(cm configs.ConfigMeta) schema.CreateContextFunc {
 
 		d.SetId(destination.ID)
 
+		// The transformation link is a separate endpoint, not part of the destination
+		// create body — attach it after the destination exists. Mirrors rudder-iac's
+		// destination handler.
+		if newID := d.Get("transformation_id").(string); newID != "" {
+			if err := reconcileTransformationLink(ctx, c, destination.ID, "", newID); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
 		return resourceDestinationRead(cm)(ctx, d, m)
 	}
+}
+
+// reconcileTransformationLink brings the destination's attached transformation from
+// oldID to newID. Empty string means "no transformation". Mirrors rudder-iac's
+// syncTransformationLink. ponytail: one small helper beside the resource, no shared pkg.
+func reconcileTransformationLink(ctx context.Context, c *Client, destinationID, oldID, newID string) error {
+	if oldID == newID {
+		return nil
+	}
+	if newID == "" {
+		if err := c.Destinations.DisconnectTransformation(ctx, destinationID); err != nil {
+			return fmt.Errorf("disconnecting transformation from destination %s: %w", destinationID, err)
+		}
+		return nil
+	}
+	if _, err := c.Destinations.ConnectTransformation(ctx, destinationID, newID); err != nil {
+		return fmt.Errorf("connecting transformation %s to destination %s: %w", newID, destinationID, err)
+	}
+	return nil
 }
 
 func resourceDestinationRead(cm configs.ConfigMeta) schema.ReadContextFunc {
@@ -135,6 +170,23 @@ func resourceDestinationRead(cm configs.ConfigMeta) schema.ReadContextFunc {
 
 		if err := storeDestinationToState(cm, destination, d); err != nil {
 			return diag.FromErr(err)
+		}
+
+		// GET /destinations/{id} does not embed the transformation link, so read it
+		// separately. A not-found means nothing is attached (empty), and also lets
+		// drift (out-of-band attach/detach) surface on the next plan.
+		transformation, err := c.Destinations.GetTransformation(ctx, id)
+		switch {
+		case err == nil:
+			if err := d.Set("transformation_id", transformation.TransformationID); err != nil {
+				return diag.FromErr(err)
+			}
+		case errors.Is(err, client.ErrResourceNotFound):
+			if err := d.Set("transformation_id", ""); err != nil {
+				return diag.FromErr(err)
+			}
+		default:
+			return diag.FromErr(fmt.Errorf("reading transformation link for destination %s: %w", id, err))
 		}
 
 		return diag.Diagnostics{}
@@ -161,6 +213,13 @@ func resourceDestinationUpdate(cm configs.ConfigMeta) schema.UpdateContextFunc {
 
 		d.SetId(destination.ID)
 
+		if d.HasChange("transformation_id") {
+			oldID, newID := d.GetChange("transformation_id")
+			if err := reconcileTransformationLink(ctx, c, destination.ID, oldID.(string), newID.(string)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
 		return resourceDestinationRead(cm)(ctx, d, m)
 	}
 }
@@ -170,6 +229,17 @@ func resourceDestinationDelete(cm configs.ConfigMeta) schema.DeleteContextFunc {
 		c, ok := m.(*Client)
 		if !ok {
 			return diag.FromErr(fmt.Errorf("API client is not configured"))
+		}
+
+		// Detach any linked transformation first, mirroring rudder-iac's destination
+		// handler. Not-found is fine — the link may already be gone or cascade-deleted.
+		if d.Get("transformation_id").(string) != "" {
+			if err := c.Destinations.DisconnectTransformation(ctx, d.Id()); err != nil {
+				var apiErr *client.APIError
+				if !errors.Is(err, client.ErrResourceNotFound) && !(errors.As(err, &apiErr) && apiErr.HTTPStatusCode == 404) {
+					return diag.FromErr(fmt.Errorf("disconnecting transformation from destination %s: %w", d.Id(), err))
+				}
+			}
 		}
 
 		if err := c.Destinations.Delete(ctx, d.Id()); err != nil {
@@ -242,6 +312,12 @@ func storeDestinationToState(cm configs.ConfigMeta, destination *client.Destinat
 		if err := d.Set("updated_at", updatedAt); err != nil {
 			return err
 		}
+	}
+
+	// SkipConfig destinations have no "config" attribute in their schema, so
+	// there is nothing to write back (and d.Set("config", ...) would fail).
+	if cm.SkipConfig {
+		return nil
 	}
 
 	state, err := cm.APIToState(string(destination.Config))

--- a/rudderstack/resource_destination_transformation_test.go
+++ b/rudderstack/resource_destination_transformation_test.go
@@ -1,0 +1,144 @@
+package rudderstack
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/rudderlabs/rudder-iac/api/client"
+	"github.com/rudderlabs/terraform-provider-rudderstack/internal/testutil"
+	"github.com/rudderlabs/terraform-provider-rudderstack/rudderstack/configs"
+)
+
+// A synthetic destination type with a trivial (empty-mapping) config schema, so
+// the test exercises the transformation_id lifecycle without a real
+// integration's config. No Properties => config round-trips as "{}".
+func transformationTestProviderFactory(dests DestinationsService) func() (*schema.Provider, error) {
+	cm := configs.ConfigMeta{APIType: "TEST", SkipConfig: true}
+	return func() (*schema.Provider, error) {
+		return &schema.Provider{
+			ConfigureContextFunc: func(_ context.Context, _ *schema.ResourceData) (interface{}, diag.Diagnostics) {
+				return &Client{Destinations: dests}, diag.Diagnostics{}
+			},
+			ResourcesMap: map[string]*schema.Resource{
+				"rudderstack_destination_test": resourceDestination(cm),
+			},
+		}, nil
+	}
+}
+
+func destWithName() *client.Destination {
+	return &client.Destination{
+		ID:        "dest-1",
+		Type:      "TEST",
+		Name:      "test-destination",
+		IsEnabled: true,
+		CreatedAt: testutil.TimePtr(time.Date(2010, 1, 2, 3, 4, 5, 0, time.UTC)),
+		UpdatedAt: testutil.TimePtr(time.Date(2010, 1, 2, 3, 4, 5, 0, time.UTC)),
+	}
+}
+
+func transformationConfig(id string) string {
+	return `
+		resource "rudderstack_destination_test" "example" {
+			name              = "test-destination"
+			transformation_id = "` + id + `"
+		}
+	`
+}
+
+// Create attaches the transformation, Update re-attaches a different one, and
+// Destroy disconnects before deleting — the destination-side reconciliation.
+func TestResourceDestinationTransformationLink(t *testing.T) {
+	dests := &mockDestinationsService{}
+
+	// Create + Read (x2: post-create read, then pre-update refresh).
+	dests.On("Create", mock.Anything, mock.Anything).Return(destWithName(), nil).Once()
+	dests.On("ConnectTransformation", mock.Anything, "dest-1", "tPub1").
+		Return(&client.DestinationTransformation{DestinationID: "dest-1", TransformationID: "tPub1"}, nil).Once()
+	dests.On("Get", mock.Anything, "dest-1").Return(destWithName(), nil)
+	dests.On("GetTransformation", mock.Anything, "dest-1").
+		Return(&client.DestinationTransformation{DestinationID: "dest-1", TransformationID: "tPub1"}, nil).Times(3)
+
+	// Update: swap tPub1 -> tPub2.
+	dests.On("Update", mock.Anything, mock.Anything).Return(destWithName(), nil).Once()
+	dests.On("ConnectTransformation", mock.Anything, "dest-1", "tPub2").
+		Return(&client.DestinationTransformation{DestinationID: "dest-1", TransformationID: "tPub2"}, nil).Once()
+	dests.On("GetTransformation", mock.Anything, "dest-1").
+		Return(&client.DestinationTransformation{DestinationID: "dest-1", TransformationID: "tPub2"}, nil).Times(2)
+
+	// Destroy: disconnect then delete.
+	dests.On("DisconnectTransformation", mock.Anything, "dest-1").Return(nil).Once()
+	dests.On("Delete", mock.Anything, "dest-1").Return(nil).Once()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"rudderstack": transformationTestProviderFactory(dests),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: transformationConfig("tPub1"),
+				Check:  checkTransformationID("tPub1"),
+			},
+			{
+				Config: transformationConfig("tPub2"),
+				Check:  checkTransformationID("tPub2"),
+			},
+		},
+	})
+
+	dests.AssertExpectations(t)
+}
+
+func checkTransformationID(want string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		return resource.TestCheckResourceAttr(
+			"rudderstack_destination_test.example", "transformation_id", want,
+		)(state)
+	}
+}
+
+type mockDestinationsService struct {
+	mock.Mock
+}
+
+func (m *mockDestinationsService) Create(ctx context.Context, d *client.Destination) (*client.Destination, error) {
+	args := m.Called(ctx, d)
+	return args.Get(0).(*client.Destination), args.Error(1)
+}
+
+func (m *mockDestinationsService) Get(ctx context.Context, id string) (*client.Destination, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(*client.Destination), args.Error(1)
+}
+
+func (m *mockDestinationsService) Update(ctx context.Context, d *client.Destination) (*client.Destination, error) {
+	args := m.Called(ctx, d)
+	return args.Get(0).(*client.Destination), args.Error(1)
+}
+
+func (m *mockDestinationsService) Delete(ctx context.Context, id string) error {
+	return m.Called(ctx, id).Error(0)
+}
+
+func (m *mockDestinationsService) GetTransformation(ctx context.Context, destinationID string) (*client.DestinationTransformation, error) {
+	args := m.Called(ctx, destinationID)
+	t, _ := args.Get(0).(*client.DestinationTransformation)
+	return t, args.Error(1)
+}
+
+func (m *mockDestinationsService) ConnectTransformation(ctx context.Context, destinationID, transformationID string) (*client.DestinationTransformation, error) {
+	args := m.Called(ctx, destinationID, transformationID)
+	t, _ := args.Get(0).(*client.DestinationTransformation)
+	return t, args.Error(1)
+}
+
+func (m *mockDestinationsService) DisconnectTransformation(ctx context.Context, destinationID string) error {
+	return m.Called(ctx, destinationID).Error(0)
+}


### PR DESCRIPTION
> **Draft, stacked on #299** (`chore: upgrade rudder-iac to v0.22.0`). Review the diff against that branch; base retargets to `main` once #299 merges. The green/build state depends on #299.

## What

Adds an optional `transformation_id` attribute to every `rudderstack_destination_<type>` resource, so a destination's linked transformation can be declared in Terraform instead of attached by hand in the dashboard.

```hcl
resource "rudderstack_destination_webhook" "my_destination" {
  name = "my-filtered-webhook"
  # ...config...
  transformation_id = "2abcTRANSFORMATIONid"   # published transformation to attach
}
```

## How

The link is **owned by the destination** and reconciled in its own CRUD via the destination-side endpoints (`PUT/DELETE/GET /destinations/{id}/transformation`), mirroring how `rudder-iac` (the CLI) already models it:

- **Create** — attach after the destination exists (the link is a separate endpoint, not part of the create body).
- **Read** — `GET` the link separately (the single-destination `GET` doesn't embed it); a not-found clears the attribute, surfacing out-of-band drift on the next plan.
- **Update** — reconcile old→new (connect / disconnect / no-op) **in place**; not `ForceNew`.
- **Delete** — disconnect before deleting the destination.

The API constraint is **1:1** (a destination has at most one transformation), which a single scalar attribute enforces structurally at plan time.

## Why this shape (not a standalone resource)

This is RudderStack's chosen alternative to the standalone `rudderstack_transformation_connection` resource proposed in #296 by @plaflamme, and it addresses the same requirement:

- Consistent with the CLI, which owns the link on the destination.
- The 1:1 rule is structural (a standalone resource lets two blocks fight over one destination).
- Uses the **already-shipped** destination-side endpoints — no fork, and none of the transformation-side endpoints from the closed rudderlabs/rudder-iac#711.
- In-place updates and import for free.

Credit to @plaflamme for raising the use-case and the initial implementation in #296.

## Changes

- `client.go`: widen `DestinationsService` with `GetTransformation` / `ConnectTransformation` / `DisconnectTransformation` (already on the underlying `rudder-iac` client).
- `resource_destination.go`: schema attribute, `reconcileTransformationLink` helper, CRUD wiring, and a `SkipConfig` guard in `storeDestinationToState` (Read must not set a `config` attribute a `SkipConfig` resource doesn't have).
- tests: mocked create/attach → update/re-attach → destroy/disconnect lifecycle; `testutil` mock gains the three methods.
- docs/examples: `transformation_id` documented on destination resources.

## Not doing

Closing #296 — leaving that to the maintainers' call. This PR is offered as the alternative that meets the requirement.

Refs #296, rudderlabs/rudder-iac#711. Depends on #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)